### PR TITLE
package gdb: fix undefined symbols in bundled readline

### DIFF
--- a/src/gdb.mk
+++ b/src/gdb.mk
@@ -8,7 +8,7 @@ $(PKG)_SUBDIR   := gdb-$($(PKG)_VERSION)
 $(PKG)_FILE     := gdb-$($(PKG)_VERSION).tar.bz2
 $(PKG)_URL      := ftp://ftp.gnu.org/pub/gnu/$(PKG)/$($(PKG)_FILE)
 $(PKG)_URL_2    := ftp://ftp.cs.tu-berlin.de/pub/gnu/$(PKG)/$($(PKG)_FILE)
-$(PKG)_DEPS     := gcc expat libiconv ncurses zlib
+$(PKG)_DEPS     := gcc expat libiconv pdcurses zlib
 
 define $(PKG)_UPDATE
     $(WGET) -q -O- 'http://ftp.gnu.org/gnu/gdb/?C=M;O=D' | \


### PR DESCRIPTION
Use pdcurses as we do for readline package.
