### PR TITLE
Ignore temporary build directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /log/
 /pkg
 /wip/
+/tmp-*


### PR DESCRIPTION
Ignore temporary build directories that could still be lying around if building a package fails.
