### PR TITLE
sox: enable most optional libraries

### DIFF
--- a/src/sox-1-magic.patch
+++ b/src/sox-1-magic.patch
@@ -1,0 +1,24 @@
+This file is part of MXE.
+See index.html for further information.
+
+diff -urN sox-14.4.1.orig/configure sox-14.4.1/configure
+--- sox-14.4.1.orig/configure	2013-02-02 03:02:52.000000000 +0100
++++ sox-14.4.1/configure	2013-03-10 08:48:41.000000000 +0100
+@@ -13240,7 +13240,7 @@
+   $as_echo_n "(cached) " >&6
+ else
+   ac_check_lib_save_LIBS=$LIBS
+-LIBS="-lmagic  $LIBS"
++LIBS="-lmagic -lshlwapi -lgnurx $LIBS"
+ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ 
+@@ -13271,7 +13271,7 @@
+ { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_magic_magic_open" >&5
+ $as_echo "$ac_cv_lib_magic_magic_open" >&6; }
+ if test "x$ac_cv_lib_magic_magic_open" = xyes; then :
+-  MAGIC_LIBS="-lmagic"
++  MAGIC_LIBS="-lmagic -lshlwapi -lgnurx"
+ else
+   using_magic=no
+ fi

--- a/src/sox.mk
+++ b/src/sox.mk
@@ -8,7 +8,7 @@ $(PKG)_CHECKSUM := 71f05afc51e3d9b03376b2f98fd452d3a274d595
 $(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
 $(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.gz
 $(PKG)_URL      := http://$(SOURCEFORGE_MIRROR)/project/$(PKG)/$(PKG)/$($(PKG)_VERSION)/$($(PKG)_FILE)
-$(PKG)_DEPS     := gcc flac lame libgomp libmad libpng libsndfile libtool opencore-amr twolame vorbis wavpack
+$(PKG)_DEPS     := gcc file flac lame libgomp libmad libpng libsndfile libtool opencore-amr twolame vorbis wavpack
 
 define $(PKG)_UPDATE
     $(WGET) -q -O- 'http://sourceforge.net/projects/sox/files/sox/' | \
@@ -20,8 +20,9 @@ define $(PKG)_BUILD
     # set pkg-config cflags and libs
     $(SED) -i 's,^\(Cflags:.*\),\1 -fopenmp,' '$(1)/sox.pc.in'
     $(SED) -i '/Libs.private/d'               '$(1)/sox.pc.in'
-    echo Libs.private: `grep sox_LDADD '$(1)/src/optional-fmts.am' | \
-    $(SED) 's, sox_LDADD += ,,g' | tr -d '\n'` >>'$(1)/sox.pc.in'
+    echo Libs.private: @MAGIC_LIBS@ \
+        `grep sox_LDADD '$(1)/src/optional-fmts.am' | \
+         $(SED) 's, sox_LDADD += ,,g' | tr -d '\n'` >>'$(1)/sox.pc.in'
 
     cd '$(1)' && ./configure \
         --host='$(TARGET)' \
@@ -31,7 +32,7 @@ define $(PKG)_BUILD
         --enable-static \
         --disable-debug \
         --with-libltdl \
-        --without-magic \
+        --with-magic \
         --with-png \
         --with-ladspa \
         --with-amrwb \


### PR DESCRIPTION
Enables libpng (for writing spectrograms), libmagic/file, LADSPA plugins, AMR-NB/AMR-WB codecs.
