### PR TITLE
Update package Polarssl

### DIFF
--- a/src/polarssl-1-cross-compile.patch
+++ b/src/polarssl-1-cross-compile.patch
@@ -1,0 +1,27 @@
+From db48c07b89c049ffda07c7efdfabbd95b1e4213e Mon Sep 17 00:00:00 2001
+From: Andre Heinecke <aheinecke@intevation.de>
+Date: Wed, 21 May 2014 10:20:14 +0000
+Subject: [PATCH] Fix symlink command for cross compiling
+
+    Check for the host system to determine which command
+    should be used to create a symlink
+---
+ tests/CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tests/CMakeLists.txt b/tests/CMakeLists.txt
+index 0460c63..975d497 100644
+--- a/tests/CMakeLists.txt
++++ b/tests/CMakeLists.txt
+@@ -95,7 +95,7 @@ if (NOT ${CMAKE_CURRENT_BINARY_DIR} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR})
+     file(TO_NATIVE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/data_files" target)
+ 
+     if (NOT EXISTS ${link})
+-        if (UNIX)
++        if (CMAKE_HOST_UNIX)
+             set(command ln -s ${target} ${link})
+         else()
+             set(command cmd.exe /c mklink ${link} ${target})
+-- 
+1.9.1
+

--- a/src/polarssl.mk
+++ b/src/polarssl.mk
@@ -3,8 +3,8 @@
 
 PKG             := polarssl
 $(PKG)_IGNORE   :=
-$(PKG)_VERSION  := 1.3.4
-$(PKG)_CHECKSUM := e43dc467e36ae2761ca2e4fa02c54f5771ee51a1
+$(PKG)_VERSION  := 1.3.7
+$(PKG)_CHECKSUM := 4bfce7f2e833bead53ecd38098325a784ada5c39
 $(PKG)_SUBDIR   := polarssl-$($(PKG)_VERSION)
 $(PKG)_FILE     := polarssl-$($(PKG)_VERSION)-gpl.tgz
 $(PKG)_URL      := https://polarssl.org/download/$($(PKG)_FILE)


### PR DESCRIPTION
The patch was handed upstream as a pull request polarssl/polarssl#104 so it is likely that it can be removed with the next update.
