### PR TITLE
WIP: Add Git patch workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -559,3 +559,35 @@ build-matrix.html: $(foreach PKG,$(PKGS), $(TOP_DIR)/src/$(PKG).mk)
 	@echo '</table>'                        >> $@
 	@echo '</body>'                         >> $@
 
+# The meat of git-init-% target.
+# argument 1: package name
+# argument 2: temporary directory used to contain the Git repo
+define GIT_INIT
+    rm -rf '$(2)'
+    mkdir -p '$(2)'
+    cd '$(2)' && $(call UNPACK_PKG_ARCHIVE,$(1))
+    cd '$(2)/$($(1)_SUBDIR)'                 && \
+    git init                                 && \
+    git config user.email "mxe@mxe.cc"       && \
+    git config user.name  "MXE"              && \
+    git add *                                && \
+    git commit -qm'Inititalize from tarball' && \
+    git branch tarball
+    $(foreach PKG_PATCH,$(sort $(wildcard $(TOP_DIR)/src/$(1)-*.patch)), \
+        (cd '$(2)/$($(1)_SUBDIR)'                 && \
+            (git am < $(TOP_DIR)/$(PKG_PATCH)                || \
+            (rm -rf .git/rebase-apply             && \
+                $(PATCH) -p1 -u < $(TOP_DIR)/$(PKG_PATCH)    && \
+                git add *                         && \
+                git commit -m'Patch $(PKG_PATCH)'))))
+	cd '$(2)/$($(1)_SUBDIR)'                 && \
+	git branch current                       && \
+    git config --unset user.email            && \
+    git config --unset user.name
+endef
+
+git-init-%:
+	$(if $(findstring $*~,$(addsuffix ~,$(PKGS))), \
+		$(call GIT_INIT,$*,$(call TMP_DIR,git-$*)),    \
+	$(error package $* not found in index.html))
+

--- a/index.html
+++ b/index.html
@@ -1040,6 +1040,19 @@ local-pkg-list: $(LOCAL_PKG_LIST)</pre>
         cleanup coding style
         </dd>
 
+    <dt>make git-init-foo</dt>
+
+        <dd>
+        for internal use only!
+        &ndash;
+        initialize a Git repository that can be used to
+        ease writing patches for the package. The generated
+        Git repo will be in <code>tmp-git-foo</code> directory.
+        The original release tarball is unpacked and branched as
+        <code>tarball</code>, and current patches are applied and
+        branched as <code>current</code>.
+        </dd>
+
     </dl>
 </div>
 
@@ -2624,6 +2637,13 @@ https://...</pre>
         <p>
         Depending on the feedback you get from the upstream project,
         you might want to improve your patch.
+        </p>
+
+        <p>
+        If you want to write a patch yourself, you can try to use
+        <code>make git-init-foo</code> which will initialize a local Git
+        repository. Then, you can use Git workflow to create patches.
+        (<code>git commit -a && git format-patch current</code>)
         </p>
     </li>
 


### PR DESCRIPTION
Attempts to fix #134.

This patch is still not optimal. Some examples of broken/missing features include:
- When Git patches are applied, the commit message and author are not imported correctly by `git am`. This is because of the initial "This patch is part of MXE" text, which `git am` doesn't know to ignore.
- If a patch doesn't apply for example because I first updates the tarball in recipe, the error is not handled gracefully. I want this target to be able to automatically rebase the old patches to newer releases.
