### PR TITLE
fix qtdeclarative on i686-pc-mingw32 target

### DIFF
--- a/src/qtdeclarative-1.patch
+++ b/src/qtdeclarative-1.patch
@@ -1,0 +1,19 @@
+diff --git a/src/qml/qml/qqmlengine.cpp b/src/qml/qml/qqmlengine.cpp
+index 91faed5..352c405 100644
+--- a/src/qml/qml/qqmlengine.cpp
++++ b/src/qml/qml/qqmlengine.cpp
+@@ -2294,10 +2294,13 @@
+ // is disabled (see 8dot3name options of fsutil.exe).
+ static inline QString shellNormalizeFileName(const QString &name)
+ {
++#ifndef PIDLIST_ABSOLUTE
++#define PIDLIST_ABSOLUTE ITEMIDLIST*
++#endif
+     const QString nativeSeparatorName(QDir::toNativeSeparators(name));
+     const LPCTSTR nameC = reinterpret_cast<LPCTSTR>(nativeSeparatorName.utf16());
+     PIDLIST_ABSOLUTE file;
+-    if (FAILED(SHParseDisplayName(nameC, NULL, &file, 0, NULL)))
++    if (FAILED(SHParseDisplayName(nameC, NULL, file, 0, NULL)))
+         return name;
+     TCHAR buffer[MAX_PATH];
+     if (!SHGetPathFromIDList(file, buffer))

--- a/src/qtdeclarative.mk
+++ b/src/qtdeclarative.mk
@@ -20,4 +20,3 @@ define $(PKG)_BUILD
     $(MAKE) -C '$(1)' -j 1 install
 endef
 
-$(PKG)_BUILD_i686-pc-mingw32 =


### PR DESCRIPTION
This add a patch to fix compilation of qml/qqmlengine.cpp, a file of qtdeclarative
solve issue https://github.com/mxe/mxe/issues/353
