### PR TITLE
libusb's header must be named usb.h.

### DIFF
--- a/src/libusb.mk
+++ b/src/libusb.mk
@@ -30,7 +30,7 @@ define $(PKG)_BUILD
         --output-lib libusb.a
 
     $(INSTALL) -d '$(PREFIX)/$(TARGET)/include'
-    $(INSTALL) -m644 '$(1)/src/lusb0_usb.h' '$(PREFIX)/$(TARGET)/include/'
+    $(INSTALL) -m644 '$(1)/src/lusb0_usb.h' '$(PREFIX)/$(TARGET)/include/usb.h'
     $(INSTALL) -d '$(PREFIX)/$(TARGET)/lib'
     $(INSTALL) -m644 '$(1)/libusb.a'  '$(PREFIX)/$(TARGET)/lib/'
     $(INSTALL) -m644 '$(1)/libusbd.a' '$(PREFIX)/$(TARGET)/lib/'


### PR DESCRIPTION
The current libusb package installs it as usb0_usb.h, which is incorrect.
For other packages to actually be able to use the installed libusb, the
header file must be named usb.h.
