### PR TITLE
add python script for recursive copy of DLL dependencies

### DIFF
--- a/tools/copydlldeps.py
+++ b/tools/copydlldeps.py
@@ -23,6 +23,8 @@ import struct
 import sys
 
 def is_pe_file(file):
+    if not os.path.isfile(file): # Skip directories
+        return False
     f = open(file, 'rb')
     if f.read(2) != b'MZ': 
         return False  # DOS magic number not present


### PR DESCRIPTION
You may be aware of a little python script that manages to parse PE header, extract DLL dependencies and copies the DLLs: https://github.com/performous/performous/blob/master/win32/mxe/copydlls.py

I think this script is very useful for shared builds with MXE to reduce deployment trouble for shared builds.

I modified it a little bit for commandline parsing and recursive dependency checking.

It's purpose is to fill a directory (targetdir) with DLLs you need to run your application.
`python copydlldeps.py -h` yields

```
usage: copydlldeps.py [-h] -C CHECKDIRS [CHECKDIRS ...] -L LIBDIRS
                      [LIBDIRS ...]
                      targetdir

Recursive copy of DLL dependencies

positional arguments:
  targetdir             target directory where to place the DLLs

optional arguments:
  -h, --help            show this help message and exit
  -C CHECKDIRS [CHECKDIRS ...], --checkdir CHECKDIRS [CHECKDIRS ...]
                        directories whose depencies must be fulfilled. All PE
                        files will be checked (mostly .exe and .dll files)
  -L LIBDIRS [LIBDIRS ...], --libdir LIBDIRS [LIBDIRS ...]
                        include directories to search for DLL dependencies
                        (only .dll files will be used from here)
```
