### PR TITLE
disable stl for wxWidgets as it seems to be very problematic:

### DIFF
--- a/src/wxwidgets.mk
+++ b/src/wxwidgets.mk
@@ -27,7 +27,7 @@ define $(PKG)_CONFIGURE_OPTS
         --disable-shared \
         --prefix='$(PREFIX)/$(TARGET)' \
         --enable-gui \
-        --enable-stl \
+        --disable-stl \
         --enable-threads \
         --disable-universal \
         --with-themes=all \


### PR DESCRIPTION
http://www.wxwidgets.org/docs/faqgen.htm#stl

i tapped into a bad compile error because of this. not sure why it is enabled, i don't see a reason for it (atm).
