### PR TITLE
Add Qt5 convenience target

### DIFF
--- a/index.html
+++ b/index.html
@@ -1999,6 +1999,11 @@ aptitude -t squeeze-backports install cmake yasm</pre>
         <td id="qt-website"><a href="http://qt-project.org/">Qt</a></td>
     </tr>
     <tr>
+        <td id="qt5-package">qt5</td>
+        <td id="qt5-version">5.1.0-rc1</td>
+        <td id="qt5-website"><a href="http://qt-project.org/">Qt5</a></td>
+    </tr>
+    <tr>
         <td id="qtactiveqt-package">qtactiveqt</td>
         <td id="qtactiveqt-version">5.1.0-rc1</td>
         <td id="qtactiveqt-website"><a href="http://qt-project.org/">Qt</a></td>

--- a/src/qt5.mk
+++ b/src/qt5.mk
@@ -1,0 +1,17 @@
+# This file is part of MXE.
+# See index.html for further information.
+
+PKG             := qt5
+$(PKG)_IGNORE    = $(qtbase_IGNORE)
+$(PKG)_CHECKSUM  = $(qtbase_CHECKSUM)
+$(PKG)_SUBDIR    = $(qtbase_SUBDIR)
+$(PKG)_FILE      = $(qtbase_FILE)
+$(PKG)_URL       = $(qtbase_URL)
+$(PKG)_DEPS     := $(patsubst $(TOP_DIR)/src/%.mk,%,\
+                        $(shell grep -l 'DEPS.*qtbase' \
+                                $(TOP_DIR)/src/qt*.mk \
+                                --exclude '$(TOP_DIR)/src/qt5.mk'))
+
+define $(PKG)_UPDATE
+    echo $(qtbase_VERSION)
+endef


### PR DESCRIPTION
A convenience wrapper for `make qt5`.

The `--exclude` for the grep command isn't necessary unless it's all on one line, but I've left it in anyway.
