### PR TITLE
enable all targets for llvm

### DIFF
--- a/src/llvm-seh.patch
+++ b/src/llvm-seh.patch
@@ -1,0 +1,28 @@
+This file is part of MXE.
+See index.html for further information.
+
+diff -NBaur llvm-3.3.src/lib/ExecutionEngine/MCJIT/SectionMemoryManager.cpp llvm-3.3.patched/lib/ExecutionEngine/MCJIT/SectionMemoryManager.cpp
+--- llvm-3.3.src/lib/ExecutionEngine/MCJIT/SectionMemoryManager.cpp	2013-05-05 17:43:10.000000000 -0300
++++ llvm-3.3.patched/lib/ExecutionEngine/MCJIT/SectionMemoryManager.cpp	2013-12-29 13:33:00.827119175 -0300
+@@ -148,7 +148,7 @@
+ 
+ // Determine whether we can register EH tables.
+ #if (defined(__GNUC__) && !defined(__ARM_EABI__) && \
+-     !defined(__USING_SJLJ_EXCEPTIONS__))
++     !defined(__SEH__) && !defined(__USING_SJLJ_EXCEPTIONS__))
+ #define HAVE_EHTABLE_SUPPORT 1
+ #else
+ #define HAVE_EHTABLE_SUPPORT 0
+
+diff -NBaur llvm-3.3.src/lib/ExecutionEngine/JIT/JIT.cpp llvm-3.3.patched/lib/ExecutionEngine/JIT/JIT.cpp
+--- llvm-3.3.src/lib/ExecutionEngine/JIT/JIT.cpp	2013-05-05 17:43:10.000000000 -0300
++++ llvm-3.3.patched/lib/ExecutionEngine/JIT/JIT.cpp	2013-12-29 13:33:00.827119175 -0300
+@@ -72,7 +72,7 @@
+ 
+ // Determine whether we can register EH tables.
+ #if (defined(__GNUC__) && !defined(__ARM_EABI__) && \
+-     !defined(__USING_SJLJ_EXCEPTIONS__))
++     !defined(__SEH__) && !defined(__USING_SJLJ_EXCEPTIONS__))
+ #define HAVE_EHTABLE_SUPPORT 1
+ #else
+ #define HAVE_EHTABLE_SUPPORT 0

--- a/src/llvm.mk
+++ b/src/llvm.mk
@@ -22,7 +22,6 @@ define $(PKG)_BUILD
     cd '$(1)/build' && cmake .. \
         -DCMAKE_TOOLCHAIN_FILE='$(CMAKE_TOOLCHAIN_FILE)' \
         -DLIBTYPE=STATIC \
-        -DLLVM_TARGETS_TO_BUILD="X86" \
         -DLLVM_BUILD_TOOLS=OFF
     $(MAKE) -C '$(1)/build' -j $(JOBS) llvm-tblgen
     $(MAKE) -C '$(1)/build' -j $(JOBS) intrinsics_gen


### PR DESCRIPTION
This enables llvm to parse and emit code on all targets it supports. I see no reason to limit it to x86 only. After the patch it builds correctly for all mxe targets.
