### PR TITLE
qtbase: Append Qt5 cmake dir to CMAKE_PREFIX_PATH.

### DIFF
--- a/src/qtbase.mk
+++ b/src/qtbase.mk
@@ -76,6 +76,10 @@ define $(PKG)_BUILD
         -I'$(1)/test-$(PKG)-pkgconfig' \
         `'$(TARGET)-pkg-config' Qt5Widgets --cflags --libs`
 
+    # setup cmake toolchain
+    $(SED) -i '/CMAKE_PREFIX_PATH/d' '$(CMAKE_TOOLCHAIN_FILE)'
+    echo 'set(CMAKE_PREFIX_PATH "$(PREFIX)/$(TARGET)/qt5" ${CMAKE_PREFIX_PATH})' >> '$(CMAKE_TOOLCHAIN_FILE)'
+
     # batch file to run test programs
     (printf 'set PATH=..\\lib;..\\qt5\\bin;..\\qt5\\lib;%%PATH%%\r\n'; \
      printf 'set QT_QPA_PLATFORM_PLUGIN_PATH=..\\qt5\\plugins\r\n'; \


### PR DESCRIPTION
This allows cmake-using programs to find Qt5 components.