### PR TITLE
sdl2: disable DirectInput because of missing wbemcli.h

### DIFF
--- a/src/sdl2-1-dinput.patch
+++ b/src/sdl2-1-dinput.patch
@@ -1,0 +1,17 @@
+This file is part of MXE.
+See index.html for further information.
+
+This patch has been taken from:
+https://bugzilla.libsdl.org/show_bug.cgi?id=1739
+
+--- a/configure.in	Sat Sep 14 11:25:52 2013 -0700
++++ b/configure.in	Fri Sep 27 15:03:58 2013 +1000
+@@ -2127,7 +2127,7 @@
+         # FIXME: latest Cygwin finds dinput headers, but we die on other win32 headers.
+         # FIXME:  ...so force it off for now.
+         case "$host" in
+-            *-*-cygwin*)
++            *-*-cygwin* | *-pc-mingw32*)
+             have_dinput=false
+             ;;
+         esac

--- a/src/sdl2.mk
+++ b/src/sdl2.mk
@@ -18,7 +18,7 @@ endef
 
 define $(PKG)_BUILD
     $(SED) -i 's,-mwindows,-lwinmm -mwindows,' '$(1)/configure'
-    cd '$(1)' && ./configure \
+    cd '$(1)' && aclocal -I acinclude && autoconf && ./configure \
         --host='$(TARGET)' \
         --disable-shared \
         --prefix='$(PREFIX)/$(TARGET)' \
@@ -31,5 +31,3 @@ define $(PKG)_BUILD
     $(MAKE) -C '$(1)' -j 1 install bin_PROGRAMS= sbin_PROGRAMS= noinst_PROGRAMS=
     ln -sf '$(PREFIX)/$(TARGET)/bin/sdl2-config' '$(PREFIX)/bin/$(TARGET)-sdl2-config'
 endef
-
-$(PKG)_BUILD_i686-pc-mingw32 =

--- a/src/sdl2_image.mk
+++ b/src/sdl2_image.mk
@@ -31,5 +31,3 @@ define $(PKG)_BUILD
         LIBS='-lz'
     $(MAKE) -C '$(1)' -j '$(JOBS)' install bin_PROGRAMS= sbin_PROGRAMS= noinst_PROGRAMS=
 endef
-
-$(PKG)_BUILD_i686-pc-mingw32 =


### PR DESCRIPTION
MXE/MinGW does not carry wbemcli.h, so SDL_dxjoystick will not build. This just enables the same workaround in configure as is done for Cygwin, which is to disable DirectInput and enable SDL_mmjoystick instead. That's enough to make SDL2 compile and link.

This is a known upstream issue, see https://bugzilla.libsdl.org/show_bug.cgi?id=1739. I've sent this patch there as well.

Also enabled SDL2_image, since that now builds successfully.
