### PR TITLE
Add "dummy" target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -421,6 +421,19 @@ clean-pkg:
                       $(foreach PKG,$(PKGS),$(PKG_DIR)/$($(PKG)_FILE)), \
                       $(wildcard $(PKG_DIR)/*)))
 
+define DUMMY_RULE
+.PHONY: dummy-$(1)
+dummy-$(1):
+	$(if $(value $(call LOOKUP_PKG_RULE,$(1),BUILD,$(2))),
+	    @echo '[build]    $(1)',
+	    @echo '[no-build] $(1)')
+endef
+$(foreach PKG,$(PKGS), \
+    $(eval $(call DUMMY_RULE,$(PKG),$(TARGET))))
+
+.PHONY: dummy
+dummy: $(foreach PKG,$(PKGS), dummy-$(PKG))
+
 .PHONY: update
 define UPDATE
     $(if $(2),

--- a/index.html
+++ b/index.html
@@ -1037,6 +1037,19 @@ local-pkg-list: $(LOCAL_PKG_LIST)</pre>
         where up to 4 packages are downloaded in parallel
         </dd>
 
+    <dt>make dummy</dt>
+
+        <dd>
+        generate a report of building status of all packages in the selected
+        target
+        </dd>
+
+    <dt>make dummy-foo</dt>
+
+        <dd>
+        show whether building of package foo is enabled
+        </dd>
+
     <dt>make clean</dt>
 
         <dd>


### PR DESCRIPTION
This is useful for generating build status of all targets. See #346.
