### PR TITLE
sdl_ttf: add Requires.private:freetype2...

### DIFF
--- a/src/sdl_ttf.mk
+++ b/src/sdl_ttf.mk
@@ -16,6 +16,7 @@ define $(PKG)_UPDATE
 endef
 
 define $(PKG)_BUILD
+    echo 'Requires.private: freetype2' >> '$(1)/SDL_ttf.pc.in'
     cd '$(1)' && ./configure \
         --host='$(TARGET)' \
         --disable-shared \


### PR DESCRIPTION
... otherwise -lfreetype is missing when doing a static build using pkg-config --static --libs
