### PR TITLE
package portaudio: update to v19_20140130

### DIFF
--- a/src/portaudio-1-win32.patch
+++ b/src/portaudio-1-win32.patch
@@ -14,60 +14,29 @@ diff -aur portaudio/src/hostapi/dsound/pa_win_ds.c portaudio-patched/src/hostapi
                              case DSSPEAKER_7POINT1:          count = 8; break;
  #ifndef DSSPEAKER_7POINT1_SURROUND
  #define DSSPEAKER_7POINT1_SURROUND 0x00000008
-diff -aur portaudio/src/hostapi/wdmks/pa_win_wdmks.c portaudio-patched/src/hostapi/wdmks/pa_win_wdmks.c
---- portaudio/src/hostapi/wdmks/pa_win_wdmks.c	2011-02-17 15:56:04.000000000 +0000
-+++ portaudio-patched/src/hostapi/wdmks/pa_win_wdmks.c	2012-03-02 21:49:13.000000000 +0000
-@@ -136,6 +136,7 @@
+diff -Nuar portaudio/src/hostapi/dsound/pa_win_ds.c portaudio-patched/src/hostapi/dsound/pa_win_ds.c
+--- portaudio/src/hostapi/dsound/pa_win_ds.c	2014-02-02 14:16:01.916602634 +0100
++++ portaudio-patched/src/hostapi/dsound/pa_win_ds.c	2014-02-02 14:17:19.340378622 +0100
+@@ -2108,7 +2108,8 @@
+         }
+         else
+         {
+-            CalculateBufferSettings( &stream->hostBufferSizeFrames, &pollingPeriodFrames,
++            CalculateBufferSettings( (unsigned long*)&stream->hostBufferSizeFrames,
++                    &pollingPeriodFrames,
+                     /* isFullDuplex = */ (inputParameters && outputParameters),
+                     suggestedInputLatencyFrames,
+                     suggestedOutputLatencyFrames,
+diff --git a/configure.in b/configure.in
+index 305b64e..3f3b31e 100644
+--- a/configure.in
++++ b/configure.in
+@@ -318,7 +318,7 @@ case "${host_os}" in
  
- #include <mmreg.h>
- #include <ks.h>
-+#define _WAVEFORMATEXTENSIBLE_
- #include <ksmedia.h>
- #include <tchar.h>
- #include <assert.h>
---- portaudio/configure.in 14:07:02.000000000 +0000
-+++ portaudio-patched/configure.in	2012-05-27 14:08:34.000000000 +0000
-@@ -247,7 +247,7 @@
-         if [[ "x$with_directx" = "xyes" ]]; then
-             DXDIR="$with_dxdir"
-             add_objects src/hostapi/dsound/pa_win_ds.o src/hostapi/dsound/pa_win_ds_dynlink.o src/os/win/pa_win_hostapis.o src/os/win/pa_win_util.o src/os/win/pa_win_coinitialize.o src/os/win/pa_win_waveformat.o
--            LIBS="-lwinmm -lm -ldsound -lole32"
-+            LIBS="$LIBS -lwinmm -lm -ldsound -lole32"
-             DLL_LIBS="${DLL_LIBS} -lwinmm -lm -L$DXDIR/lib -ldsound -lole32"
-             #VC98="\"/c/Program Files/Microsoft Visual Studio/VC98/Include\""
-             #CFLAGS="$CFLAGS -I$VC98 -DPA_NO_WMME -DPA_NO_ASIO"
-@@ -257,7 +257,7 @@
-         if [[ "x$with_asio" = "xyes" ]]; then
-             ASIODIR="$with_asiodir"
-             add_objects src/hostapi/asio/pa_asio.o src/common/pa_ringbuffer.o src/os/win/pa_win_hostapis.o src/os/win/pa_win_util.o src/os/win/pa_win_coinitialize.o src/hostapi/asio/iasiothiscallresolver.o $ASIODIR/common/asio.o $ASIODIR/host/asiodrivers.o $ASIODIR/host/pc/asiolist.o
--            LIBS="-lwinmm -lm -lole32 -luuid"
-+            LIBS="$LIBS -lwinmm -lm -lole32 -luuid"
-             DLL_LIBS="${DLL_LIBS} -lwinmm -lm -lole32 -luuid"
-             CFLAGS="$CFLAGS -ffast-math -fomit-frame-pointer -I\$(top_srcdir)/src/hostapi/asio -I$ASIODIR/host/pc -I$ASIODIR/common -I$ASIODIR/host -UPA_USE_ASIO -DPA_USE_ASIO=1 -DWINDOWS"
- 
-@@ -273,7 +273,7 @@
          if [[ "x$with_wdmks" = "xyes" ]]; then
              DXDIR="$with_dxdir"
-             add_objects src/hostapi/wdmks/pa_win_wdmks.o src/os/win/pa_win_hostapis.o src/os/win/pa_win_util.o
--            LIBS="-lwinmm -lm -luuid -lsetupapi -lole32"
-+            LIBS="$LIBS -lwinmm -lm -luuid -lsetupapi -lole32"
+-            add_objects src/hostapi/wdmks/pa_win_wdmks.o src/common/pa_ringbuffer.o src/os/win/pa_win_hostapis.o src/os/win/pa_win_util.o src/os/win/pa_win_wdmks_util.o src/os/win/pa_win_waveformat.o
++            add_objects src/hostapi/wdmks/pa_win_wdmks.o src/common/pa_ringbuffer.o src/os/win/pa_win_hostapis.o src/os/win/pa_win_util.o src/os/win/pa_win_wdmks_utils.o src/os/win/pa_win_waveformat.o
+             LIBS="${LIBS} -lwinmm -lm -luuid -lsetupapi -lole32"
              DLL_LIBS="${DLL_LIBS} -lwinmm -lm -L$DXDIR/lib -luuid -lsetupapi -lole32"
              #VC98="\"/c/Program Files/Microsoft Visual Studio/VC98/Include\""
-             #CFLAGS="$CFLAGS -I$VC98 -DPA_NO_WMME -DPA_NO_ASIO"
-@@ -282,14 +282,14 @@
- 
-         if [[ "x$with_wmme" = "xyes" ]]; then
-             add_objects src/hostapi/wmme/pa_win_wmme.o src/os/win/pa_win_hostapis.o src/os/win/pa_win_util.o src/os/win/pa_win_waveformat.o
--            LIBS="-lwinmm -lm -lole32 -luuid"
-+            LIBS="$LIBS -lwinmm -lm -lole32 -luuid"
-             DLL_LIBS="${DLL_LIBS} -lwinmm"
-             CFLAGS="$CFLAGS -UPA_USE_WMME -DPA_USE_WMME=1"
-         fi
- 
-         if [[ "x$with_wasapi" = "xyes" ]]; then
-             add_objects src/hostapi/wasapi/pa_win_wasapi.o src/common/pa_ringbuffer.o src/os/win/pa_win_hostapis.o src/os/win/pa_win_util.o src/os/win/pa_win_coinitialize.o src/os/win/pa_win_waveformat.o
--            LIBS="-lwinmm -lm -lole32 -luuid"
-+            LIBS="$LIBS -lwinmm -lm -lole32 -luuid"
-             DLL_LIBS="${DLL_LIBS} -lwinmm -lole32"
-             CFLAGS="$CFLAGS -I\$(top_srcdir)/src/hostapi/wasapi/mingw-include -UPA_USE_WASAPI -DPA_USE_WASAPI=1"
-         fi

--- a/src/portaudio.mk
+++ b/src/portaudio.mk
@@ -3,8 +3,8 @@
 
 PKG             := portaudio
 $(PKG)_IGNORE   :=
-$(PKG)_VERSION  := 19_20111121
-$(PKG)_CHECKSUM := f07716c470603729a55b70f5af68f4a6807097eb
+$(PKG)_VERSION  := 19_20140130
+$(PKG)_CHECKSUM := 526a7955de59016a06680ac24209ecb6ce05527d
 $(PKG)_SUBDIR   := portaudio
 $(PKG)_FILE     := pa_stable_v$($(PKG)_VERSION).tgz
 $(PKG)_URL      := http://www.portaudio.com/archives/$($(PKG)_FILE)


### PR DESCRIPTION
A new PortAudio stable release has been made.

The mxe-specific patches in src/portaudio-1-win32.patch have changed as
follows:

  [Unchanged]  pa_win_ds.c needs a definition for DSSPEAKER_7POINT1
  from the DirectSound headers.  Mingw doesn't include this constant so
  we patch it.

  [Added] CalculateBufferSettings() mixes int and unsigned long types.
  gcc treats this sloppy use of types as an error.  Manually cast since
  we know it's safe on Windows where the LLP64 data model is used.

  [Added] configure.in mistakingly lists pa_win_wdmks_util.o instead of
  the correct filename, pa_win_wdmks_utils.o.  I have sent a patch
  upstream to PortAudio and we'll be able to drop this in the next
  update.

  [Dropped] pa_win_wdmks.c now uses special headers for mingw so we do
  not need to define _WAVEFORMATEXTENSIBLE_ anymore.

  [Dropped] configure.in now supports building multiple hostapis with
  mingw since my patch was merged upstream in PortAudio.  We no longer
  need to modify LIBS.

Signed-off-by: Stefan Hajnoczi stefanha@gmail.com
