### PR TITLE
added armadillo 3.4.0 with test

### DIFF
--- a/index.html
+++ b/index.html
@@ -924,6 +924,11 @@ USE_OSGPLUGIN(&lt;plugin2&gt;)
         <td id="apr-website"><a href="http://apr.apache.org/">APR</a></td>
     </tr>
     <tr>
+        <td id="armadillo-package">armadillo</td>
+        <td id="armadillo-version">3.4.0</td>
+        <td id="armadillo-website"><a href="http://armadillo.sf.net/">Armadillo C++ linear algebra library</a></td>
+    </tr>
+    <tr>
         <td id="atk-package">atk</td>
         <td id="atk-version">2.4.0</td>
         <td id="atk-website"><a href="http://www.gtk.org/">ATK</a></td>

--- a/src/armadillo-1-staticlib.patch
+++ b/src/armadillo-1-staticlib.patch
@@ -1,0 +1,43 @@
+This file is part of MXE.
+See index.html for further information.
+
+--- armadillo-3.4.0/CMakeLists.txt.orig	2012-09-06 09:43:16.000000000 +0200
++++ armadillo-3.4.0/CMakeLists.txt	2012-09-09 16:18:57.000000000 +0200
+@@ -40,7 +40,7 @@
+ set(ARMA_USE_ATLAS   false)
+ set(ARMA_USE_BOOST   false)
+ set(ARMA_USE_HDF5    false)
+-set(ARMA_USE_WRAPPER true )
++set(ARMA_USE_WRAPPER false)
+ 
+ 
+ if(WIN32)
+@@ -158,15 +158,15 @@
+   endif()
+   
+ else()
++
++  if(ARMA_USE_LAPACK STREQUAL true)
++    set(ARMA_LIBS ${ARMA_LIBS} ${LAPACK_LIBRARIES})
++  endif()
+   
+   if(ARMA_USE_BLAS STREQUAL true)
+     set(ARMA_LIBS ${ARMA_LIBS} ${BLAS_LIBRARIES})
+   endif()
+   
+-  if(ARMA_USE_LAPACK STREQUAL true)
+-    set(ARMA_LIBS ${ARMA_LIBS} ${LAPACK_LIBRARIES})
+-  endif()
+-  
+   if(ARMA_USE_ATLAS STREQUAL true)
+     set(ARMA_LIBS ${ARMA_LIBS} ${CBLAS_LIBRARIES})
+     set(ARMA_LIBS ${ARMA_LIBS} ${CLAPACK_LIBRARIES})
+@@ -263,7 +263,7 @@
+ #set(CMAKE_INSTALL_RPATH_USE_LINK_PATH  TRUE)
+ 
+ 
+-add_library( armadillo SHARED src/wrap_libs )
++add_library( armadillo STATIC src/wrap_libs )
+ target_link_libraries( armadillo ${ARMA_LIBS} )
+ 
+ set_target_properties(armadillo PROPERTIES VERSION ${ARMA_MAJOR}.${ARMA_MINOR}.${ARMA_PATCH} SOVERSION 3)

--- a/src/armadillo-test.cpp
+++ b/src/armadillo-test.cpp
@@ -1,0 +1,24 @@
+/*
+ * This file is part of MXE.
+ * See index.html for further information.
+ */
+
+#include <armadillo>
+
+using namespace arma;
+
+int main()
+{
+	mat A = randu<mat>(50,50);
+	mat B = trans(A)*A;  // generate a symmetric matrix
+	
+	vec eigval;
+	mat eigvec;
+	
+	// use standard algorithm by default
+	eig_sym(eigval, eigvec, B);
+	
+	// use divide & conquer algorithm
+	eig_sym(eigval, eigvec, B, "dc");
+	return 0;
+}

--- a/src/armadillo.mk
+++ b/src/armadillo.mk
@@ -1,0 +1,30 @@
+# This file is part of MXE.
+# See index.html for further information.
+
+# armadillo
+PKG             := armadillo
+$(PKG)_IGNORE   :=
+$(PKG)_CHECKSUM := e7fdb6518172aabaa28c84412b52db7d86ef37a5
+$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.gz
+$(PKG)_URL      := http://$(SOURCEFORGE_MIRROR)/project/arma/$($(PKG)_FILE)
+$(PKG)_DEPS     := gcc boost blas lapack
+
+define $(PKG)_UPDATE
+    wget -q -O- 'http://sourceforge.net/projects/arma/files/' | \
+    $(SED) -n 's,.*/\([0-9][^"]*\)/".*,\1,p' | \
+    head -1
+endef
+
+define $(PKG)_BUILD
+    cd '$(1)' && \
+    cmake . -DCMAKE_TOOLCHAIN_FILE='$(CMAKE_TOOLCHAIN_FILE)'
+    $(MAKE) -C '$(1)' -j '$(JOBS)' install VERBOSE=1
+
+# note: don't use -Werror with GCC 4.7.0 and .1
+'$(TARGET)-g++' \
+        -W -Wall \
+        '$(2).cpp' -o '$(PREFIX)/$(TARGET)/bin/test-armadillo.exe' \
+        -larmadillo -llapack -lblas -lgfortran
+        -lboost_serialization-mt -lboost_thread_win32-mt -lboost_system-mt
+endef


### PR DESCRIPTION
Hi,

Here's a fresh branch as pull request for adding armadillo 3.4.0, a library for linear algebra using blas and lapack.

I filled in but didn't check the package update.

The patch replaces the SHARED option to STATIC in the cmake ADD_LIBRARY command and reverses the order blas and lapack are added to the ARMA_LIBS list so that they are linked in the correct reverse order for static compilation (-lapack -blas).

The example is from http://arma.sourceforge.net/docs.html#eig_sym. It tests specifically if lapack properly links. When armadillo is compiled as shared library, this example crashes at runtime if lapack can't be properly loaded.

For the test -Werror has to be disabled with GCC 4.7.0 and 4.7.1, since armadillo works around a bug introduced by these and issues a warning.
