### PR TITLE
sdl_image: test failed to compile in x86_64-w64-mingw32.static target

### DIFF
--- a/src/sdl_image.mk
+++ b/src/sdl_image.mk
@@ -19,7 +19,7 @@ define $(PKG)_UPDATE
 endef
 
 define $(PKG)_BUILD
-    $(SED) -i 's,^\(Requires:.*\),\1 libtiff-4 libpng,' '$(1)/SDL_image.pc.in'
+    $(SED) -i 's,^\(Requires:.*\),\1 libtiff-4 libpng libwebp,' '$(1)/SDL_image.pc.in'
     cd '$(1)' && ./configure \
         --host='$(TARGET)' \
         --disable-shared \


### PR DESCRIPTION
fix package config file (without this test failed to compile at master branch in x86_64-w64-mingw32.static target)
