### PR TITLE
Bullet Physics

### DIFF
--- a/index.html
+++ b/index.html
@@ -1160,6 +1160,10 @@ local-pkg-list: $(LOCAL_PKG_LIST)</pre>
         <td class="website"><a href="http://www.boost.org/">Boost C++ Library</a></td>
     </tr>
     <tr>
+        <td class="package">bullet2</td>
+        <td class="website"><a href="http://bulletphysics.org/">Bullet physics, version 2</a></td>
+    </tr>
+    <tr>
         <td class="package">bzip2</td>
         <td class="website"><a href="http://www.bzip.org/">bzip2</a></td>
     </tr>

--- a/src/bullet2-1-pkgconfig.patch
+++ b/src/bullet2-1-pkgconfig.patch
@@ -1,0 +1,22 @@
+This file is part of MXE.
+See index.html for further information.
+
+--- a/CMakeLists.txt	Sat Sep 14 11:25:52 2013 -0700
++++ b/CMakeLists.txt	Fri Sep 27 15:03:58 2013 +1000
+@@ -402,14 +402,14 @@
+ 	## the following are directories where stuff will be installed to
+ 	SET(INCLUDE_INSTALL_DIR      "${CMAKE_INSTALL_PREFIX}/include/bullet/" CACHE PATH "The subdirectory to the header prefix")
+ 	SET(PKGCONFIG_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}/lib${LIB_SUFFIX}/pkgconfig/" CACHE STRING "Base directory for pkgconfig files")
+-	IF(NOT WIN32)
++	
+ 	  CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/bullet.pc.cmake ${CMAKE_CURRENT_BINARY_DIR}/bullet.pc @ONLY)
+   	INSTALL(
+ 	    FILES
+     	${CMAKE_CURRENT_BINARY_DIR}/bullet.pc
+     	DESTINATION
+     	${PKGCONFIG_INSTALL_PREFIX})
+-	ENDIF(NOT WIN32)
++	
+ ENDIF(INSTALL_LIBS)
+ 
+ #INSTALL of other files requires CMake 2.6

--- a/src/bullet2-test.cpp
+++ b/src/bullet2-test.cpp
@@ -1,0 +1,33 @@
+/*
+ * This file is part of MXE.
+ * See index.html for further information.
+ */
+
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#pragma GCC diagnostic ignored "-Wunused-variable"
+
+#include <btBulletDynamicsCommon.h>
+
+#pragma GCC diagnostic error "-Wunused-parameter"
+#pragma GCC diagnostic error "-Wunused-variable"
+
+
+int main(int argc, char *argv[])
+{
+    btBroadphaseInterface* broadphase = new btDbvtBroadphase();
+    btDefaultCollisionConfiguration* collisionConfiguration = new btDefaultCollisionConfiguration();
+    btCollisionDispatcher* dispatcher = new btCollisionDispatcher(collisionConfiguration);
+    btSequentialImpulseConstraintSolver* solver = new btSequentialImpulseConstraintSolver();
+    btDiscreteDynamicsWorld* dynamicsWorld = new btDiscreteDynamicsWorld(dispatcher, broadphase, solver, collisionConfiguration);
+
+    (void)argc;
+    (void)argv;
+
+    delete dynamicsWorld;
+    delete solver;
+    delete dispatcher;
+    delete collisionConfiguration;
+    delete broadphase;
+
+    return 0;
+}

--- a/src/bullet2.mk
+++ b/src/bullet2.mk
@@ -1,0 +1,39 @@
+# This file is part of MXE.
+# See index.html for further information.
+
+PKG             := bullet2
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 2.82-r2704
+$(PKG)_CHECKSUM := a0867257b9b18e9829bbeb4c6c5872a5b29d1d33
+$(PKG)_SUBDIR   := bullet-$($(PKG)_VERSION)
+$(PKG)_FILE     := bullet-$($(PKG)_VERSION).tgz
+$(PKG)_URL      := https://bullet.googlecode.com/files/$($(PKG)_FILE)
+$(PKG)_DEPS     := gcc
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- 'http://code.google.com/p/bullet/downloads/list?sort=-uploaded' | \
+    $(SED) -n 's,.*bullet-\([0-9][^<]*\)\.tgz,\1,p' | \
+    head -1
+endef
+
+define $(PKG)_BUILD
+    cd '$(1)' && cmake . \
+        -DCMAKE_TOOLCHAIN_FILE='$(CMAKE_TOOLCHAIN_FILE)' \
+        -DINSTALL_LIBS=ON \
+        -DBUILD_SHARED_LIBS=ON \
+        -DBUILD_CPU_DEMOS=OFF \
+        -DBUILD_DEMOS=OFF \
+        -DBUILD_EXTRAS=OFF \
+        -DBUILD_MULTITHREADING=OFF \
+        -DBUILD_UNIT_TESTS=OFF \
+        -DUSE_CUSTOM_VECOR_MATH=OFF \
+        -DUSE_DOUBLE_PRECISION=OFF \
+        -DUSE_GLUT=OFF \
+        -DUSE_GRAPHICAL_BENCHMARK=OFF
+    $(MAKE) -C '$(1)' -j '$(JOBS)' install VERBOSE=1
+
+    '$(TARGET)-g++' \
+        -W -Wall -Werror -ansi -pedantic \
+        '$(2).cpp' -o '$(PREFIX)/$(TARGET)/bin/test-bullet.exe' \
+        `'$(TARGET)-pkg-config' bullet --cflags --libs`
+endef


### PR DESCRIPTION
This is the bullet physics library.

I'm having trouble with GCC pedantic mode and the test file, so it's not 100% operational, although the actual library appears to build. Any help with this would be appreciated.

I called the package `bullet2` so as to not conflict with a possible future package for the in-development Bullet 3 (https://github.com/erwincoumans/bullet3); people may want to install one or the other depending on what their software is using.

The patch removes some checks for WIN32 which was causing the `bullet.pc` file to not be created, preventing pkg-config from working. I haven't provided this patch to the upstream development because to best of my knowledge Bullet 2 isn't receiving any further work, only Bullet 3.
