### PR TITLE
Add package opusfile

### DIFF
--- a/index.html
+++ b/index.html
@@ -1809,6 +1809,11 @@ aptitude -t squeeze-backports install cmake yasm</pre>
         <td id="opus-website"><a href="http://opus-codec.org/">opus</a></td>
     </tr>
     <tr>
+        <td id="opusfile-package">opusfile</td>
+        <td id="opusfile-version">0.2</td>
+        <td id="opusfile-website"><a href="http://opus-codec.org/">opusfile</a></td>
+    </tr>
+    <tr>
         <td id="pango-package">pango</td>
         <td id="pango-version">1.33.8</td>
         <td id="pango-website"><a href="http://www.pango.org/">Pango</a></td>

--- a/src/opusfile-1-fseeko64.patch
+++ b/src/opusfile-1-fseeko64.patch
@@ -1,0 +1,66 @@
+This file is part of MXE.
+See index.html for further information.
+
+This patch has been taken from:
+http://git.xiph.org/?p=opusfile.git;a=patch;h=d75915786f465892f5eadcd93444f51a32b9ad1c
+
+From d75915786f465892f5eadcd93444f51a32b9ad1c Mon Sep 17 00:00:00 2001
+From: Timothy B. Terriberry <tterribe@xiph.org>
+Date: Tue, 8 Jan 2013 05:04:41 -0800
+Subject: [PATCH] Use fseeko64/ftello64 for mingw32.
+
+It turns out i686-pc-mingw32 does define these functions, and they
+ are always available (unlike _fseeki64/_ftelli64).
+This means we can build and link without requiring
+ i686-w64-mingw32.
+The resulting binary still doesn't run in wine for me, but that may
+ be a personal problem.
+---
+ src/stream.c |   22 ++++++++++++++++++++++
+ 1 files changed, 22 insertions(+), 0 deletions(-)
+
+diff --git a/src/stream.c b/src/stream.c
+index caa82f1..1c7266b 100644
+--- a/src/stream.c
++++ b/src/stream.c
+@@ -56,7 +56,18 @@ static int op_fread(void *_stream,unsigned char *_ptr,int _buf_size){
+ static int op_fseek(void *_stream,opus_int64 _offset,int _whence){
+ #if defined(_MSC_VER)
+   return _fseeki64((FILE *)_stream,_offset,_whence);
++#elif defined(__MINGW32__)
++  /*i686-pc-mingw32 does not have fseeko() and requires
++     __MSVCRT_VERSION__>=0x800 for _fseeki64(), which screws up linking with
++     other libraries (that don't use MSVCRT80 from MSVC 2005 by default).
++    i686-w64-mingw32 does have fseeko() and respects _FILE_OFFSET_BITS, but I
++     don't know how to detect that at compile time.
++    We don't need to use fopen64(), as this just dispatches to fopen() in
++     mingw32.*/
++  return fseeko64((FILE *)_stream,(off64_t)_offset,_whence);
+ #else
++  /*This function actually conforms to the SUSv2 and POSIX.1-2001, so we prefer
++     it except in the two special-cases above.*/
+   return fseeko((FILE *)_stream,(off_t)_offset,_whence);
+ #endif
+ }
+@@ -64,7 +75,18 @@ static int op_fseek(void *_stream,opus_int64 _offset,int _whence){
+ static opus_int64 op_ftell(void *_stream){
+ #if defined(_MSC_VER)
+   return _ftelli64((FILE *)_stream);
++#elif defined(__MINGW32__)
++  /*i686-pc-mingw32 does not have ftello() and requires
++     __MSVCRT_VERSION__>=0x800 for _ftelli64(), which screws up linking with
++     other libraries (that don't use MSVCRT80 from MSVC 2005 by default).
++    i686-w64-mingw32 does have ftello() and respects _FILE_OFFSET_BITS, but I
++     don't know how to detect that at compile time.
++    We don't need to use fopen64(), as this just dispatches to fopen() in
++     mingw32.*/
++  return ftello64((FILE *)_stream);
+ #else
++  /*This function actually conforms to the SUSv2 and POSIX.1-2001, so we prefer
++     it except in the two special-cases above.*/
+   return ftello((FILE *)_stream);
+ #endif
+ }
+-- 
+1.7.2.5
+

--- a/src/opusfile-2-lrint-lib.patch
+++ b/src/opusfile-2-lrint-lib.patch
@@ -1,0 +1,64 @@
+This file is part of MXE.
+See index.html for further information.
+
+This patch has been taken from:
+http://lists.xiph.org/pipermail/opus/2013-March/001972.html
+
+From 6ab2eb850c467e9eaca1c67d37b3e49521a04460 Mon Sep 17 00:00:00 2001
+From: Ulrich Klauer <ulrich@chirlu.de>
+Date: Sun, 10 Mar 2013 04:02:49 +0100
+Subject: [PATCH] Handle AC_SEARCH_LIBS special result value
+
+AC_SEARCH_LIBS will give a result of "none required" if the relevant
+function is available without any special libraries. (This is the case
+for lrintf on MinGW.) Make sure this special value isn't put verbatim
+into the pkg-config files, as it would cause the linker to search for
+files named "none" and "required", and fail.
+---
+ configure.ac               |    6 +++++-
+ opusfile-uninstalled.pc.in |    2 +-
+ opusfile.pc.in             |    2 +-
+ 3 files changed, 7 insertions(+), 3 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index 8b1a3b3..d82d53f 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -107,7 +107,11 @@ AS_IF([test "x$enable_fixed_point" = "xyes"],
+    ])
+   ]
+ )
+-AC_SUBST(ac_cv_search_lrintf)
++lrintf_lib=" $ac_cv_search_lrintf"
++AS_IF([test "x$ac_cv_search_lrintf" = "xnone required"],
++  [lrintf_lib=""]
++)
++AC_SUBST(lrintf_lib)
+ 
+ CC_ATTRIBUTE_VISIBILITY([default], [
+   CC_FLAG_VISIBILITY([CFLAGS="${CFLAGS} -fvisibility=hidden"])
+diff --git a/opusfile-uninstalled.pc.in b/opusfile-uninstalled.pc.in
+index b63a23c..7f555d6 100644
+--- a/opusfile-uninstalled.pc.in
++++ b/opusfile-uninstalled.pc.in
+@@ -10,5 +10,5 @@ Description: Opus playback library (not installed)
+ Version: @VERSION@
+ Requires: ogg >= 1.3 opus >= 1.0.1 @openssl@
+ Conflicts:
+-Libs: ${libdir}/libopusfile.la @ac_cv_search_lrintf@
++Libs: ${libdir}/libopusfile.la@lrintf_lib@
+ Cflags: -I${includedir}
+diff --git a/opusfile.pc.in b/opusfile.pc.in
+index 0a77f0c..c96d6a8 100644
+--- a/opusfile.pc.in
++++ b/opusfile.pc.in
+@@ -11,5 +11,5 @@ Version: @VERSION@
+ Requires: ogg >= 1.3 opus >= 1.0.1 @openssl@
+ Conflicts:
+ Libs: -L${libdir} -lopusfile
+-Libs.private: @ac_cv_search_lrintf@
++Libs.private:@lrintf_lib@
+ Cflags: -I${includedir}/opus
+-- 
+1.7.10.4
+

--- a/src/opusfile.mk
+++ b/src/opusfile.mk
@@ -1,0 +1,29 @@
+# This file is part of MXE.
+# See index.html for further information.
+
+PKG             := opusfile
+$(PKG)_IGNORE   :=
+$(PKG)_CHECKSUM := db020e25178b501929a11b0e0f469890f4f4e6fa
+$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.gz
+$(PKG)_URL      := http://downloads.xiph.org/releases/opus/$($(PKG)_FILE)
+$(PKG)_DEPS     := gcc ogg opus
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- 'http://downloads.xiph.org/releases/opus/?C=M;O=D' | \
+    $(SED) -n 's,.*opusfile-\([0-9][^>]*\)\.tar.*,\1,p' | \
+    grep -v 'alpha' | \
+    head -1
+endef
+
+define $(PKG)_BUILD
+    cd '$(1)' && ./configure \
+        --host='$(TARGET)' \
+        --build="`config.guess`" \
+        --disable-shared \
+        --prefix='$(PREFIX)/$(TARGET)' \
+        --disable-doc \
+        --disable-http
+    $(MAKE) -C '$(1)' -j '$(JOBS)' noinst_PROGRAMS=
+    $(MAKE) -C '$(1)' -j 1 install noinst_PROGRAMS=
+endef


### PR DESCRIPTION
Opusfile is a decoder for Opus files. It provides a higher-level API than the opus library, of which it makes use.
