### PR TITLE
libmpcdec: make sure config/compile is present

### DIFF
--- a/src/libmpcdec.mk
+++ b/src/libmpcdec.mk
@@ -20,8 +20,6 @@ define $(PKG)_UPDATE
 endef
 
 define $(PKG)_BUILD
-    cd '$(1)' && aclocal
-    cd '$(1)' && libtoolize
     cd '$(1)' && autoreconf -fi
     cd '$(1)' && ./configure \
         $(MXE_CONFIGURE_OPTS)


### PR DESCRIPTION
Log: http://pastebin.com/mrfHrWhF

```
...
configure.ac:7: error: required file 'config/compile' not found
configure.ac:7:   'automake --add-missing' can install 'compile'
...
```
