### PR TITLE
Removing reference to libusbx which is deprecated

### DIFF
--- a/src/libusb1.mk
+++ b/src/libusb1.mk
@@ -4,14 +4,14 @@
 PKG             := libusb1
 $(PKG)_IGNORE   :=
 $(PKG)_VERSION  := 1.0.18
-$(PKG)_CHECKSUM := dc206a4d3eafa740753937856b507d3d913a0e9d
-$(PKG)_SUBDIR   := libusbx-$($(PKG)_VERSION)
-$(PKG)_FILE     := libusbx-$($(PKG)_VERSION).tar.bz2
-$(PKG)_URL      := http://$(SOURCEFORGE_MIRROR)/project/libusbx/releases/$($(PKG)_VERSION)/source/$($(PKG)_FILE)
+$(PKG)_CHECKSUM := 5f7bbf42a4d6e6b88d5e7666958c80f8455ee915
+$(PKG)_SUBDIR   := libusb-$($(PKG)_VERSION)
+$(PKG)_FILE     := libusb-$($(PKG)_VERSION).tar.bz2
+$(PKG)_URL      := http://$(SOURCEFORGE_MIRROR)/project/libusb/libusb-1.0/libusb-$($(PKG)_VERSION)/$($(PKG)_FILE)
 $(PKG)_DEPS     := gcc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'http://sourceforge.net/projects/libusbx/files/releases/' | \
+    $(WGET) -q -O- 'http://sourceforge.net/projects/libusb/files/releases/' | \
     $(SED) -n 's,.*/\([0-9][^"]*\)/".*,\1,p' | \
     head -1
 endef


### PR DESCRIPTION
See note on front page http://libusbx.org/
