### PR TITLE
new package libusb1

### DIFF
--- a/index.html
+++ b/index.html
@@ -1633,6 +1633,10 @@ local-pkg-list: $(LOCAL_PKG_LIST)</pre>
         <td class="website"><a href="http://libusb-win32.sourceforge.net/">LibUsb</a></td>
     </tr>
     <tr>
+        <td class="package">libusb1</td>
+        <td class="website"><a href="http://libusb.org/">LibUsb-1.0</a></td>
+    </tr>
+    <tr>
         <td class="package">libvpx</td>
         <td class="website"><a href="http://code.google.com/p/webm/">vpx</a></td>
     </tr>

--- a/src/libusb1.mk
+++ b/src/libusb1.mk
@@ -1,0 +1,27 @@
+# This file is part of MXE.
+# See index.html for further information.
+
+PKG             := libusb1
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 1.0.16
+$(PKG)_CHECKSUM := ec164f02e6732c373e5a24be6b33a59142435615
+$(PKG)_SUBDIR   := libusbx-$($(PKG)_VERSION)
+$(PKG)_FILE     := libusbx-$($(PKG)_VERSION).tar.bz2
+$(PKG)_URL      := http://$(SOURCEFORGE_MIRROR)/project/libusbx/releases/$($(PKG)_VERSION)/source/$($(PKG)_FILE)
+$(PKG)_DEPS     := gcc
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- 'http://sourceforge.net/projects/libusbx/files/releases/' | \
+    $(SED) -n 's,.*/\([0-9][^"]*\)/".*,\1,p' | \
+    head -1
+endef
+
+define $(PKG)_BUILD
+    cd '$(1)' && ./configure \
+        --host='$(TARGET)' \
+        --build="`config.guess`" \
+        --disable-shared \
+        --enable-static \
+        --prefix='$(PREFIX)/$(TARGET)'
+    $(MAKE) -C '$(1)' -j '$(JOBS)' install
+endef


### PR DESCRIPTION
This is a package for the libusb-1.0 shared library (MXE package name
"libusb1") used by various projects. It is not to be confused with the
older libusb-0.1 library (MXE package name "libusb") which is a
completely different library with different API. Both libs are in
wide-spread use and can be installed in parallel.
