### PR TITLE
Fix ocaml-xml-light section in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -1759,9 +1759,9 @@ aptitude -t squeeze-backports install cmake yasm</pre>
         <td id="ocaml-lablgtk2-website"><a href="http://forge.ocamlcore.org/">lablgtk2</a></td>
     </tr>
     <tr>
-        <td id="ocaml-xml-light-package">xml-light</td>
+        <td id="ocaml-xml-light-package">ocaml-xml-light</td>
         <td id="ocaml-xml-light-version">2.2</td>
-        <td id="ocaml-xml-light-website"><a href="http://tech.motion-twin.com/xmllight/">xml-light</a></td>
+        <td id="ocaml-xml-light-website"><a href="http://tech.motion-twin.com/xmllight.html">xml-light</a></td>
     </tr>
     <tr>
         <td id="ogg-package">ogg</td>

--- a/src/ocaml-xml-light.mk
+++ b/src/ocaml-xml-light.mk
@@ -10,7 +10,7 @@ $(PKG)_URL      := http://tech.motion-twin.com/zip/$($(PKG)_FILE)
 $(PKG)_DEPS     := gcc ocaml-findlib
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'http://tech.motion-twin.com/xmllight' | \
+    $(WGET) -q -O- 'http://tech.motion-twin.com/xmllight.html' | \
     $(SED) -n 's,.*xml-light-\(.*\)\.zip.*,\1,ip' | \
     head -1
 endef


### PR DESCRIPTION
Trivial fixes (incomplete name, wrong website URL). In the makefile (UPDATE), the URL is OK.
