### PR TITLE
Rudix documentation update

### DIFF
--- a/index.html
+++ b/index.html
@@ -802,8 +802,8 @@ USE_OSGPLUGIN(&lt;plugin2&gt;)
     Install
     <a href="http://developer.apple.com/xcode/">Xcode 5</a>
     </p>
-    <h4 id="requirements-macos-step-1">Step 1</h3>
-    <h5 id="requirements-macos-method-1">Method 1 - MacPorts</h3>
+    <h4 id="requirements-macos-step-1">Step 1</h4>
+    <h5 id="requirements-macos-method-1">Method 1 - MacPorts</h5>
     <p>
     Install <a href="http://www.macports.org/">MacPorts</a>,
     then run:
@@ -811,7 +811,7 @@ USE_OSGPLUGIN(&lt;plugin2&gt;)
     <!-- http://www.macports.org/ports.php -->
     <pre>sudo port install \
     glib2 intltool p5-xml-parser gpatch scons wget xz</pre>
-    <h5 id="requirements-macos-method-2">Method 2 - Rudix</h3>
+    <h5 id="requirements-macos-method-2">Method 2 - Rudix</h5>
     <p>
     Install <a href="http://rudix.org/">Rudix</a> you can make it with following command
     </p>
@@ -821,7 +821,7 @@ USE_OSGPLUGIN(&lt;plugin2&gt;)
     then run:
     </p>
     <pre>sudo rudix install glib pkg-config scons wget xz</pre>
-    <h4 id="requirements-macos-step-2">Step 2</h3>
+    <h4 id="requirements-macos-step-2">Step 2</h4>
     <p>
     After installing pre-requirement run from within the mxe directory:
     </p>


### PR DESCRIPTION
I added alternative method for requirement if you don't like MacPorts Rudix has binary libraries.
I tried it on 3 different Mac's and it works well.
