### PR TITLE
package gdb: remove internal termcap support

### DIFF
--- a/src/gdb-2-fix-termcap.patch
+++ b/src/gdb-2-fix-termcap.patch
@@ -1,0 +1,24 @@
+diff -ur gdb-7.5.1_old/gdb/windows-termcap.c gdb-7.5.1/gdb/windows-termcap.c
+--- gdb-7.5.1_old/gdb/windows-termcap.c	2012-12-13 13:28:37.527194089 -0300
++++ gdb-7.5.1/gdb/windows-termcap.c	2012-12-13 13:29:54.823190855 -0300
+@@ -18,7 +18,15 @@
+ 
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
++#include "config.h"
+ 
++#if defined (HAVE_NCURSES_TERM_H)
++#elif defined (HAVE_TERM_H)
++#else
++/* On MinGW, a real termcap library is usually not present.  Stub versions
++   of the termcap functions will be built from windows-termcap.c.  Readline
++   provides its own extern declarations when there's no termcap.h; do the
++   same here for the termcap functions used in GDB.  */
+ #include <stdlib.h>
+ 
+ /* -Wmissing-prototypes */
+@@ -71,3 +79,4 @@
+ {
+   return NULL;
+ }
++#endif

--- a/src/gdb.mk
+++ b/src/gdb.mk
@@ -7,7 +7,7 @@ $(PKG)_SUBDIR   := gdb-$($(PKG)_VERSION)
 $(PKG)_FILE     := gdb-$($(PKG)_VERSION).tar.bz2
 $(PKG)_URL      := ftp://ftp.gnu.org/pub/gnu/$(PKG)/$($(PKG)_FILE)
 $(PKG)_URL_2    := ftp://ftp.cs.tu-berlin.de/pub/gnu/$(PKG)/$($(PKG)_FILE)
-$(PKG)_DEPS     := gcc expat libiconv zlib
+$(PKG)_DEPS     := gcc expat libiconv ncurses zlib
 
 define $(PKG)_UPDATE
     $(WGET) -q -O- 'http://ftp.gnu.org/gnu/gdb/?C=M;O=D' | \


### PR DESCRIPTION
in mingw termcap library is usually not present, but with ncurses termcap is present in mxe, so it's necessary remove the internal support these function in gdb
