### PR TITLE
Add cmake sdl_sound script

### DIFF
--- a/src/cmake/FindSDL_sound.cmake
+++ b/src/cmake/FindSDL_sound.cmake
@@ -1,0 +1,12 @@
+if(NOT PKG_CONFIG_FOUND)
+  find_package(PkgConfig REQUIRED)
+endif()
+
+pkg_check_modules(SDL_SOUND SDL_sound)
+
+#compatiblity
+set(SDL_SOUND_VERSION_STRING ${SDL_SOUND_VERSION})
+set(SDL_SOUND_LIBRARIES ${SDL_SOUND_EXTRAS};${SDL_SOUND_LIBRARIES})
+
+# for backward compatiblity
+set(SDL_SOUND_LIBRARY ${SDL_SOUND_LIBRARIES})

--- a/src/sdl_sound-test-CMakeLists.txt
+++ b/src/sdl_sound-test-CMakeLists.txt
@@ -1,0 +1,10 @@
+project(18)
+cmake_minimum_required(VERSION 2.8)
+
+find_package(SDL_sound REQUIRED)
+
+include_directories(${SDL_SOUND_INCLUDE_DIRS})
+add_executable(sdl_sound_test
+  sdl_sound-test.c
+  )
+target_link_libraries(sdl_sound_test ${SDL_SOUND_LIBRARIES})

--- a/src/sdl_sound.mk
+++ b/src/sdl_sound.mk
@@ -57,6 +57,13 @@ define $(PKG)_BUILD
         -W -Wall -Werror -std=c99 -pedantic \
         '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-sdl_sound.exe' \
         `'$(TARGET)-pkg-config' $(PKG) --cflags --libs`
+        
+    mkdir -p '$(1)/cmake-build-test'
+    cp '$(2)-CMakeLists.txt' '$(1)/cmake-build-test/CMakeLists.txt'
+    cp '$(2).c' '$(1)/cmake-build-test/'
+    cd '$(1)/cmake-build-test' && cmake . \
+        -DCMAKE_TOOLCHAIN_FILE='$(CMAKE_TOOLCHAIN_FILE)'
+    $(MAKE) -C '$(1)/cmake-build-test' -j '$(JOBS)'
 endef
 
 $(PKG)_BUILD_SHARED =


### PR DESCRIPTION
Provides the find-package script for SDL_sound and adds a test as in sdl_image.
