### PR TITLE
x264: Avoid circular dependency with ffmpeg

### DIFF
--- a/src/x264.mk
+++ b/src/x264.mk
@@ -22,7 +22,9 @@ define $(PKG)_BUILD
         --prefix='$(PREFIX)/$(TARGET)' \
         --disable-shared \
         --enable-static \
-        --enable-win32thread
+        --enable-win32thread \
+        --disable-lavf \    # Avoid circular dependency with ffmpeg. Remove if undesired.
+        --disable-swscale   # Avoid circular dependency with ffmpeg. Remove if undesired.
     $(MAKE) -C '$(1)' -j 1 uninstall
     $(MAKE) -C '$(1)' -j '$(JOBS)'
     $(MAKE) -C '$(1)' -j 1 install


### PR DESCRIPTION
This won't normally be a problem, but when ffmpeg is updated, it uses x264's
library, which has symbol referenced to the old version of ffmpeg.

This is only a work-around. If users need lavf/lsws support, they can manually
remove it from the x264.mk file.

Signed-off-by: Timothy Gu timothygu99@gmail.com
