### PR TITLE
package dbus: Do not build documentation

### DIFF
--- a/src/dbus.mk
+++ b/src/dbus.mk
@@ -31,6 +31,8 @@ define $(PKG)_BUILD
         --enable-static \
         --disable-silent-rules \
         --disable-launchd \
+        --disable-doxygen-docs \
+        --disable-xml--docs \
         CFLAGS='-DPROCESS_QUERY_LIMITED_INFORMATION=0x1000'
     $(MAKE) -C '$(1)' -j '$(JOBS)' install
 endef


### PR DESCRIPTION
In Debian Wheezy compiling fails due to some xml processing problem in
the docs. Since documentation is not required I think disabling it
is the simplest solution.
