### PR TITLE
ocaml-lablgtk2.mk : extra dependency w.r.t. gtksourceview

### DIFF
--- a/src/ocaml-lablgtk2.mk
+++ b/src/ocaml-lablgtk2.mk
@@ -8,7 +8,7 @@ $(PKG)_CHECKSUM := 3dec411a410fbb38d6e2e5a43a4ebfb2e407e7e6
 $(PKG)_SUBDIR   := lablgtk-$($(PKG)_VERSION)
 $(PKG)_FILE     := lablgtk-$($(PKG)_VERSION).tar.gz
 $(PKG)_URL      := https://forge.ocamlcore.org/frs/download.php/979/$($(PKG)_FILE)
-$(PKG)_DEPS     := gcc ocaml-findlib libglade gtkglarea ocaml-lablgl gtk2
+$(PKG)_DEPS     := gcc ocaml-findlib libglade gtkglarea ocaml-lablgl gtk2 gtksourceview
 
 define $(PKG)_UPDATE
     $(WGET) -q -O- 'http://forge.ocamlcore.org/frs/?group_id=220' | \


### PR DESCRIPTION
Hi
Since gtksourceview is already available as an mxe package, we could enable its support in ocaml-lablgtk2.
We just have to declare it as an extra dependency : the ./configure script of lablgtk2 will then do the right autodetection. This will help cross-compiling the coq software (coq.inria.fr).
Thanks!
Pierre Letouzey
