### PR TITLE
packages qt qtbase: install pkgconfig files in standard location

### DIFF
--- a/src/qt.mk
+++ b/src/qt.mk
@@ -84,4 +84,16 @@ define $(PKG)_BUILD
     cd               '$(1)/test-qt' && '$(PREFIX)/$(TARGET)/qt/bin/qmake' '$(PWD)/$(2).pro'
     $(MAKE)       -C '$(1)/test-qt' -j '$(JOBS)'
     $(INSTALL) -m755 '$(1)/test-qt/release/test-qt.exe' '$(PREFIX)/$(TARGET)/bin/'
+
+    # copy pkg-config files to standard directory
+    cp '$(PREFIX)/$(TARGET)'/qt/lib/pkgconfig/* '$(PREFIX)/$(TARGET)'/lib/pkgconfig/
+
+    # build test the manual way
+    mkdir '$(1)/test-$(PKG)-pkgconfig'
+    '$(PREFIX)/$(TARGET)/qt/bin/uic' -o '$(1)/test-$(PKG)-pkgconfig/ui_qt-test.h' '$(TOP_DIR)/src/qt-test.ui'
+    '$(TARGET)-g++' \
+        -W -Wall -Werror -std=c++0x -pedantic \
+        '$(TOP_DIR)/src/qt-test.cpp' -o '$(PREFIX)/$(TARGET)/bin/test-$(PKG)-pkgconfig.exe' \
+        -I'$(1)/test-$(PKG)-pkgconfig' \
+        `'$(TARGET)-pkg-config' QtGui --cflags --libs`
 endef


### PR DESCRIPTION
Following up from;
https://github.com/mxe/mxe/issues/84
https://github.com/mxe/mxe/issues/181
http://lists.nongnu.org/archive/html/mingw-cross-env-list/2013-07/msg00024.html

Qt5 now has prefixed *.pc files, so installing them side-by-side with Qt4 in the standard pkgconfig directory shouldn't be an issue. The alternative is to simply document:

``` sh
export PKG_CONFIG_PATH_i686_pc_mingw32='$(PREFIX)/$(TARGET)/qt/lib/pkgconfig':$PKG_CONFIG_PATH_i686_pc_mingw32
# note the _underscores_ instead of -dashes- in the triplet
```

There's also a workaround for Qt5 [creating *.pc files with debug libs](https://bugreports.qt-project.org/browse/QTBUG-30898), but I'm not sure how correct this is.
