### PR TITLE
fix package guile

### DIFF
--- a/src/guile-1-win32.patch
+++ b/src/guile-1-win32.patch
@@ -1,27 +1,6 @@
 This file is part of MXE.
 See index.html for further information.
 
-diff -ruN guile-1.8.7.orig/configure guile-1.8.7/configure
---- guile-1.8.7.orig/configure	2009-07-05 22:25:00.000000000 +0200
-+++ guile-1.8.7/configure	2010-04-10 07:35:25.000000000 +0200
-@@ -35057,6 +35057,7 @@
- $as_echo_n "checking whether pthread_attr_getstack works for the main thread... " >&6; }
- old_CFLAGS="$CFLAGS"
- CFLAGS="$PTHREAD_CFLAGS $CFLAGS"
-+if test "$cross_compiling" = "no"; then
- if test "$cross_compiling" = yes; then
-   { { $as_echo "$as_me:$LINENO: error: in \`$ac_pwd':" >&5
- $as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
-@@ -35140,6 +35141,9 @@
- fi
- 
- 
-+else
-+works=no
-+fi
- CFLAGS="$old_CFLAGS"
- { $as_echo "$as_me:$LINENO: result: $works" >&5
- $as_echo "$works" >&6; }
 diff -ruN guile-1.8.7.orig/guile-readline/configure guile-1.8.7/guile-readline/configure
 --- guile-1.8.7.orig/guile-readline/configure	2009-07-05 22:24:45.000000000 +0200
 +++ guile-1.8.7/guile-readline/configure	2010-04-10 07:36:18.000000000 +0200


### PR DESCRIPTION
The configuration file have changed since last version and it now compiles fine without the patch (but fails with it because patch is outdated).
