### PR TITLE
New package: hunspell

### DIFF
--- a/index.html
+++ b/index.html
@@ -1238,6 +1238,11 @@ USE_OSGPLUGIN(&lt;plugin2&gt;)
         <td id="guile-website"><a href="http://www.gnu.org/software/guile/">GNU Guile</a></td>
     </tr>
     <tr>
+        <td id="hunspell-package">hunspell</td>
+        <td id="hunspell-version">1.3.2</td>
+        <td id="hunspell-website"><a href="http://hunspell.sourceforge.net/">Hunspell</a></td>
+    </tr>
+    <tr>
         <td id="id3lib-package">id3lib</td>
         <td id="id3lib-version">3.8.3</td>
         <td id="id3lib-website"><a href="http://id3lib.sourceforge.net/">id3lib</a></td>

--- a/src/hunspell-test.aff
+++ b/src/hunspell-test.aff
@@ -1,0 +1,3 @@
+# A basic .aff for a raw wordlist, created through wordlist2hunspell
+SET UTF-8
+TRY loredWH

--- a/src/hunspell-test.cxx
+++ b/src/hunspell-test.cxx
@@ -1,0 +1,21 @@
+#include <iostream>
+#include <hunspell.hxx>
+
+int main(int argc, char *argv[])
+{
+    Hunspell h("hunspell-test.aff", "hunspell-test.dic");
+
+    (void)argc;
+    (void)argv;
+
+    if (h.spell("Hello") == 0)
+    {
+        std::cerr << "Error: hunspell marked correct word as wrong" << std::endl;
+    }
+    if (h.spell("wrld") != 0)
+    {
+        std::cerr << "Error: hunspell marked wrong word as correct" << std::endl;
+    }
+    
+    return 0;
+}

--- a/src/hunspell-test.dic
+++ b/src/hunspell-test.dic
@@ -1,0 +1,3 @@
+2
+Hello
+World

--- a/src/hunspell.mk
+++ b/src/hunspell.mk
@@ -1,0 +1,38 @@
+# This file is part of MXE.
+# See index.html for further information.
+
+PKG             := hunspell
+$(PKG)_IGNORE   :=
+$(PKG)_CHECKSUM := 902c76d2b55a22610e2227abc4fd26cbe606a51c
+$(PKG)_SUBDIR   := hunspell-$($(PKG)_VERSION)
+$(PKG)_FILE     := hunspell-$($(PKG)_VERSION).tar.gz
+$(PKG)_URL      := http://$(SOURCEFORGE_MIRROR)/project/hunspell/Hunspell/$($(PKG)_VERSION)/$($(PKG)_FILE)
+$(PKG)_DEPS     := gcc libiconv gettext readline pthreads
+
+define $(PKG)_UPDATE
+    wget -q -O- 'http://sourceforge.net/projects/hunspell/files/Hunspell/' | \
+    $(SED) -n 's,.*/\([0-9][^"]*\)/".*,\1,p' | \
+    head -1
+endef
+
+define $(PKG)_BUILD
+    # Note: the configure file doesn't pick up pdcurses, so "ui" is disabled
+    cd '$(1)' && ./configure \
+        --host='$(TARGET)' \
+        --enable-static \
+        --disable-shared \
+        --with-warnings \
+        --without-ui \
+        --with-readline \
+        --prefix='$(PREFIX)/$(TARGET)'
+    $(MAKE) -C '$(1)' -j '$(JOBS)' install bin_PROGRAMS= sbin_PROGRAMS= noinst_PROGRAMS=
+
+
+    # Test
+    '$(TARGET)-g++' \
+        -W -Wall -Werror -ansi -pedantic \
+        '$(2).cxx' -o '$(PREFIX)/$(TARGET)/bin/test-hunspell.exe' \
+        `'$(TARGET)-pkg-config' hunspell --cflags --libs`
+    # Install dummy dictionary needed by the test program
+    $(INSTALL) -m644 -t '$(PREFIX)/$(TARGET)/bin' '$(TOP_DIR)/src/hunspell-test.aff' '$(TOP_DIR)/src/hunspell-test.dic'
+endef


### PR DESCRIPTION
Hunspell is an open-source spell-checking library.

In src/hunspell.mk two files ($(TOP_DIR)/src/hunspell-test.aff and $(TOP_DIR)/src/hunspell-test.aff) needed by the test program are installed into $(PREFIX)/$(TARGET)/bin. I'm not sure if that is OK or if the test program should be changed somehow.
