### PR TITLE
Updated liboauth to 1.0.1

### DIFF
--- a/index.html
+++ b/index.html
@@ -1535,7 +1535,7 @@ aptitude -t squeeze-backports install cmake yasm</pre>
     </tr>
     <tr>
         <td id="liboauth-package">liboauth</td>
-        <td id="liboauth-version">1.0.0</td>
+        <td id="liboauth-version">1.0.1</td>
         <td id="liboauth-website"><a href="http://liboauth.sourceforge.net/">liboauth</a></td>
     </tr>
     <tr>

--- a/src/liboauth.mk
+++ b/src/liboauth.mk
@@ -3,7 +3,7 @@
 
 PKG             := liboauth
 $(PKG)_IGNORE   :=
-$(PKG)_CHECKSUM := cc936a440084f159cc46dab9018f1353f8bee80a
+$(PKG)_CHECKSUM := 2631b489c150187adcca264fe813d58b2c22bf8a
 $(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
 $(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.gz
 $(PKG)_URL      := http://liboauth.sourceforge.net/pool/$($(PKG)_FILE)


### PR DESCRIPTION
Liboauth 1.0.1 has been released.
