### PR TITLE
OpenCV: Fix paths and add shared support

### DIFF
--- a/src/opencv-2-fixes-cmake.patch
+++ b/src/opencv-2-fixes-cmake.patch
@@ -1,0 +1,70 @@
+This file is part of MXE.
+See index.html for further information.
+
+diff -ru a/cmake/OpenCVGenConfig.cmake b/cmake/OpenCVGenConfig.cmake
+--- a/cmake/OpenCVGenConfig.cmake	2014-10-01 08:33:36.000000000 +0100
++++ b/cmake/OpenCVGenConfig.cmake	2015-01-06 22:41:05.094464515 +0000
+@@ -137,8 +137,8 @@
+     install(FILES "${CMAKE_BINARY_DIR}/win-install/OpenCVConfig.cmake" DESTINATION "${OpenCV_INSTALL_BINARIES_PREFIX}lib" COMPONENT dev)
+     install(EXPORT OpenCVModules DESTINATION "${OpenCV_INSTALL_BINARIES_PREFIX}lib" FILE OpenCVModules${modules_file_suffix}.cmake COMPONENT dev)
+   else()
+-    install(FILES "${CMAKE_BINARY_DIR}/win-install/OpenCVConfig.cmake" DESTINATION "${OpenCV_INSTALL_BINARIES_PREFIX}staticlib" COMPONENT dev)
+-    install(EXPORT OpenCVModules DESTINATION "${OpenCV_INSTALL_BINARIES_PREFIX}staticlib" FILE OpenCVModules${modules_file_suffix}.cmake COMPONENT dev)
++    install(FILES "${CMAKE_BINARY_DIR}/win-install/OpenCVConfig.cmake" DESTINATION "${OpenCV_INSTALL_BINARIES_PREFIX}lib" COMPONENT dev)
++    install(EXPORT OpenCVModules DESTINATION "${OpenCV_INSTALL_BINARIES_PREFIX}lib" FILE OpenCVModules${modules_file_suffix}.cmake COMPONENT dev)
+   endif()
+   install(FILES "${CMAKE_BINARY_DIR}/win-install/OpenCVConfig-version.cmake" DESTINATION "${CMAKE_INSTALL_PREFIX}" COMPONENT dev)
+   install(FILES "${OpenCV_SOURCE_DIR}/cmake/OpenCVConfig.cmake" DESTINATION "${CMAKE_INSTALL_PREFIX}/" COMPONENT dev)
+diff -ru a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt	2014-10-01 08:33:36.000000000 +0100
++++ b/CMakeLists.txt	2015-01-06 22:31:50.118454434 +0000
+@@ -269,14 +269,7 @@
+   set(OPENCV_DOC_INSTALL_PATH share/OpenCV/doc)
+ endif()
+ 
+-if(WIN32)
+-  if(DEFINED OpenCV_RUNTIME AND DEFINED OpenCV_ARCH)
+-    set(OpenCV_INSTALL_BINARIES_PREFIX "${OpenCV_ARCH}/${OpenCV_RUNTIME}/")
+-  else()
+-    message(STATUS "Can't detect runtime and/or arch")
+-    set(OpenCV_INSTALL_BINARIES_PREFIX "")
+-  endif()
+-elseif(ANDROID)
++if(ANDROID)
+   set(OpenCV_INSTALL_BINARIES_PREFIX "sdk/native/")
+ else()
+   set(OpenCV_INSTALL_BINARIES_PREFIX "")
+@@ -310,12 +303,8 @@
+   set(LIBRARY_OUTPUT_PATH         "${OpenCV_BINARY_DIR}/lib")
+   set(3P_LIBRARY_OUTPUT_PATH      "${OpenCV_BINARY_DIR}/3rdparty/lib${LIB_SUFFIX}")
+   if(WIN32)
+-    if(OpenCV_STATIC)
+-      set(OPENCV_LIB_INSTALL_PATH   "${OpenCV_INSTALL_BINARIES_PREFIX}staticlib${LIB_SUFFIX}")
+-    else()
+-      set(OPENCV_LIB_INSTALL_PATH   "${OpenCV_INSTALL_BINARIES_PREFIX}lib${LIB_SUFFIX}")
+-    endif()
+-    set(OPENCV_3P_LIB_INSTALL_PATH  "${OpenCV_INSTALL_BINARIES_PREFIX}staticlib${LIB_SUFFIX}")
++    set(OPENCV_LIB_INSTALL_PATH   "${OpenCV_INSTALL_BINARIES_PREFIX}lib${LIB_SUFFIX}")
++    set(OPENCV_3P_LIB_INSTALL_PATH  "${OpenCV_INSTALL_BINARIES_PREFIX}lib${LIB_SUFFIX}")
+     set(OPENCV_SAMPLES_SRC_INSTALL_PATH    samples/native)
+   else()
+     set(OPENCV_LIB_INSTALL_PATH     lib${LIB_SUFFIX})
+@@ -339,15 +328,9 @@
+   set(OPENCV_INCLUDE_INSTALL_PATH ${OPENCV_INCLUDE_INSTALL_PATH}/opencv-${OPENCV_VERSION})
+ endif()
+ 
+-if(WIN32)
+-  # Postfix of DLLs:
+-  set(OPENCV_DLLVERSION "${OPENCV_VERSION_MAJOR}${OPENCV_VERSION_MINOR}${OPENCV_VERSION_PATCH}")
+-  set(OPENCV_DEBUG_POSTFIX d)
+-else()
+-  # Postfix of so's:
+-  set(OPENCV_DLLVERSION "")
+-  set(OPENCV_DEBUG_POSTFIX "")
+-endif()
++# Postfix of so's and DLLs:
++set(OPENCV_DLLVERSION "")
++set(OPENCV_DEBUG_POSTFIX "")
+ 
+ if(DEFINED CMAKE_DEBUG_POSTFIX)
+   set(OPENCV_DEBUG_POSTFIX "${CMAKE_DEBUG_POSTFIX}")

