### PR TITLE
add package portmidi

### DIFF
--- a/index.html
+++ b/index.html
@@ -1862,6 +1862,11 @@ USE_OSGPLUGIN(&lt;plugin2&gt;)
         <td id="portaudio-website"><a href="http://www.portaudio.com/">portaudio</a></td>
     </tr>
     <tr>
+        <td id="portmidi-package">portmidi</td>
+        <td id="portmidi-version">217</td>
+        <td id="portmidi-website"><a href="http://portmedia.sourceforge.net/portmidi/">portmidi</a></td>
+    </tr>
+    <tr>
         <td id="postgresql-package">postgresql</td>
         <td id="postgresql-version">9.2.2</td>
         <td id="postgresql-website"><a href="http://www.postgresql.org/">PostgreSQL</a></td>

--- a/src/portmidi-1-nojni.patch
+++ b/src/portmidi-1-nojni.patch
@@ -1,0 +1,46 @@
+This file is part of MXE.
+See index.html for further information.
+
+This patch disables the Java Native Interface dependency.
+
+--- a/pm_common/CMakeLists.txt	2013-01-27 17:48:15.819279645 +0100
++++ b/pm_common/CMakeLists.txt	2013-01-27 17:52:31.702624256 +0100
+@@ -88,9 +88,9 @@
+     # /MD is multithread DLL, /MT is multithread. Change to static:
+     include(../pm_win/static.cmake)
+     
+-    include(FindJNI)
++#    include(FindJNI)
+ 
+-    set(JAVA_INCLUDE_PATHS ${JAVA_INCLUDE_PATH} ${JAVA_INCLUDE_PATH2})
++#    set(JAVA_INCLUDE_PATHS ${JAVA_INCLUDE_PATH} ${JAVA_INCLUDE_PATH2})
+     # message(STATUS "JAVA_INCLUDE_PATHS: " ${JAVA_INCLUDE_PATHS})
+ 
+     set(WINSRC pmwin pmwinmm)
+@@ -99,7 +99,7 @@
+     set(PM_NEEDED_LIBS winmm.lib)
+   endif(WIN32)
+ endif(UNIX)
+-set(JNI_EXTRA_LIBS ${PM_NEEDED_LIBS} ${JAVA_JVM_LIBRARY})
++#set(JNI_EXTRA_LIBS ${PM_NEEDED_LIBS} ${JAVA_JVM_LIBRARY})
+ 
+ # this completes the list of library sources by adding shared code
+ list(APPEND LIBSRC pmutil portmidi)
+@@ -110,12 +110,12 @@
+ target_link_libraries(portmidi-static ${PM_NEEDED_LIBS})
+ 
+ # define the jni library
+-include_directories(${JAVA_INCLUDE_PATHS})
++#include_directories(${JAVA_INCLUDE_PATHS})
+ 
+-set(JNISRC ${LIBSRC} ../pm_java/pmjni/pmjni.c)
+-add_library(pmjni SHARED ${JNISRC})
+-target_link_libraries(pmjni ${JNI_EXTRA_LIBS})
+-set_target_properties(pmjni PROPERTIES EXECUTABLE_EXTENSION "jnilib")
++#set(JNISRC ${LIBSRC} ../pm_java/pmjni/pmjni.c)
++#add_library(pmjni SHARED ${JNISRC})
++#target_link_libraries(pmjni ${JNI_EXTRA_LIBS})
++#set_target_properties(pmjni PROPERTIES EXECUTABLE_EXTENSION "jnilib")
+ 
+ # install the libraries (Linux and Mac OS X command line)
+ if(UNIX)

--- a/src/portmidi.mk
+++ b/src/portmidi.mk
@@ -1,0 +1,34 @@
+# This file is part of MXE.
+# See index.html for further information.
+
+PKG             := portmidi
+$(PKG)_IGNORE   :=
+$(PKG)_CHECKSUM := f45bf4e247c0d7617deacd6a65d23d9fddae6117
+$(PKG)_SUBDIR   := portmidi
+$(PKG)_FILE     := $(PKG)-src-$($(PKG)_VERSION).zip
+$(PKG)_URL      := http://$(SOURCEFORGE_MIRROR)/project/portmedia/$(PKG)/$($(PKG)_VERSION)/$($(PKG)_FILE)
+$(PKG)_DEPS     := gcc
+
+define $(PKG)_BUILD
+    mkdir '$(1)/build'
+    cd '$(1)/build' && cmake .. \
+        -DCMAKE_TOOLCHAIN_FILE='$(CMAKE_TOOLCHAIN_FILE)' \
+        -DLIBTYPE=STATIC
+
+    $(MAKE) -C '$(1)/build' -j '$(JOBS)' portmidi-static
+
+    # install library files
+    $(INSTALL) -d '$(PREFIX)/$(TARGET)/lib'
+    $(INSTALL) -m644 '$(1)/build/libportmidi_s.a' \
+                     '$(PREFIX)/$(TARGET)/lib/libportmidi.a'
+
+    # install include files
+    $(INSTALL) -d                                '$(PREFIX)/$(TARGET)/include'
+    $(INSTALL) -m644 '$(1)/pm_common/portmidi.h' '$(PREFIX)/$(TARGET)/include/'
+    $(INSTALL) -m644 '$(1)/pm_common/pmutil.h'   '$(PREFIX)/$(TARGET)/include/'
+    $(INSTALL) -m644 '$(1)/porttime/porttime.h'  '$(PREFIX)/$(TARGET)/include/'
+
+    '$(TARGET)-gcc' \
+        '$(1)/pm_test/test.c' -o '$(PREFIX)/$(TARGET)/bin/test-portmidi.exe' \
+        -lportmidi -lwinmm
+endef


### PR DESCRIPTION
PortMidi is a cross-platform MIDI library.  Its webpage says:

  "It supports real-time input and output of MIDI data using a
  system-independent interface. PortMidi runs on Windows (using MME),
  Macintosh (using CoreMIDI), and Linux (using ALSA)."

The build system is cmake.  A patch was necessary to build without a
Java Native Interface dependency (only needed for Java bindings and
Java-based utilities).

The pm_test/test.c program is compiled in order to prove that building
works.

Signed-off-by: Stefan Hajnoczi stefanha@gmail.com
