### PR TITLE
Makefile: convenience targets to show dependencies and dependents

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -262,3 +262,24 @@ cleanup-style:
             rm -f $(TOP_DIR)/tmp-cleanup-style; \
         )
 
+define SHOW_DEPENDENCIES
+.PHONY: show-dependencies-$(1)
+show-dependencies-$(1): $(TOP_DIR)/tmp-dependencies/$(1)
+$(TOP_DIR)/tmp-dependencies/$(1): $(addprefix $(TOP_DIR)/tmp-dependencies/,$($(1)_DEPS))
+	@echo '$(1)'
+	$(if $(value CREATE_DEPENDENCIES),
+	@[ -d '$(TOP_DIR)/tmp-dependencies' ] || mkdir -p '$(TOP_DIR)/tmp-dependencies'
+	@touch $(TOP_DIR)/tmp-dependencies/$(1))
+endef
+$(foreach PKG,$(PKGS),$(eval $(call SHOW_DEPENDENCIES,$(PKG))))
+
+.PHONY: show-dependencies
+show-dependencies: $(addprefix show-dependencies-,$(PKGS))
+
+show-dependents-%:
+	@rm -rf '$(TOP_DIR)/tmp-dependencies'
+	@mkdir -p '$(TOP_DIR)/tmp-dependencies'
+	@touch $(addprefix $(TOP_DIR)/tmp-dependencies/,$(PKGS))
+	@rm -f '$(TOP_DIR)/tmp-dependencies/$*'
+	@$(MAKE) -f '$(MAKEFILE)' show-dependencies CREATE_DEPENDENCIES=true
+	@rm -rf '$(TOP_DIR)/tmp-dependencies'

--- a/index.html
+++ b/index.html
@@ -870,6 +870,24 @@ USE_OSGPLUGIN(&lt;plugin2&gt;)
         where up to 4 packages are downloaded in parallel
         </dd>
 
+    <dt>make show-dependencies-foo show-dependencies-bar</dt>
+
+        <dd>
+        shows a list of packages that
+        "foo" and "bar" depend on,
+        in the order they would be built
+        (effects of -j options aside)
+        </dd>
+
+    <dt>make show-dependents-foo show-dependents-bar</dt>
+
+        <dd>
+        shows a list of packages that
+        depend on "foo" and "bar",
+        in the approximate order
+        they would be rebuilt
+        </dd>
+
     <dt>make clean</dt>
 
         <dd>


### PR DESCRIPTION
I often find myself wanting a fully expanded list of dependents to see what packages are affected and if I can exclude them from the build. A concrete example would be glib on FreeBSD, I have a large list of 'pkg_BUILD=' to see if everything else works without it. 

There's probably easier ways to this in other languages, but I thought it might be an idea to let Make do it's own dependency resolution by doing a fake build and changing one of the prerequisites.

It works well enough, other than OSX has a weird fsync that can be tricked by repeated calls. I tried doing this entirely with phony targets and not touching the filesystem, but my make-fu isn't up to it. 

Comments welcome.

Update: Another use would be to build all packages that depend on a certain package:

```
make `make show-dependents-qtbase | tr '\n' ' '`
```
