### PR TITLE
add http mirrors to packages hosted at FTP

### DIFF
--- a/src/autoconf.mk
+++ b/src/autoconf.mk
@@ -7,7 +7,8 @@ $(PKG)_VERSION  := 2.69
 $(PKG)_CHECKSUM := e891c3193029775e83e0534ac0ee0c4c711f6d23
 $(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
 $(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.xz
-$(PKG)_URL      := ftp://ftp.gnu.org/pub/gnu/autoconf/$($(PKG)_FILE)
+$(PKG)_URL      := http://ftp.gnu.org/pub/gnu/autoconf/$($(PKG)_FILE)
+$(PKG)_URL_2    := ftp://ftp.gnu.org/pub/gnu/autoconf/$($(PKG)_FILE)
 $(PKG)_DEPS     := m4
 
 define $(PKG)_UPDATE

--- a/src/automake.mk
+++ b/src/automake.mk
@@ -7,7 +7,8 @@ $(PKG)_VERSION  := 1.13.2
 $(PKG)_CHECKSUM := 72ee9fcd180c54fd7c067155d85fa071a99c3ea3
 $(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
 $(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.gz
-$(PKG)_URL      := ftp://ftp.gnu.org/pub/gnu/automake/$($(PKG)_FILE)
+$(PKG)_URL      := http://ftp.gnu.org/pub/gnu/automake/$($(PKG)_FILE)
+$(PKG)_URL_2    := ftp://ftp.gnu.org/pub/gnu/automake/$($(PKG)_FILE)
 $(PKG)_DEPS     := autoconf
 
 define $(PKG)_UPDATE

--- a/src/binutils.mk
+++ b/src/binutils.mk
@@ -7,7 +7,7 @@ $(PKG)_VERSION  := 2.24
 $(PKG)_CHECKSUM := 7ac75404ddb3c4910c7594b51ddfc76d4693debb
 $(PKG)_SUBDIR   := binutils-$($(PKG)_VERSION)
 $(PKG)_FILE     := binutils-$($(PKG)_VERSION).tar.bz2
-$(PKG)_URL      := ftp://ftp.gnu.org/pub/gnu/binutils/$($(PKG)_FILE)
+$(PKG)_URL      := http://ftp.gnu.org/pub/gnu/binutils/$($(PKG)_FILE)
 $(PKG)_URL_2    := ftp://ftp.cs.tu-berlin.de/pub/gnu/binutils/$($(PKG)_FILE)
 $(PKG)_DEPS     := pkgconf
 

--- a/src/bison.mk
+++ b/src/bison.mk
@@ -7,7 +7,8 @@ $(PKG)_VERSION  := 2.7.1
 $(PKG)_CHECKSUM := 00ab1b32d864622077c311e4f5420d4e2931fdc8
 $(PKG)_SUBDIR   := bison-$($(PKG)_VERSION)
 $(PKG)_FILE     := bison-$($(PKG)_VERSION).tar.xz
-$(PKG)_URL      := ftp://ftp.gnu.org/pub/gnu/bison/$($(PKG)_FILE)
+$(PKG)_URL      := http://ftp.gnu.org/pub/gnu/bison/$($(PKG)_FILE)
+$(PKG)_URL_2    := ftp://ftp.gnu.org/pub/gnu/bison/$($(PKG)_FILE)
 $(PKG)_DEPS     := flex
 
 define $(PKG)_UPDATE

--- a/src/cloog.mk
+++ b/src/cloog.mk
@@ -7,7 +7,8 @@ $(PKG)_VERSION  := 0.18.1
 $(PKG)_CHECKSUM := 2dc70313e8e2c6610b856d627bce9c9c3f848077
 $(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
 $(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.gz
-$(PKG)_URL      := ftp://gcc.gnu.org/pub/gcc/infrastructure/$($(PKG)_FILE)
+$(PKG)_URL      := http://www.bastoul.net/cloog/pages/download/$($(PKG)_FILE)
+$(PKG)_URL_2    := ftp://gcc.gnu.org/pub/gcc/infrastructure/$($(PKG)_FILE)
 $(PKG)_DEPS     := gcc gmp isl
 
 # stick to tested versions from gcc

--- a/src/coreutils.mk
+++ b/src/coreutils.mk
@@ -7,7 +7,8 @@ $(PKG)_VERSION  := 8.22
 $(PKG)_CHECKSUM := cc7fe47b21eb49dd2ee4cdb707570f42fb2c8cc6
 $(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
 $(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.xz
-$(PKG)_URL      := ftp://ftp.gnu.org/pub/gnu/$(PKG)/$($(PKG)_FILE)
+$(PKG)_URL      := http://ftp.gnu.org/pub/gnu/$(PKG)/$($(PKG)_FILE)
+$(PKG)_URL_2    := ftp://ftp.gnu.org/pub/gnu/$(PKG)/$($(PKG)_FILE)
 $(PKG)_DEPS     := gettext gmp libiconv libtool
 
 define $(PKG)_UPDATE

--- a/src/file.mk
+++ b/src/file.mk
@@ -7,7 +7,8 @@ $(PKG)_VERSION  := 5.16
 $(PKG)_CHECKSUM := 12fd8ca35705bb24b00135ee65cb7de2d53aa69a
 $(PKG)_SUBDIR   := file-$($(PKG)_VERSION)
 $(PKG)_FILE     := file-$($(PKG)_VERSION).tar.gz
-$(PKG)_URL      := ftp://ftp.astron.com/pub/file/$($(PKG)_FILE)
+$(PKG)_URL      := http://ftp.cross-lfs.org/pub/clfs/conglomeration/file/$($(PKG)_FILE)
+$(PKG)_URL_2    := ftp://ftp.astron.com/pub/file/$($(PKG)_FILE)
 $(PKG)_DEPS     := gcc libgnurx
 
 define $(PKG)_UPDATE

--- a/src/freetds.mk
+++ b/src/freetds.mk
@@ -7,7 +7,8 @@ $(PKG)_VERSION  := 0.91
 $(PKG)_CHECKSUM := 3ab06c8e208e82197dc25d09ae353d9f3be7db52
 $(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
 $(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.gz
-$(PKG)_URL      := ftp://ftp.freetds.org/pub/$(PKG)/stable/$($(PKG)_FILE)
+$(PKG)_URL      := http://ftp.mirrorservice.org/sites/distfiles.finkmirrors.net/sha1/$($(PKG)_CHECKSUM)/$($(PKG)_FILE)
+$(PKG)_URL_2    := ftp://ftp.freetds.org/pub/$(PKG)/stable/$($(PKG)_FILE)
 $(PKG)_DEPS     := gcc libiconv gnutls
 
 define $(PKG)_UPDATE

--- a/src/gcc.mk
+++ b/src/gcc.mk
@@ -7,7 +7,7 @@ $(PKG)_VERSION  := 4.9.0
 $(PKG)_CHECKSUM := fbde8eb49f2b9e6961a870887cf7337d31cd4917
 $(PKG)_SUBDIR   := gcc-$($(PKG)_VERSION)
 $(PKG)_FILE     := gcc-$($(PKG)_VERSION).tar.bz2
-$(PKG)_URL      := ftp://ftp.gnu.org/pub/gnu/gcc/gcc-$($(PKG)_VERSION)/$($(PKG)_FILE)
+$(PKG)_URL      := http://ftp.gnu.org/pub/gnu/gcc/gcc-$($(PKG)_VERSION)/$($(PKG)_FILE)
 $(PKG)_URL_2    := ftp://ftp.mirrorservice.org/sites/sourceware.org/pub/gcc/releases/gcc-$($(PKG)_VERSION)/$($(PKG)_FILE)
 $(PKG)_DEPS     := binutils gcc-cloog gcc-gmp gcc-isl gcc-mpc gcc-mpfr
 

--- a/src/gdb.mk
+++ b/src/gdb.mk
@@ -6,7 +6,7 @@ $(PKG)_VERSION  := 7.7.1
 $(PKG)_CHECKSUM := 35228319f7c715074a80be42fff64c7645227a80
 $(PKG)_SUBDIR   := gdb-$($(PKG)_VERSION)
 $(PKG)_FILE     := gdb-$($(PKG)_VERSION).tar.bz2
-$(PKG)_URL      := ftp://ftp.gnu.org/pub/gnu/$(PKG)/$($(PKG)_FILE)
+$(PKG)_URL      := http://ftp.gnu.org/pub/gnu/$(PKG)/$($(PKG)_FILE)
 $(PKG)_URL_2    := ftp://ftp.cs.tu-berlin.de/pub/gnu/$(PKG)/$($(PKG)_FILE)
 $(PKG)_DEPS     := gcc expat libiconv pdcurses zlib
 

--- a/src/gettext.mk
+++ b/src/gettext.mk
@@ -7,7 +7,8 @@ $(PKG)_VERSION  := 0.19.1
 $(PKG)_CHECKSUM := 94cd6e81976aeb8ba35cf73967c60b72dd04af8d
 $(PKG)_SUBDIR   := gettext-$($(PKG)_VERSION)
 $(PKG)_FILE     := gettext-$($(PKG)_VERSION).tar.gz
-$(PKG)_URL      := ftp://ftp.gnu.org/pub/gnu/gettext/$($(PKG)_FILE)
+$(PKG)_URL      := http://ftp.gnu.org/pub/gnu/gettext/$($(PKG)_FILE)
+$(PKG)_URL_2    := ftp://ftp.gnu.org/pub/gnu/gettext/$($(PKG)_FILE)
 $(PKG)_DEPS     := gcc libiconv
 
 define $(PKG)_UPDATE

--- a/src/gmp.mk
+++ b/src/gmp.mk
@@ -7,7 +7,7 @@ $(PKG)_VERSION  := 6.0.0
 $(PKG)_CHECKSUM := 360802e3541a3da08ab4b55268c80f799939fddc
 $(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
 $(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION)a.tar.bz2
-$(PKG)_URL      := ftp://ftp.gmplib.org/pub/$(PKG)-$($(PKG)_VERSION)/$($(PKG)_FILE)
+$(PKG)_URL      := http://ftp.gnu.org/gnu/$(PKG)/$($(PKG)_FILE)
 $(PKG)_URL_2    := ftp://ftp.cs.tu-berlin.de/pub/gnu/$(PKG)/$($(PKG)_FILE)
 $(PKG)_DEPS     := gcc
 

--- a/src/gnutls.mk
+++ b/src/gnutls.mk
@@ -6,7 +6,8 @@ $(PKG)_VERSION  := 3.2.15
 $(PKG)_CHECKSUM := 31f289b48b0bf054f5f8c16d3b878615d0ae06fc
 $(PKG)_SUBDIR   := gnutls-$($(PKG)_VERSION)
 $(PKG)_FILE     := gnutls-$($(PKG)_VERSION).tar.xz
-$(PKG)_URL      := ftp://ftp.gnutls.org/gcrypt/gnutls/v3.2//$($(PKG)_FILE)
+$(PKG)_URL      := http://mirrors.dotsrc.org/gnupg/gnutls/v3.2/$($(PKG)_FILE)
+$(PKG)_URL_2    := ftp://ftp.gnutls.org/gcrypt/gnutls/v3.2//$($(PKG)_FILE)
 $(PKG)_DEPS     := gcc gettext gmp nettle pcre zlib
 
 define $(PKG)_UPDATE

--- a/src/gperf.mk
+++ b/src/gperf.mk
@@ -7,7 +7,8 @@ $(PKG)_VERSION  := 3.0.4
 $(PKG)_CHECKSUM := e32d4aff8f0c730c9a56554377b2c6d82d0951b8
 $(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
 $(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.gz
-$(PKG)_URL      := ftp://ftp.gnu.org/pub/gnu/$(PKG)/$($(PKG)_FILE)
+$(PKG)_URL      := http://ftp.gnu.org/pub/gnu/$(PKG)/$($(PKG)_FILE)
+$(PKG)_URL_2    := ftp://ftp.gnu.org/pub/gnu/$(PKG)/$($(PKG)_FILE)
 $(PKG)_DEPS     :=
 
 define $(PKG)_UPDATE

--- a/src/isl.mk
+++ b/src/isl.mk
@@ -7,7 +7,8 @@ $(PKG)_VERSION  := 0.12.2
 $(PKG)_CHECKSUM := ca98a91e35fb3ded10d080342065919764d6f928
 $(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
 $(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.bz2
-$(PKG)_URL      := ftp://gcc.gnu.org/pub/gcc/infrastructure/$($(PKG)_FILE)
+$(PKG)_URL      := http://isl.gforge.inria.fr/$($(PKG)_FILE)
+$(PKG)_URL_2    := ftp://gcc.gnu.org/pub/gcc/infrastructure/$($(PKG)_FILE)
 $(PKG)_DEPS     := gcc gmp
 
 # stick to tested versions from gcc

--- a/src/libbluray.mk
+++ b/src/libbluray.mk
@@ -7,7 +7,8 @@ $(PKG)_VERSION  := 0.5.0
 $(PKG)_CHECKSUM := 1a9c61daefc31438f9165e7681c563d0524b2d3e
 $(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
 $(PKG)_FILE     := $($(PKG)_SUBDIR).tar.bz2
-$(PKG)_URL      := ftp://ftp.videolan.org/pub/videolan/libbluray/$($(PKG)_VERSION)/$($(PKG)_FILE)
+$(PKG)_URL      := http://ftp.videolan.org/pub/videolan/libbluray/$($(PKG)_VERSION)/$($(PKG)_FILE)
+$(PKG)_URL_2    := ftp://ftp.videolan.org/pub/videolan/libbluray/$($(PKG)_VERSION)/$($(PKG)_FILE)
 $(PKG)_DEPS     := gcc freetype libxml2
 
 define $(PKG)_UPDATE

--- a/src/libffi.mk
+++ b/src/libffi.mk
@@ -7,7 +7,8 @@ $(PKG)_VERSION  := 3.0.13
 $(PKG)_CHECKSUM := f5230890dc0be42fb5c58fbf793da253155de106
 $(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
 $(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.gz
-$(PKG)_URL      := ftp://sourceware.org/pub/$(PKG)/$($(PKG)_FILE)
+$(PKG)_URL      := http://www.mirrorservice.org/sites/sourceware.org/pub/$(PKG)/$($(PKG)_FILE)
+$(PKG)_URL_2    := ftp://sourceware.org/pub/$(PKG)/$($(PKG)_FILE)
 $(PKG)_DEPS     := gcc
 
 define $(PKG)_UPDATE

--- a/src/libgcrypt.mk
+++ b/src/libgcrypt.mk
@@ -7,7 +7,8 @@ $(PKG)_VERSION  := 1.5.3
 $(PKG)_CHECKSUM := 2c6553cc17f2a1616d512d6870fe95edf6b0e26e
 $(PKG)_SUBDIR   := libgcrypt-$($(PKG)_VERSION)
 $(PKG)_FILE     := libgcrypt-$($(PKG)_VERSION).tar.bz2
-$(PKG)_URL      := ftp://ftp.gnupg.org/gcrypt/libgcrypt/$($(PKG)_FILE)
+$(PKG)_URL      := http://mirrors.dotsrc.org/gcrypt/libgcrypt/$($(PKG)_FILE)
+$(PKG)_URL_2    := ftp://ftp.gnupg.org/gcrypt/libgcrypt/$($(PKG)_FILE)
 $(PKG)_DEPS     := gcc libgpg_error
 
 define $(PKG)_UPDATE

--- a/src/libgpg_error.mk
+++ b/src/libgpg_error.mk
@@ -7,7 +7,8 @@ $(PKG)_VERSION  := 1.12
 $(PKG)_CHECKSUM := 259f359cd1440b21840c3a78e852afd549c709b8
 $(PKG)_SUBDIR   := libgpg-error-$($(PKG)_VERSION)
 $(PKG)_FILE     := libgpg-error-$($(PKG)_VERSION).tar.bz2
-$(PKG)_URL      := ftp://ftp.gnupg.org/gcrypt/libgpg-error/$($(PKG)_FILE)
+$(PKG)_URL      := http://mirrors.dotsrc.org/gcrypt/libgpg-error/$($(PKG)_FILE)
+$(PKG)_URL_2    := ftp://ftp.gnupg.org/gcrypt/libgpg-error/$($(PKG)_FILE)
 $(PKG)_DEPS     := gcc
 
 define $(PKG)_UPDATE

--- a/src/libidn.mk
+++ b/src/libidn.mk
@@ -7,7 +7,8 @@ $(PKG)_VERSION  := 1.28
 $(PKG)_CHECKSUM := 725587211b229c156e29fa2ad116b0ef71a7ca17
 $(PKG)_SUBDIR   := libidn-$($(PKG)_VERSION)
 $(PKG)_FILE     := libidn-$($(PKG)_VERSION).tar.gz
-$(PKG)_URL      := ftp://ftp.gnu.org/gnu/libidn/$($(PKG)_FILE)
+$(PKG)_URL      := http://ftp.gnu.org/gnu/libidn/$($(PKG)_FILE)
+$(PKG)_URL_2    := ftp://ftp.gnu.org/gnu/libidn/$($(PKG)_FILE)
 $(PKG)_DEPS     := gcc gettext libiconv
 
 define $(PKG)_UPDATE

--- a/src/libmicrohttpd.mk
+++ b/src/libmicrohttpd.mk
@@ -7,7 +7,8 @@ $(PKG)_VERSION  := 0.9.33
 $(PKG)_CHECKSUM := 75f53089ba86b5aa4e4eeb2579c47fed6ca63c72
 $(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
 $(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.gz
-$(PKG)_URL      := ftp://ftp.gnu.org/pub/gnu/libmicrohttpd/$($(PKG)_FILE)
+$(PKG)_URL      := http://ftp.gnu.org/pub/gnu/libmicrohttpd/$($(PKG)_FILE)
+$(PKG)_URL_2    := ftp://ftp.gnu.org/pub/gnu/libmicrohttpd/$($(PKG)_FILE)
 $(PKG)_DEPS     := gcc plibc pthreads
 
 define $(PKG)_UPDATE

--- a/src/libpng.mk
+++ b/src/libpng.mk
@@ -7,7 +7,8 @@ $(PKG)_VERSION  := 1.6.12
 $(PKG)_CHECKSUM := c3d54f9ab683d63218361487269380fb8e0cf3b6
 $(PKG)_SUBDIR   := libpng-$($(PKG)_VERSION)
 $(PKG)_FILE     := libpng-$($(PKG)_VERSION).tar.xz
-$(PKG)_URL      := ftp://ftp.simplesystems.org/pub/$(PKG)/png/src/libpng16/$($(PKG)_FILE)
+$(PKG)_URL      := http://downloads.sourceforge.net/project/libpng/libpng16/$($(PKG)_VERSION)/$($(PKG)_FILE)
+$(PKG)_URL_2    := ftp://ftp.simplesystems.org/pub/$(PKG)/png/src/libpng16/$($(PKG)_FILE)
 $(PKG)_DEPS     := gcc zlib
 
 define $(PKG)_UPDATE

--- a/src/libxml2.mk
+++ b/src/libxml2.mk
@@ -7,7 +7,8 @@ $(PKG)_VERSION  := 2.9.1
 $(PKG)_CHECKSUM := eb3e2146c6d68aea5c2a4422ed76fe196f933c21
 $(PKG)_SUBDIR   := libxml2-$($(PKG)_VERSION)
 $(PKG)_FILE     := libxml2-$($(PKG)_VERSION).tar.gz
-$(PKG)_URL      := ftp://xmlsoft.org/libxml2/$($(PKG)_FILE)
+$(PKG)_URL      := http://xmlsoft.org/sources/$($(PKG)_FILE)
+$(PKG)_URL_2    := ftp://xmlsoft.org/libxml2/$($(PKG)_FILE)
 $(PKG)_DEPS     := gcc xz
 
 define $(PKG)_UPDATE

--- a/src/libxslt.mk
+++ b/src/libxslt.mk
@@ -7,7 +7,8 @@ $(PKG)_VERSION  := 1.1.28
 $(PKG)_CHECKSUM := 4df177de629b2653db322bfb891afa3c0d1fa221
 $(PKG)_SUBDIR   := libxslt-$($(PKG)_VERSION)
 $(PKG)_FILE     := libxslt-$($(PKG)_VERSION).tar.gz
-$(PKG)_URL      := ftp://xmlsoft.org/libxslt/$($(PKG)_FILE)
+$(PKG)_URL      := http://xmlsoft.org/sources/$($(PKG)_FILE)
+$(PKG)_URL_2    := ftp://xmlsoft.org/libxslt/$($(PKG)_FILE)
 $(PKG)_DEPS     := gcc libxml2 libgcrypt
 
 define $(PKG)_UPDATE

--- a/src/m4.mk
+++ b/src/m4.mk
@@ -7,7 +7,8 @@ $(PKG)_VERSION  := 1.4.17
 $(PKG)_CHECKSUM := 74ad71fa100ec8c13bc715082757eb9ab1e4bbb0
 $(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
 $(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.xz
-$(PKG)_URL      := ftp://ftp.gnu.org/pub/gnu/m4/$($(PKG)_FILE)
+$(PKG)_URL      := http://ftp.gnu.org/pub/gnu/m4/$($(PKG)_FILE)
+$(PKG)_URL_2    := ftp://ftp.gnu.org/pub/gnu/m4/$($(PKG)_FILE)
 $(PKG)_DEPS     :=
 
 define $(PKG)_UPDATE

--- a/src/pthreads-w32.mk
+++ b/src/pthreads-w32.mk
@@ -7,7 +7,8 @@ $(PKG)_VERSION  := 2-9-1
 $(PKG)_CHECKSUM := 24d40e89c2e66a765733e8c98d6f94500343da86
 $(PKG)_SUBDIR   := pthreads-w32-$($(PKG)_VERSION)-release
 $(PKG)_FILE     := pthreads-w32-$($(PKG)_VERSION)-release.tar.gz
-$(PKG)_URL      := ftp://sourceware.org/pub/pthreads-win32/$($(PKG)_FILE)
+$(PKG)_URL      := http://download.videolan.org/contrib/$($(PKG)_FILE)
+$(PKG)_URL_2    := ftp://sourceware.org/pub/pthreads-win32/$($(PKG)_FILE)
 $(PKG)_DEPS     :=
 
 $(PKG)_DEPS_i686-pc-mingw32 := gcc

--- a/src/sed.mk
+++ b/src/sed.mk
@@ -7,7 +7,8 @@ $(PKG)_VERSION  := 4.2.2
 $(PKG)_CHECKSUM := f17ab6b1a7bcb2ad4ed125ef78948092d070de8f
 $(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
 $(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.bz2
-$(PKG)_URL      := ftp://ftp.gnu.org/pub/gnu/$(PKG)/$($(PKG)_FILE)
+$(PKG)_URL      := http://ftp.gnu.org/pub/gnu/$(PKG)/$($(PKG)_FILE)
+$(PKG)_URL_2    := ftp://ftp.gnu.org/pub/gnu/$(PKG)/$($(PKG)_FILE)
 $(PKG)_DEPS     := gettext libiconv
 
 define $(PKG)_UPDATE


### PR DESCRIPTION
see http://lists.nongnu.org/archive/html/mingw-cross-env-list/2014-07/msg00002.html

Many FTP servers block connections from Tor and some
VPN servers. HTTP servers don't do this normally.

Example of failed FTP download attempt of binutils-2.24.tar.bz:

```
$ torsocks wget ftp://ftp.gnu.org/pub/gnu/binutils/binutils-2.24.tar.bz2
   --2014-07-20 13:26:48-- ftp://ftp.gnu.org/pub/gnu/binutils/binutils-2.24.tar.bz2
   => `binutils-2.24.tar.bz2'
   Resolving ftp.gnu.org (ftp.gnu.org)... 208.118.235.20
   Connecting to ftp.gnu.org (ftp.gnu.org)|208.118.235.20|:21... connected.
   Logging in as anonymous ... Logged in!
   ==> SYST ... done.    ==> PWD ... done.
   ==> TYPE I ... done.  ==> CWD (1) /pub/gnu/binutils ... done.
   ==> SIZE binutils-2.24.tar.bz2 ... 22716802
   ==> PASV ... done.    ==> RETR binutils-2.24.tar.bz2 ...
   Error in server response, closing control connection.
   Retrying.
```

Same package was downloaded via HTTP successfully:

```
$ torsocks wget http://ftp.gnu.org/pub/gnu/binutils/binutils-2.24.tar.bz2
    --2014-07-20 13:32:37-- http://ftp.gnu.org/pub/gnu/binutils/binutils-2.24.tar.bz2
    Resolving ftp.gnu.org (ftp.gnu.org)... 208.118.235.20
    Connecting to ftp.gnu.org (ftp.gnu.org)|208.118.235.20|:80... connected.
    HTTP request sent, awaiting response... 200 OK
    Length: 22716802 (22M) [application/x-bzip2]
    Saving to: `binutils-2.24.tar.bz2'

    100%[=================>] 22,716,802   721K/s   in 24s

    2014-07-20 13:33:03 (915 KB/s) - `binutils-2.24.tar.bz2' saved [22716802/22716802]

Trying download from Tor Browser, I get error message:
425 Security: Bad IP connecting.
```

HTTP URLs were added to FTP URLs-only packages.
In many cases, ftp://ftp.gnu.org can be accessed
from http://ftp.gnu.org
If both URLs of a package are FTP, then one of them
was replaced with HTTP.

Command to check that those packages can be build successfully
if behind Tor:

```
$ torsocks make autoconf automake binutils bison cloog coreutils file freetds gcc gdb gettext gmp gnutls gperf isl libbluray libffi libgcrypt libgpg_error libidn libmicrohttpd libpng libxml2 libxslt m4 pthreads-w32 sed dcmtk mpfr
```

I've run the test above successfully.
