### PR TITLE
patch-tool-mxe update for index.html

### DIFF
--- a/tools/patch-tool-mxe
+++ b/tools/patch-tool-mxe
@@ -8,6 +8,7 @@ pkg=$2
 
 # MXE directory
 mxedir=~/mxe
+mxesrc=$mxedir/src
 
 # directory for unpacked tarballs/git repos
 gitsdir=~/gits
@@ -16,18 +17,17 @@ gitsdir=~/gits
 # John Doe <John Doe@acme.org>
 author=`git var GIT_AUTHOR_IDENT | sed 's/^\(.* [<].*[>]\).*$/\1/'`
 
-pkg_version=`grep '^$(PKG)_VERSION' $mxedir/src/$pkg.mk  | \
-  sed 's/.*:= \(.*\)/\1/'`
+pkg_version=`grep $pkg-version $mxedir/index.html  | sed s/.*$pkg-version'">\(.*\)<\/td>/\1/'`
 
 pkg_short_version=`echo $pkg_version | sed s/'\(.*\)\.[^.]*$'/'\1'/`
 
-pkg_subdir=`grep '^$(PKG)_SUBDIR' $mxedir/src/$pkg.mk  | \
+pkg_subdir=`grep '^$(PKG)_SUBDIR' $mxesrc/$pkg.mk  | \
   sed 's/.*:= \(.*\)/\1/' | \
   sed s/'$($(PKG)_VERSION)'/$pkg_version/ | \
   sed s/'$(call SHORT_PKG_VERSION,$(PKG))'/$pkg_short_version/ | \
   sed s/'$(PKG)'/$pkg/;`
 
-pkg_file=`grep '^$(PKG)_FILE' $mxedir/src/$pkg.mk  | \
+pkg_file=`grep '^$(PKG)_FILE' $mxesrc/$pkg.mk  | \
   sed 's/.*:= \(.*\)/\1/' | \
   sed s/'$($(PKG)_VERSION)'/$pkg_version/ | \
   sed s/'$(call SHORT_PKG_VERSION,$(PKG))'/$pkg_short_version/ | \
@@ -47,7 +47,7 @@ function init_git {
   echo $pkg_file | grep "\.tar\.xz"  >> /dev/null && xz -dc $mxedir/pkg/$pkg_file | tar xf -
   echo $pkg_file | grep "\.zip"      >> /dev/null && unzip  $mxedir/pkg/$pkg_file >> /dev/null
   cd $gitsdir/$pkg_subdir && \
-  (git init; git add -A; git commit -m "init") > /dev/null
+  (rm -Rf .git; git init; git add -A; git commit -m "init") > /dev/null
   git tag dist
 }
 
@@ -59,14 +59,16 @@ function export_patch {
     echo ''
     echo 'Contains ad hoc patches for cross building.'
     echo ''
+	git add -A;
+	git commit -a -m "new version"
     git format-patch -p --stdout dist..HEAD | \
     sed 's/^From: .*/From: MXE/g;'
-  ) > $mxedir/src/$pkg-1-fixes.patch
+  ) > $mxesrc/$pkg-1-fixes.patch
 }
 
 function import_patch {
   cd $gitsdir/$pkg_subdir && \
-  cat $mxedir/src/$pkg-1-fixes.patch | \
+  cat $mxesrc/$pkg-1-fixes.patch | \
   sed '/^From/,$  !d' | \
   sed s/'^From: .*'/"From: $author"/'g;' | \
   git am --keep-cr


### PR DESCRIPTION
changes to the patch tool :
- a script line is modified to suit the new index.html
- I made other changes to have something that works for me, but I don't know how to use the patch tool properly. Essentially, I added a "rm -Rf .git" in the "init" step. Don't know if this is usefull for others

What I do :

tar -xvzf path/to/mxe/pkg/my-package1.2.3
path/to/mxe/tools/patch-tool-mxe init my-package
[modifications]
path/to/mxe/tools/patch-tool-mxe export my-package
But then, if a new upcoming my-package1.2.4 arrives, how to do ?
