### PR TITLE
package openscenegraph: depend on gta

### DIFF
--- a/src/openscenegraph.mk
+++ b/src/openscenegraph.mk
@@ -7,7 +7,7 @@ $(PKG)_CHECKSUM := e0768e7026be239e1089f65ee0655bdda8b5949f
 $(PKG)_SUBDIR   := openscenegraph-osg-$($(PKG)_VERSION)
 $(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.gz
 $(PKG)_URL      := https://github.com/$(PKG)/osg/tarball/$($(PKG)_VERSION)/$($(PKG)_FILE)
-$(PKG)_DEPS     := gcc boost curl dcmtk ffmpeg freetype gdal giflib jasper jpeg libpng openal openexr poppler qt tiff xine-lib zlib
+$(PKG)_DEPS     := gcc boost curl dcmtk ffmpeg freetype gdal giflib gta jasper jpeg libpng openal openexr poppler qt tiff xine-lib zlib
 
 define $(PKG)_UPDATE
     $(WGET) -q -O- 'https://github.com/$(PKG)/osg/commits/master' | \


### PR DESCRIPTION
OSG builds the GTA plugin if libgta is available.
This patch makes that dependency explicit.
