### PR TITLE
reorganise native and cross tools between ocaml-native and ocaml-core

### DIFF
--- a/src/ocaml-core.mk
+++ b/src/ocaml-core.mk
@@ -43,11 +43,6 @@ define $(PKG)_BUILD
     $(MAKE) -C '$(1)' -j 1 coreboot
     $(MAKE) -C '$(1)' -j 1 all
     # install ocamldoc and camlp4 (non cross versions)
-    $(MAKE) -C '$(1)/ocamldoc' -j 1 install
-    cd '$(1)' && BINDIR=$(PREFIX)/$(TARGET)/bin \
-                 LIBDIR=$(PREFIX)/$(TARGET)/lib/ocaml \
-                 PREFIX=$(PREFIX)/$(TARGET) \
-                 ./build/partial-install.sh
 
     ####### patch mingw include
     # Now patch utils/clflags.ml to hardcode mingw-specific include.
@@ -112,15 +107,14 @@ define $(PKG)_BUILD
     $(MAKE) -C '$(1)' -j 1 installopt
     # Rename all the binaries to target-binary
     for f in ocamlc ocamlcp ocamlrun ocamldep ocamlmklib ocamlmktop ocamlopt \
-      ocamlprof camlp4prof camlp4boot camlp4 camlp4oof camlp4of camlp4o \
-      camlp4rf camlp4r camlp4orf ocamldoc ocamllex ocamlyacc; do \
+      ocamlprof; do \
         cp -f $(PREFIX)/$(TARGET)/bin/$$f $(PREFIX)/bin/$(TARGET)-$$f; \
     done
 
     # test ocamlopt
     cp '$(2).ml' '$(1)/test.ml'
     cd '$(1)' && '$(TARGET)-ocamlopt' test.ml
-    # test ocamlbuild
+    # test ocamlbuild from package ocaml-native, now that ocamlopt works
     mkdir '$(1)/tmp' && cp '$(2).ml' '$(1)/tmp/test.ml'
     cd '$(1)/tmp' && $(TARGET)-ocamlbuild test.native
 endef

--- a/src/ocaml-native.mk
+++ b/src/ocaml-native.mk
@@ -16,7 +16,13 @@ define $(PKG)_UPDATE
 endef
 
 define $(PKG)_BUILD
-    # patched ocaml source to get ocamlbuild use $(TARGET)-ocamlc, $(TARGET)-ocamlfind, ...
+    # the following script would require ocamlbuild with an option '-ocamlfind'
+    # to work:
+    #(echo '#!/bin/sh'; \
+    # echo 'exec $(PREFIX)/bin/ocamlbuild -use-ocamlfind -ocamlfind $(TARGET)-ocamlfind "$$@"') \
+    # > '$(PREFIX)/bin/$(TARGET)-ocamlbuild'
+    # chmod 0755 '$(PREFIX)/bin/$(TARGET)-ocamlbuild'
+    # As it is not the case, we patche ocaml source to get ocamlbuild use $(TARGET)-ocamlc, $(TARGET)-ocamlfind, ...
     cd '$(1)' && ./configure \
         -prefix '$(PREFIX)/$(TARGET)' \
         -bindir '$(PREFIX)/$(TARGET)/bin/ocaml-native' \
@@ -30,10 +36,10 @@ define $(PKG)_BUILD
     $(MAKE) -C '$(1)' -j '$(JOBS)' ocamlbuild.native
     cp -f '$(1)/_build/ocamlbuild/ocamlbuild.native' $(PREFIX)/bin/$(TARGET)-ocamlbuild
     $(MAKE) -C '$(1)' install
-    # the following script requires ocamlbuild with option -ocamlfind to work
-    #(echo '#!/bin/sh'; \
-    # echo 'exec $(PREFIX)/bin/ocamlbuild -use-ocamlfind -ocamlfind $(TARGET)-ocamlfind "$$@"') \
-    # > '$(PREFIX)/bin/$(TARGET)-ocamlbuild'
-    #chmod 0755 '$(PREFIX)/bin/$(TARGET)-ocamlbuild'
-    # test will be done once cross ocamlopt is built
+    # Rename all the binaries to target-binary
+    for f in camlp4 camlp4oof camlp4of camlp4o camlp4rf camlp4r camlp4orf \
+      ocamldoc ocamllex ocamlyacc; do \
+        cp -f $(PREFIX)/$(TARGET)/bin/ocaml-native/$$f $(PREFIX)/bin/$(TARGET)-$$f; \
+    done
+    # test will be done once cross ocamlopt is built in package ocaml-core
 endef


### PR DESCRIPTION
to build ocaml, there are 2 packages :
- ocaml-native 
- ocaml-cross

this commit reorganises ocaml tools : only cross tools are built in ocaml-cross, and usual ones are built in ocaml-native
