### PR TITLE
luabind depends either on lua or on luajit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,10 @@ WGET       := wget --no-check-certificate \
                    --user-agent=$(shell wget --version | \
                    $(SED) -n 's,GNU \(Wget\) \([0-9.]*\).*,\1/\2,p')
 
+# Lua implementation used as dependency of other packages
+# e.g. luabind (possible values: lua or luajit)
+LUA        := lua
+
 REQUIREMENTS := autoconf automake autopoint bash bison bzip2 cmake flex \
                 gcc g++ gperf intltoolize $(LIBTOOL) $(LIBTOOLIZE) \
                 $(MAKE) openssl $(PATCH) $(PERL) python ruby scons \

--- a/src/luabind-1-cmakelists.patch
+++ b/src/luabind-1-cmakelists.patch
@@ -3,16 +3,16 @@ See index.html for further information.
 
 commit 9b4639e25442a3b6d0337d8e602a8332ec0e26e0
 Author: Boris Nagaev <bnagaev@gmail.com>
-Date:   Fri Aug 22 15:17:21 2014 +0400
+Date:   Mon Dec  8 00:28:20 2014 +0300
 
     CMakeLists.txt
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
 new file mode 100644
-index 0000000..acc47ae
+index 0000000..c0d2627
 --- /dev/null
 +++ b/CMakeLists.txt
-@@ -0,0 +1,29 @@
+@@ -0,0 +1,41 @@
 +cmake_minimum_required(VERSION 2.6)
 +project(luabind)
 +
@@ -20,9 +20,21 @@ index 0000000..acc47ae
 +FIND_PACKAGE(Boost 1.34 REQUIRED)
 +include_directories(${Boost_INCLUDE_DIRS})
 +
-+include(FindLua51)
-+find_package(Lua51 REQUIRED)
-+include_directories(${LUA_INCLUDE_DIR})
++option(USE_LUAJIT "Use LuaJIT instead of standard Lua" OFF)
++
++if (USE_LUAJIT)
++    find_path(LUAJIT_INCLUDE_DIR luajit.h
++        PATH_SUFFIXES include/luajit-2.0)
++    find_library(LUAJIT_LIBRARY
++        NAMES luajit luajit-5.1 luajit-5.2)
++    include_directories(${LUAJIT_INCLUDE_DIR})
++    set(LUA_LIB ${LUAJIT_LIBRARY})
++else ()
++    include(FindLua51)
++    find_package(Lua51 REQUIRED)
++    include_directories(${LUA_INCLUDE_DIR})
++    set(LUA_LIB ${LUA_LIBRARIES})
++endif ()
 +
 +include_directories(${PROJECT_SOURCE_DIR})
 +
@@ -35,7 +47,7 @@ index 0000000..acc47ae
 +
 +add_definitions(-DLUA_COMPAT_ALL)
 +
-+target_link_libraries(luabind ${LUA_LIBRARIES} luabind)
++target_link_libraries(luabind ${LUA_LIB})
 +
 +install(TARGETS luabind DESTINATION
 +        ${CMAKE_INSTALL_PREFIX}/lib)


### PR DESCRIPTION
Add new configuration option LUA, which
can be "lua" or "luajit" (by default, "lua").

This option is used currently only by package luabind.
Previously package luabind depended on lua.
Luabind built with Lua (5.2 for MXE) is
not binary compatible with LuaJIT (which is
binary compatible to Lua 5.1, not Lua 5.2).
That is why an application using luabind is to use
lua instead of luabind.

Currently the problem is solved.
Compile luabind against luajit:

```
$ make luabind LUA=luajit
```

and link your application against luajit andluabind.

To compile luabind against Lua (previous and currently
default behaviour):

```
$ make luabind LUA=lua
```

or just

```
$ make luabind
```

http://permalink.gmane.org/gmane.comp.gnu.mingw.cross-env/3691
