### PR TITLE
cblas: fix gcc and ar binaries

### DIFF
--- a/src/cblas.mk
+++ b/src/cblas.mk
@@ -19,6 +19,8 @@ define $(PKG)_BUILD
     cp '$(1)/Makefile.LINUX' '$(1)/Makefile.MINGW32'
     $(SED) -i 's,CBDIR =.*,CBDIR = $(1),g'         '$(1)/Makefile.MINGW32'
     $(SED) -i 's,FC =.*,FC = $(TARGET)-gfortran,g' '$(1)/Makefile.MINGW32'
+    $(SED) -i 's,CC =.*,CC = $(TARGET)-gcc,g' '$(1)/Makefile.MINGW32'
+    $(SED) -i 's,ARCH =.*,ARCH = $(TARGET)-ar,g' '$(1)/Makefile.MINGW32'
     $(SED) -i 's, make , $(MAKE) ,g'               '$(1)/Makefile'
     rm '$(1)/Makefile.in'
     ln -sf '$(1)/Makefile.MINGW32' '$(1)/Makefile.in'


### PR DESCRIPTION
cblas contains the C bindings for the BLAS functions. It requires a C compiler, which was not correctly set before. The AR binary has also to be set properly.

And thank you for maintaining this cross-compilation toolchain and environment ! 
