### PR TITLE
mingw-w64: Use --enable-idl so widl can be used.

### DIFF
--- a/src/mingw-w64.mk
+++ b/src/mingw-w64.mk
@@ -22,7 +22,8 @@ define $(PKG)_BUILD_mingw-w64
     cd '$(1).headers-build' && '$(1)/mingw-w64-headers/configure' \
         --host='$(TARGET)' \
         --prefix='$(PREFIX)/$(TARGET)' \
-        --enable-sdk=all
+        --enable-sdk=all \
+        --enable-idl
     $(MAKE) -C '$(1).headers-build' install
 endef
 


### PR DESCRIPTION
Any attempt to generate headers for an idl that imports a "standard" idl
will fail if the respective idl files are not in the include path.

MingW-W64 copies the idl .h files but not the idl files unless --enable-idl
is used.