### PR TITLE
libftdi: Explicitly disable bindings and docs.

### DIFF
--- a/src/libftdi.mk
+++ b/src/libftdi.mk
@@ -23,7 +23,10 @@ define $(PKG)_BUILD
         --disable-shared \
         --enable-static \
         --prefix='$(PREFIX)/$(TARGET)' \
+        --disable-libftdipp \
+        --disable-python-binding \
         --without-examples \
+        --without-docs
         HAVELIBUSB=true
     $(MAKE) -C '$(1)' -j '$(JOBS)' install
 endef


### PR DESCRIPTION
Building the libftdi C++/Python bindings requires the (pretty large)
dependencies on boost/Python, so disable them for now.

Also disable unneeded documentation.

This fixes issue #572.
