### PR TITLE
Update to boost 1.51.0

### DIFF
--- a/index.html
+++ b/index.html
@@ -955,7 +955,7 @@ USE_OSGPLUGIN(&lt;plugin2&gt;)
     </tr>
     <tr>
         <td id="boost-package">boost</td>
-        <td id="boost-version">1.50.0</td>
+        <td id="boost-version">1.51.0</td>
         <td id="boost-website"><a href="http://www.boost.org/">Boost C++ Library</a></td>
     </tr>
     <tr>

--- a/src/boost.mk
+++ b/src/boost.mk
@@ -3,7 +3,7 @@
 
 PKG             := boost
 $(PKG)_IGNORE   :=
-$(PKG)_CHECKSUM := ee06f89ed472cf369573f8acf9819fbc7173344e
+$(PKG)_CHECKSUM := 52ef06895b97cc9981b8abf1997c375ca79f30c5
 $(PKG)_SUBDIR   := boost_$(subst .,_,$($(PKG)_VERSION))
 $(PKG)_FILE     := boost_$(subst .,_,$($(PKG)_VERSION)).tar.bz2
 $(PKG)_URL      := http://$(SOURCEFORGE_MIRROR)/project/boost/boost/$($(PKG)_VERSION)/$($(PKG)_FILE)
@@ -33,6 +33,7 @@ define $(PKG)_BUILD
         --layout=tagged \
         --without-mpi \
         --without-python \
+        --without-context \
         --prefix='$(PREFIX)/$(TARGET)' \
         --exec-prefix='$(PREFIX)/$(TARGET)/bin' \
         --libdir='$(PREFIX)/$(TARGET)/lib' \


### PR DESCRIPTION
Update to boost 1.51.0. The new lib named "Context"
http://www.boost.org/users/history/version_1_51_0.html
currently does not compile using the cross compiler. I will report this upstream. However, it is better to update and skip this new lib (there are no problems with existing code, because the lib did not exist previously) than not to update at all :-).

Best regards,
Lothar
