### PR TITLE
packages graphicsmagick and hdf5: downgrade autoconf version requirement

### DIFF
--- a/src/graphicsmagick-2-fix-autoconf-version.patch
+++ b/src/graphicsmagick-2-fix-autoconf-version.patch
@@ -1,0 +1,12 @@
+diff --git a/configure.ac b/configure.ac
+--- a/configure.ac
++++ b/configure.ac
+@@ -11,7 +11,7 @@
+ # Written by Bob Friesenhahn <bfriesen@GraphicsMagick.org>
+ #
+  
+-AC_PREREQ(2.69)
++AC_PREREQ(2.68)
+ AC_INIT(magick/magick.h)
+ 
+ # Specify directory where m4 macros may be found.

--- a/src/hdf5-3-fix-autoconf-version.patch
+++ b/src/hdf5-3-fix-autoconf-version.patch
@@ -1,0 +1,12 @@
+diff --git a/configure.ac b/configure.ac
+--- a/configure.ac	2012-12-11 00:17:32.377025807 -0300
++++ b/configure.ac	2012-12-11 00:17:57.589024754 -0300
+@@ -17,7 +17,7 @@
+ ## Initialize configure.
+ ##
+ AC_REVISION($Id: configure.ac 22979 2012-10-27 00:14:40Z acheng $)
+-AC_PREREQ([2.69])
++AC_PREREQ([2.68])
+ 
+ ## AC_INIT takes the name of the package, the version number, and an
+ ## email address to report bugs. AC_CONFIG_SRCDIR takes a unique file


### PR DESCRIPTION
.downgrade in the autoconf version requirement (2.69 --> 2.68), in both cases 2.69 is not necessary
