### PR TITLE
upgrade to wxwidgets 2.9.4 and fix built for x86_64 target

### DIFF
--- a/index.html
+++ b/index.html
@@ -2113,7 +2113,7 @@ USE_OSGPLUGIN(&lt;plugin2&gt;)
     </tr>
     <tr>
         <td id="wxwidgets-package">wxwidgets</td>
-        <td id="wxwidgets-version">2.8.12</td>
+        <td id="wxwidgets-version">2.9.4</td>
         <td id="wxwidgets-website"><a href="http://www.wxwidgets.org/">wxWidgets</a></td>
     </tr>
     <tr>

--- a/src/wxwidgets-1-fixes.patch
+++ b/src/wxwidgets-1-fixes.patch
@@ -1,0 +1,11 @@
+--- ./src/msw/textctrl.cpp	2013-01-02 21:47:03.000000000 +0100
++++ ./src/msw/textctrl.cpp	2013-01-02 21:46:53.000000000 +0100
+@@ -992,7 +992,7 @@
+ 
+     EDITSTREAM eds;
+     wxZeroMemory(eds);
+-    eds.dwCookie = (DWORD)&data;
++    eds.dwCookie = (DWORD_PTR)&data;
+     eds.pfnCallback = wxRichEditStreamOut;
+ 
+     ::SendMessage

--- a/src/wxwidgets.mk
+++ b/src/wxwidgets.mk
@@ -3,9 +3,9 @@
 
 PKG             := wxwidgets
 $(PKG)_IGNORE   :=
-$(PKG)_CHECKSUM := 39552f3e49341197fea8373824ec609c757e890b
-$(PKG)_SUBDIR   := wxMSW-$($(PKG)_VERSION)
-$(PKG)_FILE     := wxMSW-$($(PKG)_VERSION).tar.bz2
+$(PKG)_CHECKSUM := 5a34ddf19d37c741f74652ee847df9568a8b81e1
+$(PKG)_SUBDIR   := wxWidgets-$($(PKG)_VERSION)
+$(PKG)_FILE     := wxWidgets-$($(PKG)_VERSION).tar.bz2
 $(PKG)_URL      := http://$(SOURCEFORGE_MIRROR)/project/wxwindows/$($(PKG)_VERSION)/$($(PKG)_FILE)
 $(PKG)_DEPS     := gcc libiconv libpng jpeg tiff sdl zlib expat
 


### PR DESCRIPTION
wxwidgets 2.8.12 does not built for x86_64 target, the same is true for wx2.9.4. the attached patch provides a patch for 2.9.4 and upgrades wx to 2.9.4. 

The patch has been reported upstream, too. see http://trac.wxwidgets.org/ticket/14949
