### PR TITLE
Added -IM4 to autoreconf for libsndfile.

### DIFF
--- a/src/libsndfile.mk
+++ b/src/libsndfile.mk
@@ -18,7 +18,7 @@ define $(PKG)_UPDATE
 endef
 
 define $(PKG)_BUILD
-    cd '$(1)' && autoreconf -fi
+    cd '$(1)' && autoreconf -fi -IM4
     cd '$(1)' && ./configure \
         $(MXE_CONFIGURE_OPTS) \
         --enable-sqlite \


### PR DESCRIPTION
On ubuntu 12.04 libsndfile fails to compile with the following error:

```
Failed to build package libsndfile!
------------------------------------------------------------
    See the Autoconf documentation.
configure.ac:291: error: possibly undefined macro: AC_OCTAVE_BUILD
configure.ac:311: error: possibly undefined macro: PKG_CHECK_MOD_VERSION
autoreconf: /usr/bin/autoconf failed with exit status: 1
make[1]: *** [build-only-libsndfile_i686-w64-mingw32.static] Error 1
make[1]: Leaving directory `/home/eivind/git/mxe'
real    0m8.879s
user    0m6.957s
sys 0m1.097s
```

It seems that autoreconf need to include the M4 directory to expand the two macros correctly.
