### PR TITLE
Make glib run on WinXP again

### DIFF
--- a/src/glib.mk
+++ b/src/glib.mk
@@ -89,8 +89,7 @@ define $(PKG)_BUILD
         PKG_CONFIG='$(PREFIX)/bin/$(TARGET)-pkg-config' \
         GLIB_GENMARSHAL='$(PREFIX)/$(TARGET)/bin/glib-genmarshal' \
         GLIB_COMPILE_SCHEMAS='$(PREFIX)/$(TARGET)/bin/glib-compile-schemas' \
-        GLIB_COMPILE_RESOURCES='$(PREFIX)/$(TARGET)/bin/glib-compile-resources' \
-        $(if $(findstring w64-mingw32,$(TARGET)),  CFLAGS="-DHAVE_IF_NAMETOINDEX=1")
+        GLIB_COMPILE_RESOURCES='$(PREFIX)/$(TARGET)/bin/glib-compile-resources'
     $(MAKE) -C '$(1)/glib'    -j '$(JOBS)' install sbin_PROGRAMS= noinst_PROGRAMS=
     $(MAKE) -C '$(1)/gmodule' -j '$(JOBS)' install bin_PROGRAMS= sbin_PROGRAMS= noinst_PROGRAMS=
     $(MAKE) -C '$(1)/gthread' -j '$(JOBS)' install bin_PROGRAMS= sbin_PROGRAMS= noinst_PROGRAMS=

--- a/src/mingw-w64-2-netioapi-winxp.patch
+++ b/src/mingw-w64-2-netioapi-winxp.patch
@@ -1,0 +1,29 @@
+This file is part of MXE.
+See index.html for further information.
+
+Some functions in netioapi.h were only added in Windows Vista. This patch removes
+function definitions for if_nametoindex and if_indextoname on older API
+versions, so they don't conflict with replacement implementations in libraries
+(e.g. glib).
+
+This is fixed on the 4.x branch of mingw-w64.
+
+diff -Naur mingw-w64-v3.3.0.orig/mingw-w64-headers/include/netioapi.h mingw-w64-v3.3.0/mingw-w64-headers/include/netioapi.h
+--- mingw-w64-v3.3.0.orig/mingw-w64-headers/include/netioapi.h	2015-01-17 00:07:51.030935703 +0100
++++ mingw-w64-v3.3.0/mingw-w64-headers/include/netioapi.h	2015-01-17 01:09:47.546591536 +0100
+@@ -311,6 +311,7 @@
+   PNET_LUID InterfaceLuid
+ );
+ 
++#if (_WIN32_WINNT >= 0x0600)
+ PCHAR WINAPI if_indextoname(
+   NET_IFINDEX InterfaceIndex,
+   PCHAR InterfaceName
+@@ -319,6 +320,7 @@
+ NET_IFINDEX WINAPI if_nametoindex(
+   PCSTR InterfaceName
+ );
++#endif
+ 
+ NETIO_STATUS WINAPI ConvertInterfaceGuidToLuid(
+   const GUID *InterfaceGuid,


### PR DESCRIPTION
Recently, a Performous user notified me that Performous does not run under Windows XP anymore, because the function if_nametoindex was not found in iphlpapi.dll. This happens because glib in MXE is build in a way to use the system if_nametoindex instead of its own replacement.

This branch tries to fix that. Part of the reason why compilation of glib failed is a conflicting definition of if_nametoindex in the mingw-w64 headers and glib sources. I checked with mingw-w64 upstream and their trunk has this fixed: If the API version is lower then Vista, those functions are not exposed and there is no conflict in glib.

Unfortunately, the structure of those header files changed very much in mingw-w64 trunk, so cherry-picking patches is not really possible. Therefore, since this will be fixed eventually, this patch uses the minimal-invasive way: It only protects if_nametoindex and if_indextoname (because I know those are missing on Windows XP) and makes glib compile and run correctly.

This patch can be removed again when mingw-w64 is updated to 4.0...