### PR TITLE
Build QT with shared memory support

### DIFF
--- a/src/qt-2-dont-perform-ipc-checks-for-win32.patch
+++ b/src/qt-2-dont-perform-ipc-checks-for-win32.patch
@@ -1,0 +1,11 @@
+--- a/configure
++++ b/configure
+@@ -5313,7 +5313,7 @@
+ fi
+ 
+ # check IPC support
+-if [ "$XPLATFORM_SYMBIAN_SBSV2" = "no" ]; then
++if [ "$XPLATFORM_SYMBIAN_SBSV2" = "no" -a "$XPLATFORM_MINGW" = "no" ]; then
+     # Raptor does not support configure tests.
+     if ! compileTest unix/ipc_sysv "ipc_sysv" ; then
+         # SYSV IPC is not supported - check POSIX IPC


### PR DESCRIPTION
Include qt-dont-perform-ipc-checks-for-win32.patch from Fedora mingw-qt
package so that QT will be built with support for shared memory.  The
comment accompanying this patch is: "The configure script thinks that
there is no IPC/shared memory support for this platform, while there
is support. Fix the configure script"
