### PR TITLE
new package: plibc

### DIFF
--- a/index.html
+++ b/index.html
@@ -1684,6 +1684,11 @@ USE_OSGPLUGIN(&lt;plugin2&gt;)
         <td id="pdcurses-website"><a href="http://pdcurses.sourceforge.net/">PDcurses</a></td>
     </tr>
     <tr>
+        <td id="plibc-package">plibc</td>
+        <td id="plibc-version">0.1.7</td>
+        <td id="plibc-website"><a href="http://plibc.sourceforge.net/">Plibc</a></td>
+    </tr>
+    <tr>
         <td id="pdflib_lite-package">pdflib_lite</td>
         <td id="pdflib_lite-version">7.0.5</td>
         <td id="pdflib_lite-website"><a href="http://www.pdflib.com/download/free-software/pdflib-lite-7/">PDFlib Lite</a></td>

--- a/src/plibc.mk
+++ b/src/plibc.mk
@@ -1,0 +1,21 @@
+# This file is part of MXE.
+# See index.html for further information.
+
+PKG             := plibc
+$(PKG)_IGNORE   :=
+$(PKG)_CHECKSUM := b545c602dc5b381fcea9d096910dede95168fbeb
+$(PKG)_SUBDIR   := PlibC-$($(PKG)_VERSION)
+$(PKG)_FILE     := plibc-$($(PKG)_VERSION)-src.tar.gz
+$(PKG)_URL      := http://sourceforge.net/projects/plibc/files/plibc/$($(PKG)_VERSION)/$($(PKG)_FILE)/download
+$(PKG)_DEPS     := gcc
+
+define $(PKG)_BUILD
+    cd '$(1)' && \
+    chmod 0755 configure && \
+    ./configure \
+        --host='$(TARGET)' \
+        --prefix='$(PREFIX)/$(TARGET)' \
+        --enable-static \
+        --disable-shared
+    $(MAKE) -C '$(1)' -j '$(JOBS)' install
+endef


### PR DESCRIPTION
This pull request adds support for the plibc compatibility library; needed for applications like restpose (restpose.org) and gnu libmicrohttpd.  The packaging is fairly simple (no test, no package update command definition), but produces a working executable for me.
