### PR TITLE
sdl_gfx: 64-bit support

### DIFF
--- a/src/sdl_gfx.mk
+++ b/src/sdl_gfx.mk
@@ -17,9 +17,14 @@ define $(PKG)_UPDATE
     head -1
 endef
 
+# --disable-mmx: the GCC ASM never worked properly (segfaults), and
+#   doesn't compile on 64bit.  This is fixed for the future SDL2_gfx:
+#   http://sourceforge.net/p/sdl2gfx/code/HEAD/tree/trunk/SDL2_imageFilter.c
+#   No plans for SDL(1)_gfx, but see https://gitorious.org/sdlgfx/asm/
 define $(PKG)_BUILD
     cd '$(1)' && ./configure \
         --host='$(TARGET)' \
+        --disable-mmx \
         --disable-shared \
         --prefix='$(PREFIX)/$(TARGET)' \
         --with-sdl-prefix='$(PREFIX)/$(TARGET)'
@@ -30,5 +35,3 @@ define $(PKG)_BUILD
         '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-sdl_gfx.exe' \
         `'$(TARGET)-pkg-config' SDL_gfx --cflags --libs`
 endef
-
-$(PKG)_BUILD_x86_64-w64-mingw32 =


### PR DESCRIPTION
Hi,

I disabled 'mmx' buggy support in sdl_gfx, so it compiles on 64-bit (and doesn't crash on i386 - see below).
I also removed the 'autoreconf'iguration as everything compiled fine without.

Additional note: SDL_imagefilter.c, which uses MMX is actually rarely used, and was tested VC++. The GCC ASM version crashed due to incorrect use of popa/pusha instructions (the code didn't take the stack pointer change into account). I worked for 2 weeks on a fix using GCC intrinsics at https://gitorious.org/sdlgfx/asm/, fixing i386 and adding 64-bit support. The SDL_gfx maintainer took is for the upcoming SDL2_gfx, although there's no plan for SDL_gfx right now.
