### PR TITLE
configuring SHELL because libtools fails with dash in some systems

### DIFF
--- a/src/libmikmod-1-fixes.patch
+++ b/src/libmikmod-1-fixes.patch
@@ -25,3 +25,23 @@ index 8698715..c788c8a 100644
 -- 
 1.7.9.2
 
+diff --git a/libmikmod/Makefile.in b/libmikmod/Makefile.in
+--- a/libmikmod/Makefile.in
++++ b/libmikmod/Makefile.in
+@@ -23,13 +23,15 @@
+ LIBOBJS=@LIBOBJS@
+ LIBRARY_LIB=@LIBRARY_LIB@
+ 
++SHELL=@SHELL@
++
+ CC=@CC@
+ INSTALL=@INSTALL@
+ LIBTOOL=@LIBTOOL@
+ MKINSTALLDIRS=${top_srcdir}/mkinstalldirs
+ 
+ DEFS=@DEFS@
+-CFLAGS=@CFLAGS@ -Dunix
++CFLAGS=@CFLAGS@ 
+ COMPILE=$(LIBTOOL) --silent --mode=compile $(CC) $(DEFS) $(CFLAGS) -I$(top_srcdir)/include -I$(top_builddir) -I$(top_builddir)/include -DMIKMOD_H=$(top_srcdir)/include/mikmod.h
+ 
+ LIB = libmikmod.la

--- a/src/libmikmod.mk
+++ b/src/libmikmod.mk
@@ -16,12 +16,12 @@ define $(PKG)_UPDATE
 endef
 
 define $(PKG)_BUILD
-    $(SED) -i 's,-Dunix,,' '$(1)/libmikmod/Makefile.in'
     $(SED) -i 's,`uname`,MinGW,g' '$(1)/configure'
     cd '$(1)' && ./configure \
         --host='$(TARGET)' \
         --disable-shared \
         --prefix='$(PREFIX)/$(TARGET)' \
+        CONFIG_SHELL='$(SHELL)' \
         CFLAGS='-msse2'
     $(MAKE) -C '$(1)' -j '$(JOBS)' install bin_PROGRAMS= sbin_PROGRAMS= noinst_PROGRAMS=
 


### PR DESCRIPTION
for example, in Ubuntu 12.04.2 LTS /bin/sh -> dash 
