### PR TITLE
explicitly disable mysql driver in Qt

### DIFF
--- a/src/qt.mk
+++ b/src/qt.mk
@@ -53,6 +53,7 @@ define $(PKG)_BUILD
         -qt-sql-sqlite \
         -qt-sql-odbc \
         -qt-sql-psql \
+        -no-sql-mysql \
         -qt-sql-tds -D Q_USE_SYBASE \
         -system-zlib \
         -system-libpng \


### PR DESCRIPTION
When I tried to build Qt on my Arch Linux box, the build always failed, complaining it couldn't find `mysql.h`.
I suppose since mysql is not part of mxe, disabling the mysql driver in Qt shouldn't change much ... I assume the driver should be skipped automatically in that case, but for me it always failed to build completely.
