### PR TITLE
Adding the Alure package

### DIFF
--- a/index.html
+++ b/index.html
@@ -909,6 +909,11 @@ aptitude -t squeeze-backports install cmake yasm</pre>
         <td id="agg-website"><a href="http://www.antigrain.com/">Anti-Grain Geometry</a></td>
     </tr>
     <tr>
+        <td id="alure-package">alure</td>
+        <td id="alure-version">1.2</td>
+        <td id="alure-website"><a href="ihttp://kcat.strangesoft.net/alure.html">alure</a></td>
+    </tr>
+    <tr>
         <td id="apr-util-package">apr-util</td>
         <td id="apr-util-version">1.4.1</td>
         <td id="apr-util-website"><a href="http://apr.apache.org/">APR-util</a></td>

--- a/src/alure.mk
+++ b/src/alure.mk
@@ -1,0 +1,31 @@
+# This file is part of MXE.
+# See index.html for further information
+
+PKG             := alure
+$(PKG)_IGNORE   :=
+$(PKG)_CHECKSUM := f033f0820c449ebff7b4b0254a7b1f26c0ba485b
+$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.bz2
+$(PKG)_URL      := http://kcat.strangesoft.net/alure-releases/$($(PKG)_FILE)
+$(PKG)_DEPS     := gcc openal flac ogg libsndfile vorbis
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- http://repo.or.cz/w/alure.git/tags | \
+    grep alure- | \
+    $(SED) -n 's,.*alure-\([0-9\.]*\)<.*,\1,p' | \
+    head -1
+endef
+
+define $(PKG)_BUILD
+    cd '$(1)/build' && cmake \
+        -DBUILD_STATIC=ON \
+        -DBUILD_SHARED=OFF \
+        -DBUILD_EXAMPLES=OFF \
+        -DCMAKE_C_FLAGS="-DAL_LIBTYPE_STATIC -DALURE_STATIC_LIBRARY" \
+        -DCMAKE_CXX_FLAGS="-DAL_LIBTYPE_STATIC -DALURE_STATIC_LIBRARY" \
+        -DCMAKE_TOOLCHAIN_FILE='$(CMAKE_TOOLCHAIN_FILE)' \
+        ..
+    $(MAKE) -C '$(1)/build' -j $(JOBS) VERBOSE=1
+    $(MAKE) -C '$(1)/build' -j $(JOBS) install
+endef
+


### PR DESCRIPTION
The alure package is an conveniance library for openal that packs certain OpenAL functionality
in a os independent wrapper. It also can use certain audio libraries to extend the type of loadable
audio files. The current package setup depends on all the audio libraries that mxe currently has
and that Alure can handle.

Moved VERBOSE=1 to the end of the make line as per request.

Also moved the cmake_toolchain_file line to the end of the cmake command block.

Moved from a insource to an outsource build of alure with cmake

I'm sorry but like a said in my second attempt I'm very new at using github and especially the pull requests feature. I should have paid more attention to i was actually requesting to be pulled but i didn't, my sincere apologies.
