### PR TITLE
package pango: split DllMain patch and make it callable

### DIFF
--- a/src/pango-1-fixes.patch
+++ b/src/pango-1-fixes.patch
@@ -1,19 +1,14 @@
-This file is part of MXE.
-See index.html for further information.
-
-Contains ad hoc patches for cross building.
-
-From 2227d3bd55d64510cdb9761a55dfcfa86c594ae4 Mon Sep 17 00:00:00 2001
-From: Mark Brand <mabrand@mabrand.nl>
-Date: Wed, 29 Sep 2010 00:52:59 +0200
-Subject: [PATCH 1/4] s,DllMain,static _disabled_DllMain,
+From 971738e2fc2bc3faae52952dd08ee08b34ff4b86 Mon Sep 17 00:00:00 2001
+From: Matthias Gehre <M.Gehre@gmx.de>
+Date: Mon, 9 Jul 2012 13:13:49 +0200
+Subject: [PATCH 1/4] Rename DllMain to pango_DllMain
 
 ---
  pango/pango-utils.c |    4 ++--
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/pango/pango-utils.c b/pango/pango-utils.c
-index c68e2d4..e55b71d 100644
+index c68e2d4..47ca433 100644
 --- a/pango/pango-utils.c
 +++ b/pango/pango-utils.c
 @@ -692,12 +692,12 @@ pango_config_key_get (const char *key)
@@ -21,21 +16,21 @@ index c68e2d4..e55b71d 100644
  #ifdef G_OS_WIN32
  
 -/* DllMain function needed to tuck away the DLL handle */
-+/* static _disabled_DllMain function needed to tuck away the DLL handle */
++/* pango_DllMain function needed to tuck away the DLL handle */
  
  static HMODULE pango_dll;
  
  BOOL WINAPI
 -DllMain (HINSTANCE hinstDLL,
-+static _disabled_DllMain (HINSTANCE hinstDLL,
++pango_DllMain (HINSTANCE hinstDLL,
  	 DWORD     fdwReason,
  	 LPVOID    lpvReserved)
  {
 -- 
-1.7.10.4
+1.7.9.5
 
 
-From f168a8e1bf39a2605850ba2619992b6de99c58ba Mon Sep 17 00:00:00 2001
+From 779c533bf4354cbc747d82532f4798e6ef006d1b Mon Sep 17 00:00:00 2001
 From: Mark Brand <mabrand@mabrand.nl>
 Date: Wed, 29 Sep 2010 00:50:08 +0200
 Subject: [PATCH 2/4] add missing lib to pango.pc for static linking
@@ -56,10 +51,10 @@ index 17a8b7a..16c5981 100644
 +Libs: -L${libdir} -lpango-@PANGO_API_VERSION@ @PKGCONFIG_MATH_LIBS@ -lusp10
  Cflags: -I${includedir}/pango-1.0
 -- 
-1.7.10.4
+1.7.9.5
 
 
-From 6a9d9d2b6151f93a6a0a1a1e3cf8381d47da59a1 Mon Sep 17 00:00:00 2001
+From 4340125c6b7f26106f7f021ec4c9612f7384e6c1 Mon Sep 17 00:00:00 2001
 From: Mark Brand <mabrand@mabrand.nl>
 Date: Fri, 15 Jun 2012 16:21:40 +0200
 Subject: [PATCH 3/4] do not force shared for win32
@@ -123,10 +118,10 @@ index dc8a2c8..dc22e59 100644
  uninstall-local:
  	$(RM) $(DESTDIR)$(sysconfdir)/pango/pango.modules
 -- 
-1.7.10.4
+1.7.9.5
 
 
-From fd0523d0d19e0b2ea6ff27689738ce540d1047f7 Mon Sep 17 00:00:00 2001
+From ff735b2f71b07e7216856a473ed283eb24dd012a Mon Sep 17 00:00:00 2001
 From: Mark Brand <mabrand@mabrand.nl>
 Date: Mon, 18 Jun 2012 21:36:53 +0200
 Subject: [PATCH 4/4] kill gtk-doc (MXE specific)
@@ -189,5 +184,5 @@ index 6a000cc..e7538f6 100644
  AC_ARG_ENABLE(man,
                AC_HELP_STRING([--enable-man],
 -- 
-1.7.10.4
+1.7.9.5
 


### PR DESCRIPTION
This allows users of this library to explicitly call the DllMain
to run the necessary initialization.

This was actually introduced in 
https://github.com/mxe/mxe/pull/20
but (by accident?) reverted in one of the last updates.