--- a/src/opencv-3-fixes-pkgconfig.patch
+++ b/src/opencv-3-fixes-pkgconfig.patch
@@ -1,0 +1,157 @@
+This file is part of MXE.
+See index.html for further information.
+
+This patch was commited to OpenCV's 2.4 branch and we should be able to drop
+it in the next point release.
+
+commit eceada586bbf18fc267e437522ec4f1f23ddc656
+Author: Samuel Martin <s.martin49@gmail.com>
+Date:   Fri Oct 3 00:32:40 2014 +0200
+
+    cmake/OpenCVGenPkgconfig.cmake: rework opencv.pc generation
+    
+    Using absolute path to locate the components in the "Libs:" field of the
+    *.pc can badly break cross-compilation, especially when building
+    statically linked objects.
+    
+    Indeed, pkg-config automatically replaces the '-I...' and '-L...' paths
+    when the PKG_CONFIG_SYSROOT_DIR and PKG_CONFIG_LIBDIR environment
+    variables are set [1]. This feature is very helpful and common in
+    cross-compilation framework like Buildroot [2,3].
+    
+    When there are absolute paths in the *.pc files, pkg-config won't be
+    able to do the path substitions for these paths when the afromentioned
+    environment variables are set.
+    In such case, since the prefix is the target one, not the sysroot one,
+    these libraries' abolute paths will point to:
+    - in the best case: a non-existing file (i.e. these files do not exists
+      on the host system;
+    - at worst: the host system's libraries. This will make the linking
+      failed because these host system's libraries will most likely not be
+      build for the target architecture [4].
+    
+    So, this patch replace the components' absolute paths by the form:
+      -L<libdir> -l<libname>
+    
+    This way, the linker will be able to resolve each dependency path,
+    whatever the kind of objects/build (shared object or static build) it
+    is dealing with.
+    
+    Note that for static link, the library order does matter [5]. The order
+    of the opencv components has been carefully chosen to comply with this
+    requirement.
+    
+    Fixes #3931
+    
+    [1] http://linux.die.net/man/1/pkg-config
+    [2] http://buildroot.org/
+    [3] http://git.buildroot.net/buildroot/tree/package/pkgconf/pkg-config.in
+    [4] http://autobuild.buildroot.net/results/e8a/e8a859276db34aff87ef181b0cce98916b0afc90/build-end.log
+    [5] http://stackoverflow.com/questions/45135/linker-order-gcc
+    
+    Signed-off-by: Samuel Martin <s.martin49@gmail.com>
+    
+    ---
+    Note: this patch properly applies on top of the master branch, though it
+          has been written on top of the 2.4 branch.
+
+diff --git a/cmake/OpenCVGenPkgconfig.cmake b/cmake/OpenCVGenPkgconfig.cmake
+index fa57db9..183c56d 100644
+--- a/cmake/OpenCVGenPkgconfig.cmake
++++ b/cmake/OpenCVGenPkgconfig.cmake
+@@ -8,10 +8,6 @@
+ #
+ # ${BIN_DIR}/unix-install/opencv.pc -> For use *with* "make install"
+ # -------------------------------------------------------------------------------------------
+-set(prefix      "${CMAKE_INSTALL_PREFIX}")
+-set(exec_prefix "\${prefix}")
+-set(libdir      "") #TODO: need link paths for OpenCV_EXTRA_COMPONENTS
+-set(includedir  "\${prefix}/${OPENCV_INCLUDE_INSTALL_PATH}")
+ 
+ if(CMAKE_BUILD_TYPE MATCHES "Release")
+   set(ocv_optkind OPT)
+@@ -35,42 +31,66 @@ ocv_list_reverse(OpenCV_LIB_COMPONENTS)
+ ocv_list_reverse(OpenCV_EXTRA_COMPONENTS)
+ 
+ #build the list of components
+-set(OpenCV_LIB_COMPONENTS_ "")
+-foreach(CVLib ${OpenCV_LIB_COMPONENTS})
+-  get_target_property(libpath ${CVLib} LOCATION_${CMAKE_BUILD_TYPE})
+-  get_filename_component(libname "${libpath}" NAME)
+ 
+-  if(INSTALL_TO_MANGLED_PATHS)
+-    set(libname "${libname}.${OPENCV_VERSION}")
+-  endif()
++# Note:
++#   when linking against static libraries, if libfoo depends on libbar, then
++#   libfoo must come first in the linker flags.
++
++# world is a special target whose library should come first, especially for
++# static link.
++if(OpenCV_LIB_COMPONENTS MATCHES "opencv_world")
++  list(REMOVE_ITEM OpenCV_LIB_COMPONENTS "opencv_world")
++  list(INSERT OpenCV_LIB_COMPONENTS 0 "opencv_world")
++endif()
++
++set(OpenCV_LIB_COMPONENTS_)
++foreach(CVLib ${OpenCV_LIB_COMPONENTS})
+ 
+-  #need better solution....
+-  if(libpath MATCHES "3rdparty")
+-    set(installDir "share/OpenCV/3rdparty/${OPENCV_LIB_INSTALL_PATH}")
++  get_target_property(libloc ${CVLib} LOCATION_${CMAKE_BUILD_TYPE})
++  if(libloc MATCHES "3rdparty")
++    set(libpath "\${exec_prefix}/share/OpenCV/3rdparty/${OPENCV_LIB_INSTALL_PATH}")
+   else()
+-    set(installDir "${OPENCV_LIB_INSTALL_PATH}")
++    set(libpath "\${exec_prefix}/${OPENCV_LIB_INSTALL_PATH}")
+   endif()
++  list(APPEND OpenCV_LIB_COMPONENTS_ "-L${libpath}")
++
++  get_filename_component(libname ${CVLib} NAME_WE)
++  string(REGEX REPLACE "^lib" "" libname "${libname}")
++  list(APPEND OpenCV_LIB_COMPONENTS_ "-l${libname}")
+ 
+-  set(OpenCV_LIB_COMPONENTS_ "${OpenCV_LIB_COMPONENTS_} \${exec_prefix}/${installDir}/${libname}")
+ endforeach()
+ 
+ # add extra dependencies required for OpenCV
+-set(OpenCV_LIB_COMPONENTS ${OpenCV_LIB_COMPONENTS_})
+ if(OpenCV_EXTRA_COMPONENTS)
+   foreach(extra_component ${OpenCV_EXTRA_COMPONENTS})
+ 
+-    if(extra_component MATCHES "^-[lL]" OR extra_component MATCHES "[\\/]")
+-      set(maybe_l_prefix "")
++    if(extra_component MATCHES "^-[lL]")
++      set(libprefix "")
++      set(libname "${extra_component}")
++    elseif(extra_component MATCHES "[\\/]")
++      get_filename_component(libdir "${extra_component}" PATH)
++      list(APPEND OpenCV_LIB_COMPONENTS_ "-L${libdir}")
++      get_filename_component(libname "${extra_component}" NAME_WE)
++      string(REGEX REPLACE "^lib" "" libname "${libname}")
++      set(libprefix "-l")
+     else()
+-      set(maybe_l_prefix "-l")
++      set(libprefix "-l")
++      set(libname "${extra_component}")
+     endif()
+-
+-    set(OpenCV_LIB_COMPONENTS "${OpenCV_LIB_COMPONENTS} ${maybe_l_prefix}${extra_component}")
++    list(APPEND OpenCV_LIB_COMPONENTS_ "${libprefix}${libname}")
+ 
+   endforeach()
+ endif()
+ 
++list(REMOVE_DUPLICATES OpenCV_LIB_COMPONENTS_)
++string(REPLACE ";" " " OpenCV_LIB_COMPONENTS "${OpenCV_LIB_COMPONENTS_}")
++
+ #generate the .pc file
++set(prefix      "${CMAKE_INSTALL_PREFIX}")
++set(exec_prefix "\${prefix}")
++set(libdir      "\${exec_prefix}/${OPENCV_LIB_INSTALL_PATH}")
++set(includedir  "\${prefix}/${OPENCV_INCLUDE_INSTALL_PATH}")
++
+ if(INSTALL_TO_MANGLED_PATHS)
+   set(OPENCV_PC_FILE_NAME "opencv-${OPENCV_VERSION}.pc")
+ else()

--- a/src/opencv.mk
+++ b/src/opencv.mk
@@ -27,7 +27,7 @@ define $(PKG)_BUILD
       -DWITH_GTK=OFF \
       -DWITH_VIDEOINPUT=ON \
       -DWITH_XINE=OFF \
-      -DBUILD_SHARED_LIBS=OFF \
+      -DBUILD_SHARED_LIBS=$(if $(BUILD_STATIC),OFF,ON) \
       -DBUILD_opencv_apps=OFF \
       -DBUILD_DOCS=OFF \
       -DBUILD_EXAMPLES=OFF \
@@ -63,5 +63,3 @@ define $(PKG)_BUILD
         '$(1)/samples/c/fback_c.c' -o '$(PREFIX)/$(TARGET)/bin/test-opencv.exe' \
         `'$(TARGET)-pkg-config' opencv --cflags --libs`
 endef
-
-$(PKG)_BUILD_SHARED =


### PR DESCRIPTION
Tested with x86_64-w64-mingw32.static and x86_64-w64-mingw32.shared.

Cherrypicks an upstream commit that cleanups the pkg-config file.
Also removes the version postfix on Windows dll's (matching other platforms).

These changes allows us to easilly support shared builds.
Removing the postfix avoids breaking programs that only link
to a subset of opencv modules, everytime a new version is released.

It should be noted that OpenCV forces static linking of libopencv_ts.
There are also 3 files that are left at usr/<triplet>/ that this commit does not
attempt to fix (LICENSE, OpenCVConfig.cmake and OpenCVConfig-version.cmake).

They cannot be moved to lib/ because a different OpenCVConfig.cmake is placed
there. On Ubuntu, for example, those cmake files are in /usr/share/OpenCV/.