### PR TITLE
texinfo is needed to build gnutls on Debian

### DIFF
--- a/index.html
+++ b/index.html
@@ -695,7 +695,7 @@ USE_OSGPLUGIN(&lt;plugin2&gt;)
                     cmake flex gettext git g++ intltool \
                     libffi-dev libtool libltdl-dev openssl libssl-dev \
                     libxml-parser-perl make patch perl \
-                    pkg-config scons sed unzip wget \
+                    pkg-config scons sed texinfo unzip wget \
                     xz-utils yasm</pre>
 
     <p>


### PR DESCRIPTION
See: 4a3b2f5fd2bab3433e3d0b129f248f131860b513 comment
