### PR TITLE
Update of json-c

### DIFF
--- a/index.html
+++ b/index.html
@@ -1285,7 +1285,7 @@ USE_OSGPLUGIN(&lt;plugin2&gt;)
     </tr>
     <tr>
         <td id="json-c-package">json-c</td>
-        <td id="json-c-version">0.9</td>
+        <td id="json-c-version">0.10</td>
         <td id="json-c-website"><a href="http://oss.metaparadigm.com/json-c/">json-c</a></td>
     </tr>
     <tr>

--- a/src/json-c-1-patch-missingfile.patch
+++ b/src/json-c-1-patch-missingfile.patch
@@ -1,0 +1,15 @@
+This file is part of MXE.
+See index.html for further information.
+
+Contains a fix for issue 35 on json-c (https://github.com/json-c/json-c/issues/35)
+
+--- a/Makefile.am	2012-07-17 22:52:19.000000000 +0200
++++ b/Makefile.am	2012-07-17 22:54:09.000000000 +0200
+@@ -17,6 +17,7 @@
+ 	json_config.h \
+ 	json_inttypes.h \
+ 	json_object.h \
++	json_object_iterator.h \
+ 	json_object_private.h \
+ 	json_tokener.h \
+ 	json_util.h \

--- a/src/json-c-2-patch-remove-rpl.patch
+++ b/src/json-c-2-patch-remove-rpl.patch
@@ -1,0 +1,16 @@
+This file is part of MXE.
+See index.html for further information.
+
+see http://lists.fedoraproject.org/pipermail/mingw/2009-May/001567.html
+
+--- a/configure.in	2012-07-12 01:57:09.000000000 +0200
++++ b/configure.in	2012-07-12 01:59:06.000000000 +0200
+@@ -25,8 +25,6 @@
+ # Checks for library functions.
+ AC_FUNC_VPRINTF
+ AC_FUNC_MEMCMP
+-AC_FUNC_MALLOC
+-AC_FUNC_REALLOC
+ AC_CHECK_FUNCS(strndup strerror vsnprintf vasprintf open vsyslog strncasecmp)
+ 
+ AM_PROG_LIBTOOL

--- a/src/json-c.mk
+++ b/src/json-c.mk
@@ -3,23 +3,26 @@
 
 PKG             := json-c
 $(PKG)_IGNORE   :=
-$(PKG)_CHECKSUM := daaf5eb960fa98e137abc5012f569b83c79be90f
+$(PKG)_CHECKSUM := f90f643c8455da21d57b3e8866868a944a93c596
 $(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
 $(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.gz
-$(PKG)_URL      := http://oss.metaparadigm.com/$(PKG)/$($(PKG)_FILE)
+$(PKG)_URL      := https://github.com/downloads/$(PKG)/$(PKG)/$($(PKG)_FILE)
 $(PKG)_DEPS     := gcc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'http://oss.metaparadigm.com/json-c/?C=M;O=D' | \
-    $(SED) -n 's,.*json-c-\([0-9][^>]*\)\.tar.*,\1,p' | \
+    $(WGET) - q -O 'https://github.com/json-c/json-c/downloads' | \
+    grep '<a href="/downloads/json-c/json-c/' | \
+    $(SED) -n -s,.*href="/downloads/json-c/json-c/json-c-\([0-9.]*\).tar.gz,\1,p' | \
     head -1
 endef
 
 define $(PKG)_BUILD
+    cd '$(1)' && ./autogen.sh
     cd '$(1)' && ./configure \
         --host='$(TARGET)' \
         --prefix='$(PREFIX)/$(TARGET)' \
         --build="`config.guess`"\
+        --disable-shared
         CFLAGS=-Wno-error
     $(MAKE) -C '$(1)' -j '$(JOBS)' install
 endef


### PR DESCRIPTION
Update of json-c to version 0.10, using github downloads. This includes fixes for missing header file after installation and checking for rpl_\* functions.
