### PR TITLE
Add package for librtmp (version 2.3)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1492,6 +1492,11 @@ USE_OSGPLUGIN(&lt;plugin2&gt;)
         <td id="librsvg-package">librsvg</td>
         <td id="librsvg-version">2.36.1</td>
         <td id="librsvg-website"><a href="http://librsvg.sourceforge.net/">librsvg</a></td>
+	</tr>
+    <tr>
+        <td id="librtmp-package">librtmp</td>
+        <td id="librtmp-version">2.3</td>
+        <td id="librtmp-website"><a href="http://rtmpdump.mplayerhq.hu/">librtmp</a></td>
     </tr>
     <tr>
         <td id="libsamplerate-package">libsamplerate</td>

--- a/src/librtmp.mk
+++ b/src/librtmp.mk
@@ -1,0 +1,21 @@
+# This file is part of MXE.
+# See index.html for further information.
+
+PKG             := librtmp
+$(PKG)_IGNORE   :=
+$(PKG)_CHECKSUM := b65ce7708ae79adb51d1f43dd0b6d987076d7c42
+$(PKG)_SUBDIR   := rtmpdump-$($(PKG)_VERSION)
+$(PKG)_FILE     := rtmpdump-$($(PKG)_VERSION).tgz
+$(PKG)_URL      := http://rtmpdump.mplayerhq.hu/download/$($(PKG)_FILE)
+$(PKG)_DEPS     := gcc openssl
+
+define $(PKG)_UPDATE
+	wget -q -O- 'http://rtmpdump.mplayerhq.hu/download/' | \
+    $(SED) -n 's,.*rtmpdump-\([0-9.]*\)\.tgz.*,\1,ip' | \
+    sort -r | \
+	head -1
+endef
+
+define $(PKG)_BUILD
+    cd '$(1)' && make SYS=mingw CROSS_COMPILE='$(TARGET)-' prefix='$(PREFIX)/$(TARGET)' -j '$(JOBS)' install
+endef


### PR DESCRIPTION
Added support for the librtmp package implementing Adobe's rtmp protocol.
It is used in the open source flash player lightspark.

This package installs headers, a library and a pkg-config file.
The update script seems to work, too.
