### PR TITLE
Makefile: default JOBS to number of CPUs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 # This file is part of MXE.
 # See index.html for further information.
 
-JOBS               := 1
 TARGET             := i686-pc-mingw32
 SOURCEFORGE_MIRROR := freefr.dl.sourceforge.net
 PKG_MIRROR         := s3.amazonaws.com/mxe-pkg
@@ -9,6 +8,7 @@ PKG_CDN            := d1yihgixbnrglp.cloudfront.net
 
 PWD        := $(shell pwd)
 SHELL      := bash
+JOBS       := $(shell nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 1)
 
 INSTALL    := $(shell ginstall --help >/dev/null 2>&1 && echo g)install
 LIBTOOL    := $(shell glibtool --help >/dev/null 2>&1 && echo g)libtool


### PR DESCRIPTION
Mostly a convenience for new users, I think this is a sensible default for modern hardware.

Any thoughts?
