### PR TITLE
package ncurses: fix termcap support

### DIFF
--- a/src/ncurses-1-fix-headers.patch
+++ b/src/ncurses-1-fix-headers.patch
@@ -1,0 +1,57 @@
+# ncurses 5.9 - patch 20120707 - Thomas E. Dickey
+#
+# ------------------------------------------------------------------------------
+#
+# Ncurses 5.9 is at
+# 	ftp.gnu.org:/pub/gnu
+#
+# Patches for ncurses 5.9 are in the subdirectory
+# 	ftp://invisible-island.net/ncurses/5.9
+#
+# ------------------------------------------------------------------------------
+# ftp://invisible-island.net/ncurses/5.9/ncurses-5.9-20120707.patch.gz
+# patch by Thomas E. Dickey <dickey@invisible-island.net>
+# created  Sat Jul  7 23:45:45 UTC 2012
+# ------------------------------------------------------------------------------
+# include/headers             |   17 +++++++++++++----
+# 15 files changed, 13 insertions(+), 4 deletions(-)
+# ------------------------------------------------------------------------------
+Index: include/headers
+Prereq:  1.10 
+--- ncurses-5.9-20120630+/include/headers	2009-09-05 17:46:30.000000000 +0000
++++ ncurses-5.9-20120707/include/headers	2012-07-07 19:58:24.000000000 +0000
+@@ -1,6 +1,6 @@
+-# $Id: headers,v 1.10 2009/09/05 17:46:30 tom Exp $
++# $Id: headers,v 1.11 2012/07/07 19:58:24 tom Exp $
+ ##############################################################################
+-# Copyright (c) 1998-2007,2009 Free Software Foundation, Inc.                #
++# Copyright (c) 1998-2009,2012 Free Software Foundation, Inc.                #
+ #                                                                            #
+ # Permission is hereby granted, free of charge, to any person obtaining a    #
+ # copy of this software and associated documentation files (the "Software"), #
+@@ -29,14 +29,23 @@
+ #
+ # Author: Thomas E. Dickey	1996-on
+ #
+-term.h
+ curses.h
+ unctrl.h
+-termcap.h
+ ncurses_dll.h
++
++# Support for termcap (and tic, etc.), which can be a separate library
++@ termlib
++term.h
++termcap.h
++
++# Headers used only for tic, other programs using internal interfaces
+ @ ticlib
+ $(srcdir)/tic.h
+ $(srcdir)/term_entry.h
+ $(srcdir)/nc_tparm.h
+ 
++# Porting
++@ port_win32con
++$(srcdir)/ncurses_mingw.h
++
+ # vile:makemode


### PR DESCRIPTION
this patch is an extract of 20120707-patch of ncurses development see this thread:

http://lists.gnu.org/archive/html/bug-ncurses/2012-07/msg00007.html

with this patch is added ncurses_mingw.h to installed headers and
with ncurses_mingw.h header term.h becomes usable (to support termcap with ncurses)
