### PR TITLE
mxe configury: build native pkgconf and centralise various conf files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,10 +46,6 @@ BUILD      := $(shell '$(TOP_DIR)/tools/config.guess')
 BUILD_PKGS := $(shell grep -l 'BUILD_$$(BUILD)' '$(TOP_DIR)/src/'*.mk | $(SED) -n 's,.*src/\(.*\)\.mk,\1,p')
 PATH       := $(PREFIX)/$(BUILD)/bin:$(PREFIX)/bin:$(PATH)
 
-# install config.guess for general use
-$(shell $(INSTALL) -d '$(PREFIX)/bin')
-$(shell $(INSTALL) -m755 '$(TOP_DIR)/tools/config.guess' '$(PREFIX)/bin/')
-
 # use a minimal whitelist of safe environment variables
 ENV_WHITELIST := PATH LANG MAKE% MXE% %PROXY %proxy
 unexport $(filter-out $(ENV_WHITELIST),$(shell env | cut -d '=' -f1))

--- a/src/binutils.mk
+++ b/src/binutils.mk
@@ -9,7 +9,7 @@ $(PKG)_SUBDIR   := binutils-$($(PKG)_VERSION)
 $(PKG)_FILE     := binutils-$($(PKG)_VERSION).tar.bz2
 $(PKG)_URL      := ftp://ftp.gnu.org/pub/gnu/binutils/$($(PKG)_FILE)
 $(PKG)_URL_2    := ftp://ftp.cs.tu-berlin.de/pub/gnu/binutils/$($(PKG)_FILE)
-$(PKG)_DEPS     :=
+$(PKG)_DEPS     := pkgconf
 
 define $(PKG)_UPDATE
     $(WGET) -q -O- 'http://ftp.gnu.org/gnu/binutils/?C=M;O=D' | \
@@ -19,13 +19,9 @@ define $(PKG)_UPDATE
 endef
 
 define $(PKG)_BUILD
-    # install target-specific autotools config file
-    $(INSTALL) -d '$(PREFIX)/$(TARGET)/share'
-    echo "ac_cv_build=`$(1)/config.guess`" > '$(PREFIX)/$(TARGET)/share/config.site'
-
     cd '$(1)' && ./configure \
         --target='$(TARGET)' \
-        --build="`config.guess`" \
+        --build='$(BUILD)' \
         --prefix='$(PREFIX)' \
         --disable-multilib \
         --with-gcc \

--- a/src/gcc.mk
+++ b/src/gcc.mk
@@ -27,7 +27,7 @@ define $(PKG)_CONFIGURE
     mkdir '$(1).build'
     cd    '$(1).build' && '$(1)/configure' \
         --target='$(TARGET)' \
-        --build="`config.guess`" \
+        --build='$(BUILD)' \
         --prefix='$(PREFIX)' \
         --libdir='$(PREFIX)/lib' \
         --enable-languages='c,c++,objc,fortran' \
@@ -51,60 +51,12 @@ define $(PKG)_CONFIGURE
         $(shell [ `uname -s` == Darwin ] && echo "LDFLAGS='-Wl,-no_pie'")
 endef
 
