### PR TITLE
Patch OpenSSL POD docs for perl-5.16+

### DIFF
--- a/src/openssl-2-pod.patch
+++ b/src/openssl-2-pod.patch
@@ -1,0 +1,580 @@
+This file is part of MXE.
+See index.html for further information.
+
+diff -uNPr a/doc/apps/cms.pod b/doc/apps/cms.pod
+--- a/doc/apps/cms.pod	2013-02-11 15:26:04.000000000 +0000
++++ b/doc/apps/cms.pod	2013-06-01 22:08:31.005787054 +0100
+@@ -450,28 +450,28 @@
+ 
+ =over 4
+ 
+-=item 0
++=item * 0
+ 
+ the operation was completely successfully.
+ 
+-=item 1 
++=item * 1 
+ 
+ an error occurred parsing the command options.
+ 
+-=item 2
++=item * 2
+ 
+ one of the input files could not be read.
+ 
+-=item 3
++=item * 3
+ 
+ an error occurred creating the CMS file or when reading the MIME
+ message.
+ 
+-=item 4
++=item * 4
+ 
+ an error occurred decrypting or verifying the message.
+ 
+-=item 5
++=item * 5
+ 
+ the message was verified correctly but an error occurred writing out
+ the signers certificates.
+diff -uNPr a/doc/apps/smime.pod b/doc/apps/smime.pod
+--- a/doc/apps/smime.pod	2013-02-11 15:26:04.000000000 +0000
++++ b/doc/apps/smime.pod	2013-06-01 22:09:26.732719037 +0100
+@@ -308,28 +308,28 @@
+ 
+ =over 4
+ 
+-=item 0
++=item * 0
+ 
+ the operation was completely successfully.
+ 
+-=item 1 
++=item * 1 
+ 
+ an error occurred parsing the command options.
+ 
+-=item 2
++=item * 2
+ 
+ one of the input files could not be read.
+ 
+-=item 3
++=item * 3
+ 
+ an error occurred creating the PKCS#7 file or when reading the MIME
+ message.
+ 
+-=item 4
++=item * 4
+ 
+ an error occurred decrypting or verifying the message.
+ 
+-=item 5
++=item * 5
+ 
+ the message was verified correctly but an error occurred writing out
+ the signers certificates.
+diff -uNPr a/doc/crypto/rand.pod b/doc/crypto/rand.pod
+--- a/doc/crypto/rand.pod	2013-02-11 15:02:48.000000000 +0000
++++ b/doc/crypto/rand.pod	2013-06-01 22:15:07.474188667 +0100
+@@ -74,17 +74,14 @@
+ 
+ =over 4
+ 
+-=item 1
+-
++=item * 1
+ A good hashing algorithm to mix things up and to convert the RNG 'state'
+ to random numbers.
+ 
+-=item 2
+-
++=item * 2
+ An initial source of random 'state'.
+ 
+-=item 3
+-
++=item * 3
+ The state should be very large.  If the RNG is being used to generate
+ 4096 bit RSA keys, 2 2048 bit random strings are required (at a minimum).
+ If your RNG state only has 128 bits, you are obviously limiting the
+@@ -93,14 +90,12 @@
+ a bad idea to keep quite a lot of RNG state.  It should be easier to
+ break a cipher than guess the RNG seed data.
+ 
+-=item 4
+-
++=item * 4
+ Any RNG seed data should influence all subsequent random numbers
+ generated.  This implies that any random seed data entered will have
+ an influence on all subsequent random numbers generated.
+ 
+-=item 5
+-
++=item * 5
+ When using data to seed the RNG state, the data used should not be
+ extractable from the RNG state.  I believe this should be a
+ requirement because one possible source of 'secret' semi random
+@@ -108,13 +103,11 @@
+ not be disclosed by either subsequent random numbers or a
+ 'core' dump left by a program crash.
+ 
+-=item 6
+-
++=item * 6
+ Given the same initial 'state', 2 systems should deviate in their RNG state
+ (and hence the random numbers generated) over time if at all possible.
+ 
+-=item 7
+-
++=item * 7
+ Given the random number output stream, it should not be possible to determine
+ the RNG state or the next random number.
+ 
+diff -uNPr a/doc/crypto/X509_STORE_CTX_get_error.pod b/doc/crypto/X509_STORE_CTX_get_error.pod
+--- a/doc/crypto/X509_STORE_CTX_get_error.pod	2013-02-11 15:26:04.000000000 +0000
++++ b/doc/crypto/X509_STORE_CTX_get_error.pod	2013-06-01 22:11:00.014931266 +0100
+@@ -278,6 +278,8 @@
+ an application specific error. This will never be returned unless explicitly
+ set by an application.
+ 
++=back
++
+ =head1 NOTES
+ 
+ The above functions should be used instead of directly referencing the fields
+diff -uNPr a/doc/ssl/SSL_accept.pod b/doc/ssl/SSL_accept.pod
+--- a/doc/ssl/SSL_accept.pod	2013-02-11 15:02:48.000000000 +0000
++++ b/doc/ssl/SSL_accept.pod	2013-06-01 22:21:46.302545052 +0100
+@@ -44,18 +44,16 @@
+ 
+ =over 4
+ 
+-=item 1
+-
++=item * 1
+ The TLS/SSL handshake was successfully completed, a TLS/SSL connection has been
+ established.
+ 
+-=item 0
+-
++=item * 0
+ The TLS/SSL handshake was not successful but was shut down controlled and
+ by the specifications of the TLS/SSL protocol. Call SSL_get_error() with the
+ return value B<ret> to find out the reason.
+ 
+-=item E<lt>0
++=item * E<lt>0
+ 
+ The TLS/SSL handshake was not successful because a fatal error occurred either
+ at the protocol level or a connection failure occurred. The shutdown was
+diff -uNPr a/doc/ssl/SSL_clear.pod b/doc/ssl/SSL_clear.pod
+--- a/doc/ssl/SSL_clear.pod	2013-02-11 15:02:48.000000000 +0000
++++ b/doc/ssl/SSL_clear.pod	2013-06-01 22:15:07.474188667 +0100
+@@ -56,13 +56,11 @@
+ 
+ =over 4
+ 
+-=item 0
+-
++=item * 0
+ The SSL_clear() operation could not be performed. Check the error stack to
+ find out the reason.
+ 
+-=item 1
+-
++=item * 1
+ The SSL_clear() operation was successful.
+ 
+ =back
+diff -uNPr a/doc/ssl/SSL_COMP_add_compression_method.pod b/doc/ssl/SSL_COMP_add_compression_method.pod
+--- a/doc/ssl/SSL_COMP_add_compression_method.pod	2013-02-11 15:02:48.000000000 +0000
++++ b/doc/ssl/SSL_COMP_add_compression_method.pod	2013-06-01 22:12:10.753575547 +0100
+@@ -53,11 +53,11 @@
+ 
+ =over 4
+ 
+-=item 0
++=item * 0
+ 
+ The operation succeeded.
+ 
+-=item 1
++=item * 1
+ 
+ The operation failed. Check the error queue to find out the reason.
+ 
+diff -uNPr a/doc/ssl/SSL_connect.pod b/doc/ssl/SSL_connect.pod
+--- a/doc/ssl/SSL_connect.pod	2013-02-11 15:02:48.000000000 +0000
++++ b/doc/ssl/SSL_connect.pod	2013-06-01 22:22:44.109437174 +0100
+@@ -41,18 +41,16 @@
+ 
+ =over 4
+ 
+-=item 1
+-
++=item * 1
+ The TLS/SSL handshake was successfully completed, a TLS/SSL connection has been
+ established.
+ 
+-=item 0
+-
++=item * 0
+ The TLS/SSL handshake was not successful but was shut down controlled and
+ by the specifications of the TLS/SSL protocol. Call SSL_get_error() with the
+ return value B<ret> to find out the reason.
+ 
+-=item E<lt>0
++=item * E<lt>0
+ 
+ The TLS/SSL handshake was not successful, because a fatal error occurred either
+ at the protocol level or a connection failure occurred. The shutdown was
+diff -uNPr a/doc/ssl/SSL_CTX_add_session.pod b/doc/ssl/SSL_CTX_add_session.pod
+--- a/doc/ssl/SSL_CTX_add_session.pod	2013-02-11 15:02:48.000000000 +0000
++++ b/doc/ssl/SSL_CTX_add_session.pod	2013-06-01 22:13:06.396509142 +0100
+@@ -52,15 +52,15 @@
+ 
+ =over 4
+ 
+-=item 0
++=item * 0
+ 
+- The operation failed. In case of the add operation, it was tried to add
+- the same (identical) session twice. In case of the remove operation, the
+- session was not found in the cache.
++The operation failed. In case of the add operation, it was tried to add
++the same (identical) session twice. In case of the remove operation, the
++session was not found in the cache.
+ 
+-=item 1
++=item * 1
+  
+- The operation succeeded.
++The operation succeeded.
+ 
+ =back
+ 
+diff -uNPr a/doc/ssl/SSL_CTX_load_verify_locations.pod b/doc/ssl/SSL_CTX_load_verify_locations.pod
+--- a/doc/ssl/SSL_CTX_load_verify_locations.pod	2013-02-11 15:02:48.000000000 +0000
++++ b/doc/ssl/SSL_CTX_load_verify_locations.pod	2013-06-01 22:13:55.759563092 +0100
+@@ -100,13 +100,13 @@
+ 
+ =over 4
+ 
+-=item 0
++=item * 0
+ 
+ The operation failed because B<CAfile> and B<CApath> are NULL or the
+ processing at one of the locations specified failed. Check the error
+ stack to find out the reason.
+ 
+-=item 1
++=item * 1
+ 
+ The operation succeeded.
+ 
+diff -uNPr a/doc/ssl/SSL_CTX_set_client_CA_list.pod b/doc/ssl/SSL_CTX_set_client_CA_list.pod
+--- a/doc/ssl/SSL_CTX_set_client_CA_list.pod	2013-02-11 15:02:48.000000000 +0000
++++ b/doc/ssl/SSL_CTX_set_client_CA_list.pod	2013-06-01 22:15:07.470188744 +0100
+@@ -66,12 +66,10 @@
+ 
+ =over 4
+ 
+-=item 1
+-
++=item * 1
+ The operation succeeded.
+ 
+-=item 0
+-
++=item * 0
+ A failure while manipulating the STACK_OF(X509_NAME) object occurred or
+ the X509_NAME could not be extracted from B<cacert>. Check the error stack
+ to find out the reason.
+diff -uNPr a/doc/ssl/SSL_CTX_set_session_id_context.pod b/doc/ssl/SSL_CTX_set_session_id_context.pod
+--- a/doc/ssl/SSL_CTX_set_session_id_context.pod	2013-02-11 15:02:48.000000000 +0000
++++ b/doc/ssl/SSL_CTX_set_session_id_context.pod	2013-06-01 22:15:07.470188744 +0100
+@@ -64,14 +64,12 @@
+ 
+ =over 4
+ 
+-=item 0
+-
++=item * 0
+ The length B<sid_ctx_len> of the session id context B<sid_ctx> exceeded
+ the maximum allowed length of B<SSL_MAX_SSL_SESSION_ID_LENGTH>. The error
+ is logged to the error stack.
+ 
+-=item 1
+-
++=item * 1
+ The operation succeeded.
+ 
+ =back
+diff -uNPr a/doc/ssl/SSL_CTX_set_ssl_version.pod b/doc/ssl/SSL_CTX_set_ssl_version.pod
+--- a/doc/ssl/SSL_CTX_set_ssl_version.pod	2013-02-11 15:26:04.000000000 +0000
++++ b/doc/ssl/SSL_CTX_set_ssl_version.pod	2013-06-01 22:15:07.470188744 +0100
+@@ -42,12 +42,10 @@
+ 
+ =over 4
+ 
+-=item 0
+-
++=item * 0
+ The new choice failed, check the error stack to find out the reason.
+ 
+-=item 1
+-
++=item * 1
+ The operation succeeded.
+ 
+ =back
+diff -uNPr a/doc/ssl/SSL_CTX_use_psk_identity_hint.pod b/doc/ssl/SSL_CTX_use_psk_identity_hint.pod
+--- a/doc/ssl/SSL_CTX_use_psk_identity_hint.pod	2013-02-11 15:26:04.000000000 +0000
++++ b/doc/ssl/SSL_CTX_use_psk_identity_hint.pod	2013-06-01 22:16:32.156565713 +0100
+@@ -81,7 +81,9 @@
+ 
+ Return values from the server callback are interpreted as follows:
+ 
+-=item > 0
++=over 4
++
++=item * > 0
+ 
+ PSK identity was found and the server callback has provided the PSK
+ successfully in parameter B<psk>. Return value is the length of
+@@ -94,9 +96,11 @@
+ connection will fail with decryption_error before it will be finished
+ completely.
+ 
+-=item 0
++=item * 0
+ 
+ PSK identity was not found. An "unknown_psk_identity" alert message
+ will be sent and the connection setup fails.
+ 
++=back
++
+ =cut
+diff -uNPr a/doc/ssl/SSL_do_handshake.pod b/doc/ssl/SSL_do_handshake.pod
+--- a/doc/ssl/SSL_do_handshake.pod	2013-02-11 15:02:48.000000000 +0000
++++ b/doc/ssl/SSL_do_handshake.pod	2013-06-01 22:23:52.496126530 +0100
+@@ -45,18 +45,16 @@
+ 
+ =over 4
+ 
+-=item 1
+-
++=item * 1
+ The TLS/SSL handshake was successfully completed, a TLS/SSL connection has been
+ established.
+ 
+-=item 0
+-
++=item * 0
+ The TLS/SSL handshake was not successful but was shut down controlled and
+ by the specifications of the TLS/SSL protocol. Call SSL_get_error() with the
+ return value B<ret> to find out the reason.
+ 
+-=item E<lt>0
++=item * E<lt>0
+ 
+ The TLS/SSL handshake was not successful because a fatal error occurred either
+ at the protocol level or a connection failure occurred. The shutdown was
+diff -uNPr a/doc/ssl/SSL_get_ex_data_X509_STORE_CTX_idx.pod b/doc/ssl/SSL_get_ex_data_X509_STORE_CTX_idx.pod
+--- a/doc/ssl/SSL_get_ex_data_X509_STORE_CTX_idx.pod	2013-02-11 15:02:48.000000000 +0000
++++ b/doc/ssl/SSL_get_ex_data_X509_STORE_CTX_idx.pod	2013-06-01 22:23:52.496126530 +0100
+@@ -36,11 +36,11 @@
+ 
+ =over 4
+ 
+-=item E<gt>=0
++=item * E<gt>=0
+ 
+ The index value to access the pointer.
+ 
+-=item E<lt>0
++=item * E<lt>0
+ 
+ An error occurred, check the error stack for a detailed error message.
+ 
+diff -uNPr a/doc/ssl/SSL_get_fd.pod b/doc/ssl/SSL_get_fd.pod
+--- a/doc/ssl/SSL_get_fd.pod	2013-02-11 15:02:48.000000000 +0000
++++ b/doc/ssl/SSL_get_fd.pod	2013-06-01 22:26:15.961376995 +0100
+@@ -26,12 +26,12 @@
+ 
+ =over 4
+ 
+-=item -1
++=item * -1
+ 
+ The operation failed, because the underlying BIO is not of the correct type
+ (suitable for file descriptors).
+ 
+-=item E<gt>=0
++=item * E<gt>=0
+ 
+ The file descriptor linked to B<ssl>.
+ 
+diff -uNPr a/doc/ssl/SSL_read.pod b/doc/ssl/SSL_read.pod
+--- a/doc/ssl/SSL_read.pod	2013-02-11 15:02:48.000000000 +0000
++++ b/doc/ssl/SSL_read.pod	2013-06-01 22:23:52.496126530 +0100
+@@ -81,13 +81,12 @@
+ 
+ =over 4
+ 
+-=item E<gt>0
++=item * E<gt>0
+ 
+ The read operation was successful; the return value is the number of
+ bytes actually read from the TLS/SSL connection.
+ 
+-=item 0
+-
++=item * 0
+ The read operation was not successful. The reason may either be a clean
+ shutdown due to a "close notify" alert sent by the peer (in which case
+ the SSL_RECEIVED_SHUTDOWN flag in the ssl shutdown state is set
+@@ -103,7 +102,7 @@
+ be checked, whether the closure was initiated by the peer or by something
+ else.
+ 
+-=item E<lt>0
++=item * E<lt>0
+ 
+ The read operation was not successful, because either an error occurred
+ or action must be taken by the calling process. Call SSL_get_error() with the
+diff -uNPr a/doc/ssl/SSL_session_reused.pod b/doc/ssl/SSL_session_reused.pod
+--- a/doc/ssl/SSL_session_reused.pod	2013-02-11 15:02:48.000000000 +0000
++++ b/doc/ssl/SSL_session_reused.pod	2013-06-01 22:15:07.474188667 +0100
+@@ -27,12 +27,10 @@
+ 
+ =over 4
+ 
+-=item 0
+-
++=item * 0
+ A new session was negotiated.
+ 
+-=item 1
+-
++=item * 1
+ A session was reused.
+ 
+ =back
+diff -uNPr a/doc/ssl/SSL_set_fd.pod b/doc/ssl/SSL_set_fd.pod
+--- a/doc/ssl/SSL_set_fd.pod	2013-02-11 15:02:48.000000000 +0000
++++ b/doc/ssl/SSL_set_fd.pod	2013-06-01 22:15:07.470188744 +0100
+@@ -35,12 +35,10 @@
+ 
+ =over 4
+ 
+-=item 0
+-
++=item * 0
+ The operation failed. Check the error stack to find out why.
+ 
+-=item 1
+-
++=item * 1
+ The operation succeeded.
+ 
+ =back
+diff -uNPr a/doc/ssl/SSL_set_session.pod b/doc/ssl/SSL_set_session.pod
+--- a/doc/ssl/SSL_set_session.pod	2013-02-11 15:02:48.000000000 +0000
++++ b/doc/ssl/SSL_set_session.pod	2013-06-01 22:15:07.470188744 +0100
+@@ -37,12 +37,10 @@
+ 
+ =over 4
+ 
+-=item 0
+-
++=item * 0
+ The operation failed; check the error stack to find out the reason.
+ 
+-=item 1
+-
++=item * 1
+ The operation succeeded.
+ 
+ =back
+diff -uNPr a/doc/ssl/SSL_set_shutdown.pod b/doc/ssl/SSL_set_shutdown.pod
+--- a/doc/ssl/SSL_set_shutdown.pod	2013-02-11 15:02:48.000000000 +0000
++++ b/doc/ssl/SSL_set_shutdown.pod	2013-06-01 22:29:14.361957917 +0100
+@@ -24,16 +24,16 @@
+ 
+ =over 4
+ 
+-=item 0
++=item * 0
+ 
+ No shutdown setting, yet.
+ 
+-=item SSL_SENT_SHUTDOWN
++=item * SSL_SENT_SHUTDOWN
+ 
+ A "close notify" shutdown alert was sent to the peer, the connection is being
+ considered closed and the session is closed and correct.
+ 
+-=item SSL_RECEIVED_SHUTDOWN
++=item * SSL_RECEIVED_SHUTDOWN
+ 
+ A shutdown alert was received form the peer, either a normal "close notify"
+ or a fatal error.
+diff -uNPr a/doc/ssl/SSL_shutdown.pod b/doc/ssl/SSL_shutdown.pod
+--- a/doc/ssl/SSL_shutdown.pod	2013-02-11 15:02:48.000000000 +0000
++++ b/doc/ssl/SSL_shutdown.pod	2013-06-02 01:49:05.023205397 +0100
+@@ -92,19 +92,17 @@
+ 
+ =over 4
+ 
+-=item 1
+-
++=item * 1
+ The shutdown was successfully completed. The "close notify" alert was sent
+ and the peer's "close notify" alert was received.
+ 
+-=item 0
+-
++=item * 0
+ The shutdown is not yet finished. Call SSL_shutdown() for a second time,
+ if a bidirectional shutdown shall be performed.
+ The output of L<SSL_get_error(3)|SSL_get_error(3)> may be misleading, as an
+ erroneous SSL_ERROR_SYSCALL may be flagged even though no error occurred.
+ 
+-=item -1
++=item * -1
+ 
+ The shutdown was not successful because a fatal error occurred either
+ at the protocol level or a connection failure occurred. It can also occur if
+diff -uNPr a/doc/ssl/SSL_write.pod b/doc/ssl/SSL_write.pod
+--- a/doc/ssl/SSL_write.pod	2013-02-11 15:02:48.000000000 +0000
++++ b/doc/ssl/SSL_write.pod	2013-06-01 22:23:52.496126530 +0100
+@@ -74,13 +74,12 @@
+ 
+ =over 4
+ 
+-=item E<gt>0
++=item * E<gt>0
+ 
+ The write operation was successful, the return value is the number of
+ bytes actually written to the TLS/SSL connection.
+ 
+-=item 0
+-
++=item * 0
+ The write operation was not successful. Probably the underlying connection
+ was closed. Call SSL_get_error() with the return value B<ret> to find out,
+ whether an error occurred or the connection was shut down cleanly
+@@ -90,7 +89,7 @@
+ only be detected, whether the underlying connection was closed. It cannot
+ be checked, why the closure happened.
+ 
+-=item E<lt>0
++=item * E<lt>0
+ 
+ The write operation was not successful, because either an error occurred
+ or action must be taken by the calling process. Call SSL_get_error() with the


### PR DESCRIPTION
Patch for #198 - stricter validation in recent Perl versions means the install stage fails without these applied.

Should be harmless for earlier versions of perl.
