### PR TITLE
Fix build of lame with GCC 4.9.

### DIFF
--- a/src/lame-1-fix-xmmintrin-errors.patch
+++ b/src/lame-1-fix-xmmintrin-errors.patch
@@ -1,0 +1,31 @@
+This file is part of MXE.
+See index.html for further information.
+
+Fix compilation of SSE2 sources with GCC 4.9. Since this requires an autoreconf
+run, we manually disable the GTK 1.2 dependency, because we don't have the GTK
+M4 files available.
+
+diff -Naur lame-3.99.5.orig/configure.in lame-3.99.5/configure.in
+--- lame-3.99.5.orig/configure.in	2014-05-02 13:00:26.006106005 +0200
++++ lame-3.99.5/configure.in	2014-05-02 13:14:01.690106046 +0200
+@@ -393,7 +393,8 @@
+ 
+ dnl configure use of features
+ 
+-AM_PATH_GTK(1.2.0, HAVE_GTK="yes", HAVE_GTK="no")
++HAVE_GTK="no"
++AC_SUBST(GTK_CFLAGS)
+ 
+ dnl ElectricFence malloc debugging
+ AC_MSG_CHECKING(use of ElectricFence malloc debugging)
+diff -Naur lame-3.99.5.orig/libmp3lame/vector/Makefile.am lame-3.99.5/libmp3lame/vector/Makefile.am
+--- lame-3.99.5.orig/libmp3lame/vector/Makefile.am	2014-05-02 13:00:26.002106005 +0200
++++ lame-3.99.5/libmp3lame/vector/Makefile.am	2014-05-02 13:08:03.854106010 +0200
+@@ -20,6 +20,7 @@
+ 
+ if WITH_XMM
+ liblamevectorroutines_la_SOURCES = $(xmm_sources)
++liblamevectorroutines_la_CFLAGS = -msse
+ endif
+ 
+ noinst_HEADERS = lame_intrin.h

--- a/src/lame.mk
+++ b/src/lame.mk
@@ -20,8 +20,8 @@ define $(PKG)_UPDATE
 endef
 
 define $(PKG)_BUILD
-    cd '$(1)' && ./configure \
+    cd '$(1)' && autoreconf -i && ./configure \
         $(MXE_CONFIGURE_OPTS)
-    $(MAKE) -C '$(1)' -j '$(JOBS)' MXE_CFLAGS=
+    $(MAKE) -C '$(1)' -j '$(JOBS)'
     $(MAKE) -C '$(1)' -j 1 install
 endef


### PR DESCRIPTION
It seems GCC 4.9 got way pickier when compiling this SSE stuff in Lame. I tried to make the requirement of SSE as small in scope as possible (only the affected source file), so lame still runs on older x86 hardware (SSE2 is from ~2001...) - but couldn't test it since I don't own hardware that old anymore ;)

I had to manually disable GTK in the configure script, since that's still GTK 1.2 and a really don't want to have anything to do with that ;)