-define $(PKG)_POST_BUILD
-    # create pkg-config script
-    (echo '#!/bin/sh'; \
-     echo 'PKG_CONFIG_PATH="$(PREFIX)/$(TARGET)/qt5/lib/pkgconfig":"$$PKG_CONFIG_PATH_$(subst -,_,$(TARGET))" PKG_CONFIG_LIBDIR='\''$(PREFIX)/$(TARGET)/lib/pkgconfig'\'' exec pkg-config --static "$$@"') \
-             > '$(PREFIX)/bin/$(TARGET)-pkg-config'
-    chmod 0755 '$(PREFIX)/bin/$(TARGET)-pkg-config'
-
-    # create the CMake toolchain file
-    [ -d '$(dir $(CMAKE_TOOLCHAIN_FILE))' ] || mkdir -p '$(dir $(CMAKE_TOOLCHAIN_FILE))'
-    (echo 'set(CMAKE_SYSTEM_NAME Windows)'; \
-     echo 'set(MSYS 1)'; \
-     echo 'set(BUILD_SHARED_LIBS OFF)'; \
-     echo 'set(CMAKE_BUILD_TYPE Release)'; \
-     echo 'set(CMAKE_FIND_ROOT_PATH $(PREFIX)/$(TARGET))'; \
-     echo 'set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)'; \
-     echo 'set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)'; \
-     echo 'set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)'; \
-     echo 'set(CMAKE_C_COMPILER $(PREFIX)/bin/$(TARGET)-gcc)'; \
-     echo 'set(CMAKE_CXX_COMPILER $(PREFIX)/bin/$(TARGET)-g++)'; \
-     echo 'set(CMAKE_Fortran_COMPILER $(PREFIX)/bin/$(TARGET)-gfortran)'; \
-     echo 'set(CMAKE_RC_COMPILER $(PREFIX)/bin/$(TARGET)-windres)'; \
-     echo 'set(HDF5_C_COMPILER_EXECUTABLE $(PREFIX)/bin/$(TARGET)-h5cc)'; \
-     echo 'set(HDF5_CXX_COMPILER_EXECUTABLE $(PREFIX)/bin/$(TARGET)-h5c++)'; \
-     echo 'set(PKG_CONFIG_EXECUTABLE $(PREFIX)/bin/$(TARGET)-pkg-config)'; \
-     echo 'set(QT_QMAKE_EXECUTABLE $(PREFIX)/$(TARGET)/qt/bin/qmake)'; \
-     echo 'set(CMAKE_INSTALL_PREFIX $(PREFIX)/$(TARGET) CACHE PATH "Installation Prefix")'; \
-     echo 'set(CMAKE_BUILD_TYPE Release CACHE STRING "Debug|Release|RelWithDebInfo|MinSizeRel")') \
-     > '$(CMAKE_TOOLCHAIN_FILE)'
-endef
-
-define $(PKG)_POST_BUILD_mingw32
-    # create pkg-config files
-    $(INSTALL) -d '$(PREFIX)/$(TARGET)/lib/pkgconfig'
-    (echo 'Name: gl'; \
-     echo 'Version: 0'; \
-     echo 'Description: OpenGL'; \
-     echo 'Libs: -lopengl32';) \
-     > '$(PREFIX)/$(TARGET)/lib/pkgconfig/gl.pc'
-
-    (echo 'Name: glu'; \
-     echo 'Version: 0'; \
-     echo 'Description: OpenGL'; \
-     echo 'Libs: -lglu32';) \
-     > '$(PREFIX)/$(TARGET)/lib/pkgconfig/glu.pc'
-endef
-
 define $(PKG)_BUILD_i686-pc-mingw32
     # build full cross gcc
     $($(PKG)_CONFIGURE) \
         --disable-sjlj-exceptions
     $(MAKE) -C '$(1).build' -j '$(JOBS)'
     $(MAKE) -C '$(1).build' -j 1 install
-    $($(PKG)_POST_BUILD)
-    $($(PKG)_POST_BUILD_mingw32)
 endef
 
 define $(PKG)_BUILD_mingw-w64
@@ -127,9 +79,6 @@ define $(PKG)_BUILD_mingw-w64
     cd '$(1).build'
     $(MAKE) -C '$(1).build' -j '$(JOBS)'
     $(MAKE) -C '$(1).build' -j 1 install
-
-    $($(PKG)_POST_BUILD)
-    $($(PKG)_POST_BUILD_mingw32)
 endef
 
 $(PKG)_BUILD_x86_64-w64-mingw32 = $(subst mxe-config-opts,--disable-lib32,$($(PKG)_BUILD_mingw-w64))
@@ -139,5 +88,4 @@ define $(PKG)_BUILD_$(BUILD)
     for f in c++ cpp g++ gcc gcov; do \
         ln -sf "`which $$f`" '$(PREFIX)/bin/$(TARGET)'-$$f ; \
     done
-    $($(PKG)_POST_BUILD)
 endef

--- a/src/pkgconf.mk
+++ b/src/pkgconf.mk
@@ -8,7 +8,9 @@ $(PKG)_CHECKSUM := 1e7b5ffe35ca4580a9b801307c3bc919fd77a4fd
 $(PKG)_SUBDIR   := $(PKG)-$(PKG)-$($(PKG)_VERSION)
 $(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.gz
 $(PKG)_URL      := http://github.com/$(PKG)/$(PKG)/tarball/$($(PKG)_VERSION)/$($(PKG)_FILE)
-$(PKG)_DEPS     := automake
+$(PKG)_DEPS     :=
+
+$(PKG)_DEPS_$(BUILD) := automake
 
 define $(PKG)_UPDATE_
     $(WGET) -q -O- 'https://github.com/pkgconf/pkgconf/commits/master' | \
@@ -21,11 +23,67 @@ define $(PKG)_UPDATE
     echo $(pkgconf_VERSION)
 endef
 
-define $(PKG)_BUILD_$(BUILD)
+define $(PKG)_BUILD_COMMON
     cd '$(1)' && ./autogen.sh
     cd '$(1)' && ./configure \
         --prefix='$(PREFIX)/$(TARGET)'
     $(MAKE) -C '$(1)' -j '$(JOBS)'
     $(MAKE) -C '$(1)' -j 1 install
     ln -sf '$(PREFIX)/$(TARGET)/bin/pkgconf' '$(PREFIX)/$(TARGET)/bin/pkg-config'
+
+    # install target-specific autotools config file
+    $(INSTALL) -d '$(PREFIX)/$(TARGET)/share'
+    echo "ac_cv_build=$(BUILD)" > '$(PREFIX)/$(TARGET)/share/config.site'
+
+    # install config.guess for general use
+    $(INSTALL) -d '$(PREFIX)/bin'
+    $(INSTALL) -m755 '$(TOP_DIR)/tools/config.guess' '$(PREFIX)/bin/'
+
+    # create pkg-config script
+    (echo '#!/bin/sh'; \
+     echo 'PKG_CONFIG_PATH="$(PREFIX)/$(TARGET)/qt5/lib/pkgconfig":"$$PKG_CONFIG_PATH_$(subst -,_,$(TARGET))" PKG_CONFIG_LIBDIR='\''$(PREFIX)/$(TARGET)/lib/pkgconfig'\'' exec '$(PREFIX)/$(TARGET)/bin/pkg-config' --static "$$@"') \
+             > '$(PREFIX)/bin/$(TARGET)-pkg-config'
+    chmod 0755 '$(PREFIX)/bin/$(TARGET)-pkg-config'
+
+    # create the CMake toolchain file
+    [ -d '$(dir $(CMAKE_TOOLCHAIN_FILE))' ] || mkdir -p '$(dir $(CMAKE_TOOLCHAIN_FILE))'
+    (echo 'set(CMAKE_SYSTEM_NAME Windows)'; \
+     echo 'set(MSYS 1)'; \
+     echo 'set(BUILD_SHARED_LIBS OFF)'; \
+     echo 'set(CMAKE_BUILD_TYPE Release)'; \
+     echo 'set(CMAKE_FIND_ROOT_PATH $(PREFIX)/$(TARGET))'; \
+     echo 'set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)'; \
+     echo 'set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)'; \
+     echo 'set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)'; \
+     echo 'set(CMAKE_C_COMPILER $(PREFIX)/bin/$(TARGET)-gcc)'; \
+     echo 'set(CMAKE_CXX_COMPILER $(PREFIX)/bin/$(TARGET)-g++)'; \
+     echo 'set(CMAKE_Fortran_COMPILER $(PREFIX)/bin/$(TARGET)-gfortran)'; \
+     echo 'set(CMAKE_RC_COMPILER $(PREFIX)/bin/$(TARGET)-windres)'; \
+     echo 'set(HDF5_C_COMPILER_EXECUTABLE $(PREFIX)/bin/$(TARGET)-h5cc)'; \
+     echo 'set(HDF5_CXX_COMPILER_EXECUTABLE $(PREFIX)/bin/$(TARGET)-h5c++)'; \
+     echo 'set(PKG_CONFIG_EXECUTABLE $(PREFIX)/bin/$(TARGET)-pkg-config)'; \
+     echo 'set(QT_QMAKE_EXECUTABLE $(PREFIX)/$(TARGET)/qt/bin/qmake)'; \
+     echo 'set(CMAKE_INSTALL_PREFIX $(PREFIX)/$(TARGET) CACHE PATH "Installation Prefix")'; \
+     echo 'set(CMAKE_BUILD_TYPE Release CACHE STRING "Debug|Release|RelWithDebInfo|MinSizeRel")') \
+     > '$(CMAKE_TOOLCHAIN_FILE)'
 endef
+
+define $(PKG)_BUILD
+    $($(PKG)_BUILD_COMMON)
+
+    # create pkg-config files for OpenGL/GLU
+    $(INSTALL) -d '$(PREFIX)/$(TARGET)/lib/pkgconfig'
+    (echo 'Name: gl'; \
+     echo 'Version: 0'; \
+     echo 'Description: OpenGL'; \
+     echo 'Libs: -lopengl32';) \
+     > '$(PREFIX)/$(TARGET)/lib/pkgconfig/gl.pc'
+
+    (echo 'Name: glu'; \
+     echo 'Version: 0'; \
+     echo 'Description: OpenGL'; \
+     echo 'Libs: -lglu32';) \
+     > '$(PREFIX)/$(TARGET)/lib/pkgconfig/glu.pc'
+endef
+
+$(PKG)_BUILD_$(BUILD) = $($(PKG)_BUILD_COMMON)


### PR DESCRIPTION
Since we need pkgconf for Cflags.private support, it seems like a
logical place for these types of config files instead of being
spread over Makefile, binutils, and gcc.
