### PR TITLE
Makefile : add http_proxy in white list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,8 @@ BUILD_PKGS := $(shell grep -l 'BUILD_$$(BUILD)' '$(TOP_DIR)/src/'*.mk | $(SED) -
 PATH       := $(PREFIX)/$(BUILD)/bin:$(PREFIX)/bin:$(PATH)
 
 # use a minimal whitelist of safe environment variables
-ENV_WHITELIST := PATH LANG MAKE% MXE%
+# http_proxy for wget
+ENV_WHITELIST := PATH LANG MAKE% MXE% http_proxy
 unexport $(filter-out $(ENV_WHITELIST),$(shell env | $(SED) -n 's,\(.*\)=.*,\1,p'))
 
 SHORT_PKG_VERSION = \
@@ -202,7 +203,7 @@ $(PREFIX)/$(3)/installed/$(1): $(TOP_DIR)/src/$(1).mk \
 	    ln -sf '$(TIMESTAMP)/$(1)-download' '$(LOG_DIR)/$(1)-download'; \
 	    if ! $(call CHECK_PKG_ARCHIVE,$(1)); then \
 	        echo; \
-	        echo 'Wrong checksum of package $(1)!'; \
+	        echo 'Wrong checksum of package $(1) or package not found!'; \
 	        echo '------------------------------------------------------------'; \
 	        tail -n 10 '$(LOG_DIR)/$(1)-download' | $(SED) -n '/./p'; \
 	        echo '------------------------------------------------------------'; \


### PR DESCRIPTION
Hello,
two things here :

1) 
With the new whitelist trick, I could not download packages anymore through proxy, because wget needs to access the environment variable http_proxy. Two solutions : 
- instead of setting http_proxy in ~/.bashrc, set it in ~/.wgetrc (but it sucks because http_proxy was supposed to be used, and it is also used by other tools).
- use the following patch

It is more a proposal than a "request", you are the expert!

2) 
add "or package not found" after package checksum check. I got mislead several times with this, thinking I could not download the package because of some checksum problem, while actually it was more a download problem.
