### PR TITLE
package vtk6: fix configure of native build for missing X11/OSMesa libraries

### DIFF
--- a/src/vtk6-3-optional-osmesa.patch
+++ b/src/vtk6-3-optional-osmesa.patch
@@ -1,0 +1,14 @@
+# This file is part of MXE.
+# See index.html for further information.
+
+--- VTK6.0.0/Rendering/OpenGL/CMakeLists.txt	2013-06-12 21:47:10.000000000 +0200
++++ VTK6.0.0/Rendering/OpenGL/CMakeLists.txt	2013-08-27 13:15:06.770690266 +0200
+@@ -29,7 +29,7 @@
+ if(VTK_USE_X OR VTK_USE_CARBON OR VTK_USE_COCOA OR WIN32)
+   set(VTK_USE_OSMESA FALSE)
+ else()
+-  set(VTK_USE_OSMESA TRUE)
++  option(VTK_USE_OSMESA "Use OSMesa for VTK render windows" ON)
+ endif()
+ 
+ # FIXME: The TDx support needs some refactoring before we can build it in a

--- a/src/vtk6.mk
+++ b/src/vtk6.mk
@@ -26,6 +26,10 @@ define $(PKG)_BUILD
     cd '$(1).native_build' && cmake \
         -DBUILD_TESTING=FALSE \
         -DVTK_USE_RENDERING=FALSE \
+        -DVTK_USE_X=FALSE \
+        -DVTK_Group_Rendering=FALSE \
+        -DCMAKE_BUILD_TYPE="Release" \
+        -DVTK_USE_OSMESA=FALSE \
         '$(1)'
     $(MAKE) -C '$(1).native_build' -j '$(JOBS)' VERBOSE=1 vtkCompileTools
 


### PR DESCRIPTION
Fix for #232
