### PR TITLE
Github downloads are deprecated

### DIFF
--- a/src/ilmbase.mk
+++ b/src/ilmbase.mk
@@ -7,7 +7,6 @@ $(PKG)_CHECKSUM := 20597d2a27e3b580e0972576e6b07bf4836b5dc6
 $(PKG)_SUBDIR   := ilmbase-$($(PKG)_VERSION)
 $(PKG)_FILE     := ilmbase-$($(PKG)_VERSION).tar.gz
 $(PKG)_URL      := http://download.savannah.nongnu.org/releases/openexr/$($(PKG)_FILE)
-$(PKG)_URL_2    := https://github.com/downloads/openexr/openexr/$($(PKG)_FILE)
 $(PKG)_DEPS     := gcc
 
 define $(PKG)_UPDATE

--- a/src/json-c.mk
+++ b/src/json-c.mk
@@ -3,15 +3,15 @@
 
 PKG             := json-c
 $(PKG)_IGNORE   :=
-$(PKG)_CHECKSUM := f90f643c8455da21d57b3e8866868a944a93c596
-$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
-$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.gz
-$(PKG)_URL      := https://github.com/downloads/$(PKG)/$(PKG)/$($(PKG)_FILE)
+$(PKG)_CHECKSUM := d78d38037dd6d9d19388770b5ebe33a8531b32ba
+$(PKG)_SUBDIR   := $(PKG)-$(PKG)-$($(PKG)_VERSION)-20120530
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION)-20120530.tar.gz
+$(PKG)_URL      := https://github.com/$(PKG)/$(PKG)/archive/$($(PKG)_FILE)
 $(PKG)_DEPS     := gcc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://github.com/json-c/json-c/downloads' | \
-    $(SED) -n 's,.*href="/downloads/json-c/json-c/json-c-\([0-9.]*\).tar.gz.*,\1,p' | \
+    $(WGET) -q -O- 'https://github.com/json-c/json-c/tags' | \
+    $(SED) -n 's,.*href="/json-c/json-c/archive/json-c-\([0-9.]*\)-\([0-9]*\).tar.gz.*,\1,p' | \
     head -1
 endef
 

--- a/src/libevent.mk
+++ b/src/libevent.mk
@@ -3,10 +3,10 @@
 
 PKG             := libevent
 $(PKG)_IGNORE   :=
-$(PKG)_CHECKSUM := 3e6674772eb77de24908c6267c698146420ab699
-$(PKG)_SUBDIR   := libevent-$($(PKG)_VERSION)-stable
-$(PKG)_FILE     := libevent-$($(PKG)_VERSION)-stable.tar.gz
-$(PKG)_URL      := https://github.com/downloads/$(PKG)/$(PKG)/$($(PKG)_FILE)
+$(PKG)_CHECKSUM := 8a8813b2173b374cb64260245d7094fa81176854
+$(PKG)_SUBDIR   := libevent-release-$($(PKG)_VERSION)-stable
+$(PKG)_FILE     := release-$($(PKG)_VERSION)-stable.tar.gz
+$(PKG)_URL      := https://github.com/$(PKG)/$(PKG)/archive/$($(PKG)_FILE)
 $(PKG)_DEPS     := gcc
 
 define $(PKG)_UPDATE
@@ -17,7 +17,7 @@ define $(PKG)_UPDATE
 endef
 
 define $(PKG)_BUILD
-    cd '$(1)' && ./configure \
+    cd '$(1)' && ./autogen.sh && ./configure \
         --host='$(TARGET)' \
         --build="`config.guess`" \
         --disable-shared \

--- a/src/openexr.mk
+++ b/src/openexr.mk
@@ -7,7 +7,6 @@ $(PKG)_CHECKSUM := b97cc40af82a8514c95c7a6a31f4e3233dcc2912
 $(PKG)_SUBDIR   := openexr-$($(PKG)_VERSION)
 $(PKG)_FILE     := openexr-$($(PKG)_VERSION).tar.gz
 $(PKG)_URL      := http://download.savannah.nongnu.org/releases/openexr/$($(PKG)_FILE)
-$(PKG)_URL_2    := https://github.com/downloads/openexr/openexr/$($(PKG)_FILE)
 $(PKG)_DEPS     := gcc ilmbase pthreads zlib
 
 define $(PKG)_UPDATE


### PR DESCRIPTION
see https://github.com/blog/1302-goodbye-uploads 

Using tags instead or remove Github as alternative URL.
