### PR TITLE
Add build matrix generation target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /settings.mk
+/build-matrix.html
 /usr/
 /gits/
 /log*/

--- a/assets/build-matrix.css
+++ b/assets/build-matrix.css
@@ -1,0 +1,15 @@
+/* This file is part of MXE.
+ * See index.html for further information. */
+
+table.fullscreen {
+    width: 100%;
+}
+
+td.supported {
+    background-color: #98fb98;
+    text-align: center;
+}
+td.unsupported {
+    background-color: #f99;
+    text-align: center;
+}

--- a/index.html
+++ b/index.html
@@ -999,6 +999,13 @@ local-pkg-list: $(LOCAL_PKG_LIST)</pre>
         suitable for usage in shell scripts
         </dd>
 
+    <dt>make build-matrix.html</dt>
+
+        <dd>
+        generate a report of what packages are
+        supported on what targets to build-matrix.html
+        </dd>
+
     <dt>make update</dt>
 
         <dd>


### PR DESCRIPTION
Based on a patch by @TobiX.

Some questions about this patch I want to hear more on:
- Should the build-matrix and build-matrix.html targets both be there?
- If so, should they both be phony targets or one phony one real?
