### PR TITLE
Add Travis CI building system

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,36 @@
+language: c
+
+env:
+  - MXE_TARGETS=i686-pc-mingw32
+  - MXE_TARGETS=x86_64-w64-mingw32
+  - MXE_TARGETS=i686-w64-mingw32
+
+compiler:
+  - gcc
+
+#branches:
+#  only:
+#    - master
+#    - stable
+
+before_install:
+  - sudo apt-get update  -qq
+  - sudo apt-get install -qq autoconf automake bash bison bzip2 cmake flex gettext git g++ intltool libffi-dev libtool libltdl-dev libssl-dev libxml-parser-perl make openssl patch perl pkg-config scons sed unzip wget xz-utils g++-multilib libc6-dev-i386
+
+# What to enable is still an Request-For-Comment
+script: make gcc JOBS=4 MXE_TARGETS=$MXE_TARGETS
+
+cache:
+  apt: true
+  directories:
+    - pkg
+
+notifications:
+  email:
+    recipients:
+      - mingw-cross-env-list@nongnu.org
+#   Enable these when Travis CI building is stable enough
+    on_success: never
+    on_failure: never
+#    on_success: change
+#    on_failure: always


### PR DESCRIPTION
Should fix #140. The list of packages to build still requires discussion. However, be aware that Travis CI cannot build all packages at once, or it will end up like [this](https://travis-ci.org/TimothyGu/mxe/jobs/13556477#L386).

There are some comments in the .travis.yml file. They are to be enabled after Travis CI is tested enough that it works. They are disabled right now because it will either spam the mailing list, or it will mess up my own repo.
