### PR TITLE
various packages: fix inter-project macro dependencies

### DIFF
--- a/src/bfd.mk
+++ b/src/bfd.mk
@@ -1,6 +1,7 @@
 # This file is part of MXE.
 # See index.html for further information.
 
+include $(TOP_DIR)/src/binutils.mk
 PKG             := bfd
 $(PKG)_IGNORE    = $(binutils_IGNORE)
 $(PKG)_VERSION   = $(binutils_VERSION)

--- a/src/binutils.mk
+++ b/src/binutils.mk
@@ -2,6 +2,7 @@
 # See index.html for further information.
 
 PKG             := binutils
+ifndef $(PKG)_FILE
 $(PKG)_IGNORE   :=
 $(PKG)_VERSION  := 2.23.2
 $(PKG)_CHECKSUM := 042c51073205ebaf88c272d6168f9deb71984b56
@@ -39,3 +40,4 @@ define $(PKG)_BUILD
 endef
 
 $(PKG)_BUILD_$(BUILD) :=
+endif

--- a/src/gcc.mk
+++ b/src/gcc.mk
@@ -2,6 +2,7 @@
 # See index.html for further information.
 
 PKG             := gcc
+ifndef $(PKG)_FILE
 $(PKG)_IGNORE   :=
 $(PKG)_VERSION  := 4.8.1
 $(PKG)_CHECKSUM := 4e655032cda30e1928fcc3f00962f4238b502169
@@ -150,3 +151,4 @@ define $(PKG)_BUILD_$(BUILD)
     done
     $($(PKG)_POST_BUILD)
 endef
+endif

--- a/src/libgomp.mk
+++ b/src/libgomp.mk
@@ -1,6 +1,7 @@
 # This file is part of MXE.
 # See index.html for further information.
 
+include $(TOP_DIR)/src/gcc.mk
 PKG             := libgomp
 $(PKG)_IGNORE    = $(gcc_IGNORE)
 $(PKG)_VERSION   = $(gcc_VERSION)

--- a/src/libiberty.mk
+++ b/src/libiberty.mk
@@ -1,6 +1,7 @@
 # This file is part of MXE.
 # See index.html for further information.
 
+include $(TOP_DIR)/src/binutils.mk
 PKG             := libiberty
 $(PKG)_IGNORE    = $(binutils_IGNORE)
 $(PKG)_VERSION   = $(binutils_VERSION)

--- a/src/libltdl.mk
+++ b/src/libltdl.mk
@@ -1,6 +1,7 @@
 # This file is part of MXE.
 # See index.html for further information.
 
+include $(TOP_DIR)/src/libtool.mk
 PKG             := libltdl
 $(PKG)_IGNORE    = $(libtool_IGNORE)
 $(PKG)_VERSION   = $(libtool_VERSION)

--- a/src/libtool.mk
+++ b/src/libtool.mk
@@ -2,6 +2,7 @@
 # See index.html for further information.
 
 PKG             := libtool
+ifndef $(PKG)_FILE
 $(PKG)_IGNORE   :=
 $(PKG)_VERSION  := 2.4.2
 $(PKG)_CHECKSUM := 22b71a8b5ce3ad86e1094e7285981cae10e6ff88
@@ -23,3 +24,4 @@ define $(PKG)_BUILD_$(BUILD)
     $(MAKE) -C '$(1).build' -j '$(JOBS)'
     $(MAKE) -C '$(1).build' -j 1 install
 endef
+endif

--- a/src/ocaml-core.mk
+++ b/src/ocaml-core.mk
@@ -1,6 +1,7 @@
 # This file is part of MXE.
 # See index.html for further information.
 
+include $(TOP_DIR)/src/ocaml-native.mk
 PKG             := ocaml-core
 $(PKG)_IGNORE    = $(ocaml-native_IGNORE)
 $(PKG)_VERSION   = $(ocaml-native_VERSION)

--- a/src/ocaml-native.mk
+++ b/src/ocaml-native.mk
@@ -2,6 +2,7 @@
 # See index.html for further information.
 
 PKG             := ocaml-native
+ifndef $(PKG)_FILE
 $(PKG)_IGNORE   :=
 $(PKG)_VERSION  := 4.00.1
 $(PKG)_CHECKSUM := 5abf04cd4fccfcc980e8592995b9159014f23f53
@@ -46,3 +47,4 @@ define $(PKG)_BUILD
 endef
 
 $(PKG)_BUILD_x86_64-w64-mingw32 =
+endif


### PR DESCRIPTION
Solves this mysterious error on some operations such as "make update":

Makefile:273: **\* Unknown archive format: /home/brand/projects/mxe/mxe/pkg/.  Stop.

This problem affected packages whose macros refer to other package
macros that were not yet defined due to the second package's .mk file
not being included before the first package's .mk file. Now we include
the file with the required macros explicitly on-time. The included .mk
file now has a multiple-inclusion guard.
