### PR TITLE
Add libepoxy

### DIFF
--- a/index.html
+++ b/index.html
@@ -2522,6 +2522,10 @@ local-pkg-list: $(LOCAL_PKG_LIST)</pre>
         <td class="website"><a href="http://sourceforge.net/projects/xmlwrapp/">xmlwrapp</a></td>
     </tr>
     <tr>
+        <td class="package">xorg-macros</td>
+        <td class="website"><a href="http://cgit.freedesktop.org/xorg/util/macros/">X.org utility macros</a></td>
+    </tr>
+    <tr>
         <td class="package">xvidcore</td>
         <td class="website"><a href="http://www.xvid.org/">xvidcore</a></td>
     </tr>

--- a/index.html
+++ b/index.html
@@ -1634,6 +1634,10 @@ local-pkg-list: $(LOCAL_PKG_LIST)</pre>
         <td class="website"><a href="https://dvdnav.mplayerhq.hu/">libdvdread</a></td>
     </tr>
     <tr>
+        <td class="package">libepoxy</td>
+        <td class="website"><a href="https://github.com/anholt/libepoxy">libepoxy</a></td>
+    </tr>
+    <tr>
         <td class="package">libevent</td>
         <td class="website"><a href="http://libevent.org/">libevent</a></td>
     </tr>

--- a/src/libepoxy.mk
+++ b/src/libepoxy.mk
@@ -1,0 +1,24 @@
+# This file is part of MXE.
+# See index.html for further information.
+
+PKG             := libepoxy
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 1.2
+$(PKG)_CHECKSUM := e700520711b9e4fa07c286aa36e431d8ad4133f5
+$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
+$(PKG)_FILE     := $($(PKG)_SUBDIR).tar.gz
+$(PKG)_GITHUB   := https://github.com/anholt/$(PKG)
+$(PKG)_URL      := $($(PKG)_GITHUB)/archive/v$($(PKG)_VERSION).tar.gz
+$(PKG)_DEPS     := gcc xorg-macros
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- '$(libepoxy_GITHUB)/releases' | \
+    $(SED) -n 's,.*/archive/v\([0-9.]*\)\.tar.*,\1,p' | \
+    head -1
+endef
+
+define $(PKG)_BUILD
+    cd '$(1)' && autoreconf -fi -I'$(PREFIX)/$(TARGET)/share/aclocal' \
+      && ./configure $(MXE_CONFIGURE_OPTS)
+    $(MAKE) -C '$(1)' -j '$(JOBS)' install $(MXE_DISABLE_CRUFT)
+endef

--- a/src/xorg-macros.mk
+++ b/src/xorg-macros.mk
@@ -1,0 +1,23 @@
+# This file is part of MXE.
+# See index.html for further information.
+
+PKG             := xorg-macros
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 1.19.0
+$(PKG)_CHECKSUM := 00cfc636694000112924198e6b9e4d72f1601338
+$(PKG)_SUBDIR   := util-macros-$($(PKG)_VERSION)
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.bz2
+$(PKG)_URL      := http://xorg.freedesktop.org/releases/individual/util/util-macros-$($(PKG)_VERSION).tar.bz2
+$(PKG)_DEPS     :=
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- 'http://cgit.freedesktop.org/xorg/util/macros/refs/tags' | \
+    $(SED) -n "s,.*<a href='[^']*/tag/?id=util-macros-\\([0-9.]*\\)'.*,\\1,p" | \
+    $(SORT) -V | \
+    tail -1
+endef
+
+define $(PKG)_BUILD
+    cd '$(1)' && ./configure $(MXE_CONFIGURE_OPTS)
+    $(MAKE) -C '$(1)' -j '$(JOBS)' install pkgconfigdir='$$(libdir)/pkgconfig'
+endef


### PR DESCRIPTION
This adds libepoxy (and the required xorg-macros), a modern alternative to GLEW.

PS: I noticed that there are many packages with quite similar $(PKG)_UPDATE parts, for example many github projects. Would it be a good idea to create some common templates for these cases?