### PR TITLE
Add package protobuf

### DIFF
--- a/index.html
+++ b/index.html
@@ -1759,6 +1759,11 @@ USE_OSGPLUGIN(&lt;plugin2&gt;)
         <td id="proj-website"><a href="http://trac.osgeo.org/proj/">proj</a></td>
     </tr>
     <tr>
+        <td id="protobuf-package">protobuf</td>
+        <td id="protobuf-version">2.4.1</td>
+        <td id="protobuf-website"><a href="http://code.google.com/p/protobuf"/>protobuf</a></td>
+    </tr>
+    <tr>
         <td id="pthreads-package">pthreads</td>
         <td id="pthreads-version">2-9-1</td>
         <td id="pthreads-website"><a href="http://sourceware.org/pthreads-win32/">Pthreads-w32</a></td>

--- a/src/protobuf-test.cpp
+++ b/src/protobuf-test.cpp
@@ -1,0 +1,9 @@
+#include <google/protobuf/stubs/common.h>
+
+int
+main()
+{
+    GOOGLE_PROTOBUF_VERIFY_VERSION;
+    google::protobuf::ShutdownProtobufLibrary();
+    return 0;
+}

--- a/src/protobuf.mk
+++ b/src/protobuf.mk
@@ -1,0 +1,39 @@
+# This file is part of MXE.
+# See index.html for further information.
+
+PKG             := protobuf
+$(PKG)_IGNORE   :=
+$(PKG)_CHECKSUM := df5867e37a4b51fb69f53a8baf5b994938691d6d
+$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.bz2
+$(PKG)_URL      := http://protobuf.googlecode.com/files/$($(PKG)_FILE)
+$(PKG)_DEPS     := gcc zlib
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- 'http://code.google.com/p/protobuf/downloads/list?sort=-uploaded' | \
+    $(SED) -n 's,.*protobuf-\([0-9][^<]*\)\.tar.*,\1,p' | \
+    head -1
+endef
+
+define $(PKG)_BUILD
+# First step: Build for host system in order to create "protoc" binary.
+    cd '$(1)' && ./configure \
+        --disable-shared
+    $(MAKE) -C '$(1)' -j '$(JOBS)'
+    cp '$(1)/src/protoc' '$(1)/src/protoc_host'
+    $(MAKE) -C '$(1)' -j 1 distclean
+# Second step: Build for target system.
+    cd '$(1)' && ./configure \
+        --host='$(TARGET)' \
+        --prefix='$(PREFIX)/$(TARGET)' \
+        --disable-shared \
+        --with-zlib \
+        --with-protoc=src/protoc_host
+    $(MAKE) -C '$(1)' -j '$(JOBS)'
+    $(MAKE) -C '$(1)' -j 1 install
+
+    '$(TARGET)-gcc' \
+        -W -Wall -Werror -ansi -pedantic \
+        '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-protobuf.exe' \
+        `'$(TARGET)-pkg-config' protobuf --cflags --libs`
+endef


### PR DESCRIPTION
This patch adds "protobuf" (main relevant content: libprotobuf). The lib is required when using generated code from the google protocol buffer compiler.

Note that the build (protobuf.mk) contains two steps: First, "protoc" needs to be built for the host system, because it is required during build. Then it is used in the cross-build. That way, building works without patching protobuf.
