### PR TITLE
Qt4, Qt5: create symlinks $(TARGET)-qmake-qtX in $(PREFIX)/bin

### DIFF
--- a/src/qt.mk
+++ b/src/qt.mk
@@ -69,6 +69,7 @@ define $(PKG)_BUILD
     $(MAKE) -C '$(1)' -j '$(JOBS)'
     rm -rf '$(PREFIX)/$(TARGET)/qt'
     $(MAKE) -C '$(1)' -j 1 install
+    ln -sf '$(PREFIX)/$(TARGET)/qt/bin/qmake' '$(PREFIX)/bin/$(TARGET)'-qmake-qt4
 
     cd '$(1)/tools/assistant' && '$(1)/bin/qmake' assistant.pro
     $(MAKE) -C '$(1)/tools/assistant' -j '$(JOBS)' install

--- a/src/qtbase.mk
+++ b/src/qtbase.mk
@@ -56,6 +56,7 @@ define $(PKG)_BUILD
     $(MAKE) -C '$(1)' -j '$(JOBS)' QMAKE="$(1)/bin/qmake CONFIG-='debug debug_and_release'"
     rm -rf '$(PREFIX)/$(TARGET)/qt5'
     $(MAKE) -C '$(1)' -j 1 install
+    ln -sf '$(PREFIX)/$(TARGET)/qt5/bin/qmake' '$(PREFIX)/bin/$(TARGET)'-qmake-qt5
 
     mkdir            '$(1)/test-qt'
     cd               '$(1)/test-qt' && '$(PREFIX)/$(TARGET)/qt5/bin/qmake' '$(PWD)/src/qt-test.pro'


### PR DESCRIPTION
That way a configure script looking for "qmake-qt4" or "qmake-qt5"
with AC_PATH_PROG will find e.g. x86_64-w64-mingw32-qmake-qt5
properly. See
http://thread.gmane.org/gmane.comp.gnu.mingw.cross-env/3424/focus=3426
