### PR TITLE
Fix linking error on sfml and cegui: harfbuzz issues

### DIFF
--- a/src/freetype.mk
+++ b/src/freetype.mk
@@ -26,7 +26,7 @@ define $(PKG)_BUILD
         LIBPNG_CFLAGS="`$(TARGET)-pkg-config libpng --cflags`" \
         LIBPNG_LDFLAGS="`$(TARGET)-pkg-config libpng --libs`" \
         FT2_EXTRA_LIBS="`$(TARGET)-pkg-config libpng --libs`" \
-        $(if $(BUILD_STATIC),HARFBUZZ_LIBS="`$(TARGET)-pkg-config harfbuzz --libs` -lharfbuzz_too",)
+        $(if $(BUILD_STATIC),HARFBUZZ_LIBS="`$(TARGET)-pkg-config harfbuzz --libs` -lharfbuzz_too `$(TARGET)-pkg-config glib-2.0 --libs`",)
     $(MAKE) -C '$(1)' -j '$(JOBS)'
     $(MAKE) -C '$(1)' -j 1 install
     ln -sf '$(PREFIX)/$(TARGET)/bin/freetype-config' '$(PREFIX)/bin/$(TARGET)-freetype-config'


### PR DESCRIPTION
Packages sfml and cegui fail to build because of this. libharfbuzz_too.a requires glibc and it must be repeated after it.

Here is the error message from sfml:

```
'i686-pc-mingw32.static-g++' -W -Wall -Werror -ansi -pedantic './src/sfml-test.cpp' -o '~/lib/mxe/usr/i686-pc-mingw32.static/bin/test-sfml.exe' `i686-pc-mingw32.static-pkg-config --cflags --libs sfml`
~/lib/mxe/usr/lib/gcc/i686-pc-mingw32.static/4.9.0/../../../../i686-pc-mingw32.static/lib/libharfbuzz_too.a(libharfbuzz_la-hb-glib.o): In function `hb_glib_unicode_script':
~/lib/mxe/tmp-harfbuzz-i686-pc-mingw32.static/harfbuzz-0.9.29/src/hb-glib.cc:236: undefined reference to `g_unichar_get_script'
~/lib/mxe/usr/lib/gcc/i686-pc-mingw32.static/4.9.0/../../../../i686-pc-mingw32.static/lib/libharfbuzz_too.a(libharfbuzz_la-hb-glib.o): In function `hb_glib_unicode_mirroring':
~/lib/mxe/tmp-harfbuzz-i686-pc-mingw32.static/harfbuzz-0.9.29/src/hb-glib.cc:227: undefined reference to `g_unichar_get_mirror_char'
~/lib/mxe/usr/lib/gcc/i686-pc-mingw32.static/4.9.0/../../../../i686-pc-mingw32.static/lib/libharfbuzz_too.a(libharfbuzz_la-hb-glib.o): In function `hb_glib_unicode_eastasian_width':
~/lib/mxe/tmp-harfbuzz-i686-pc-mingw32.static/harfbuzz-0.9.29/src/hb-glib.cc:209: undefined reference to `g_unichar_iswide'
~/lib/mxe/usr/lib/gcc/i686-pc-mingw32.static/4.9.0/../../../../i686-pc-mingw32.static/lib/libharfbuzz_too.a(libharfbuzz_la-hb-glib.o): In function `hb_glib_unicode_decompose_compatibility':
~/lib/mxe/tmp-harfbuzz-i686-pc-mingw32.static/harfbuzz-0.9.29/src/hb-glib.cc:343: undefined reference to `g_unichar_fully_decompose'
~/lib/mxe/usr/lib/gcc/i686-pc-mingw32.static/4.9.0/../../../../i686-pc-mingw32.static/lib/libharfbuzz_too.a(libharfbuzz_la-hb-glib.o): In function `hb_glib_unicode_decompose':
~/lib/mxe/tmp-harfbuzz-i686-pc-mingw32.static/harfbuzz-0.9.29/src/hb-glib.cc:284: undefined reference to `g_unichar_decompose'
~/lib/mxe/usr/lib/gcc/i686-pc-mingw32.static/4.9.0/../../../../i686-pc-mingw32.static/lib/libharfbuzz_too.a(libharfbuzz_la-hb-glib.o): In function `hb_glib_unicode_compose':
~/lib/mxe/tmp-harfbuzz-i686-pc-mingw32.static/harfbuzz-0.9.29/src/hb-glib.cc:247: undefined reference to `g_unichar_compose'
~/lib/mxe/usr/lib/gcc/i686-pc-mingw32.static/4.9.0/../../../../i686-pc-mingw32.static/lib/libharfbuzz_too.a(libharfbuzz_la-hb-glib.o): In function `hb_glib_script_to_script':
~/lib/mxe/tmp-harfbuzz-i686-pc-mingw32.static/harfbuzz-0.9.29/src/hb-glib.cc:164: undefined reference to `g_unicode_script_to_iso15924'
~/lib/mxe/usr/lib/gcc/i686-pc-mingw32.static/4.9.0/../../../../i686-pc-mingw32.static/lib/libharfbuzz_too.a(libharfbuzz_la-hb-glib.o): In function `hb_glib_unicode_general_category':
~/lib/mxe/tmp-harfbuzz-i686-pc-mingw32.static/harfbuzz-0.9.29/src/hb-glib.cc:219: undefined reference to `g_unichar_type'
~/lib/mxe/usr/lib/gcc/i686-pc-mingw32.static/4.9.0/../../../../i686-pc-mingw32.static/lib/libharfbuzz_too.a(libharfbuzz_la-hb-glib.o): In function `hb_glib_unicode_combining_class':
~/lib/mxe/tmp-harfbuzz-i686-pc-mingw32.static/harfbuzz-0.9.29/src/hb-glib.cc:201: undefined reference to `g_unichar_combining_class'
~/lib/mxe/usr/lib/gcc/i686-pc-mingw32.static/4.9.0/../../../../i686-pc-mingw32.static/lib/libharfbuzz_too.a(libharfbuzz_la-hb-glib.o): In function `hb_glib_script_to_script':
~/lib/mxe/tmp-harfbuzz-i686-pc-mingw32.static/harfbuzz-0.9.29/src/hb-glib.cc:164: undefined reference to `g_unicode_script_to_iso15924'
~/lib/mxe/usr/lib/gcc/i686-pc-mingw32.static/4.9.0/../../../../i686-pc-mingw32.static/lib/libharfbuzz_too.a(libharfbuzz_la-hb-glib.o): In function `hb_glib_script_from_script':
~/lib/mxe/tmp-harfbuzz-i686-pc-mingw32.static/harfbuzz-0.9.29/src/hb-glib.cc:180: undefined reference to `g_unicode_script_from_iso15924'
collect2: error: ld returned 1 exit status
make[1]: *** [build-only-sfml_i686-pc-mingw32.static] Error 1
make[1]: Leaving directory `~/lib/mxe'
```
