### PR TITLE
Readline: fix runtime problems

### DIFF
--- a/index.html
+++ b/index.html
@@ -2410,6 +2410,10 @@ local-pkg-list: $(LOCAL_PKG_LIST)</pre>
         <td class="website"><a href="http://teem.sourceforge.net/">Teem</a></td>
     </tr>
     <tr>
+        <td class="package">termcap</td>
+        <td class="website"><a href="https://www.gnu.org/software/termutils/">Termcap</a></td>
+    </tr>
+    <tr>
         <td class="package">theora</td>
         <td class="website"><a href="http://theora.org/">Theora</a></td>
     </tr>

--- a/src/gta.mk
+++ b/src/gta.mk
@@ -3,8 +3,8 @@
 
 PKG             := gta
 $(PKG)_IGNORE   :=
-$(PKG)_VERSION  := 1.0.5
-$(PKG)_CHECKSUM := 7fdca4a37c6f1617952c69b5aac370fed2f00e41
+$(PKG)_VERSION  := 1.0.7
+$(PKG)_CHECKSUM := e0feb2a9cce6c9658fd9e92870d83d1275435800
 $(PKG)_SUBDIR   := libgta-$($(PKG)_VERSION)
 $(PKG)_FILE     := libgta-$($(PKG)_VERSION).tar.xz
 $(PKG)_URL      := http://download.savannah.gnu.org/releases/gta/$($(PKG)_FILE)

--- a/src/pfstools-test.cpp
+++ b/src/pfstools-test.cpp
@@ -1,0 +1,20 @@
+/*
+ * This file is part of MXE.
+ * See index.html for further information.
+ */
+
+#include <pfs/pfs.h>
+
+int main(int argc, char *argv[])
+{
+    pfs::DOMIO pfsio;
+    pfs::Frame* frame;
+
+    (void)argc;
+    (void)argv;
+
+    frame = pfsio.createFrame(10, 10);
+    pfsio.freeFrame(frame);
+
+    return 0;
+}

--- a/src/pfstools.mk
+++ b/src/pfstools.mk
@@ -3,10 +3,10 @@
 
 PKG             := pfstools
 $(PKG)_IGNORE   :=
-$(PKG)_VERSION  := 1.9.1
-$(PKG)_CHECKSUM := d89ca4ea501ba9569b36ce9497aff1194e93ebee
+$(PKG)_VERSION  := 2.0.0
+$(PKG)_CHECKSUM := 1501b58d0014a9e92e6e2b7b8829b3f015204b29
 $(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
-$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.gz
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tgz
 $(PKG)_URL      := http://$(SOURCEFORGE_MIRROR)/project/$(PKG)/$(PKG)/$($(PKG)_VERSION)/$($(PKG)_FILE)
 $(PKG)_DEPS     := gcc
 
@@ -16,23 +16,30 @@ define $(PKG)_UPDATE
     head -1
 endef
 
+# Note: all the external dependencies are used for the tools, but we
+# only want the library so we don't need them.
 define $(PKG)_BUILD
-    cd '$(1)' && ./configure \
-        --host='$(TARGET)' \
-        --prefix='$(PREFIX)/$(TARGET)' \
-        --disable-shared \
-        --disable-netpbm \
-        --disable-openexr \
-        --disable-tiff \
-        --disable-qt \
-        --disable-jpeghdr \
-        --disable-imagemagick \
-        --disable-octave \
-        --disable-opengl \
-        --disable-matlab \
-        --disable-gdal
-    $(MAKE) -C '$(1)'/src/pfs -j '$(JOBS)'
-    $(MAKE) -C '$(1)'/src/pfs -j 1 install
+    mkdir '$(1).build'
+    cd '$(1).build' && cmake '$(1)' \
+        -DCMAKE_TOOLCHAIN_FILE='$(CMAKE_TOOLCHAIN_FILE)' \
+        -DPKG_CONFIG_EXECUTABLE='$(PREFIX)/bin/$(TARGET)-pkg-config' \
+        -DWITH_OpenEXR=false \
+        -DWITH_ImageMagick=false \
+        -DWITH_NetPBM=false \
+        -DWITH_TIFF=false \
+        -DWITH_QT=false \
+        -DWITH_pfsglview=false \
+        -DWITH_MATLAB=false \
+        -DWITH_Octave=false \
+        -DWITH_FFTW=false \
+        -DWITH_GSL=false \
+        -DWITH_OpenCV=false
+    $(MAKE) -C '$(1).build/src/pfs' -j '$(JOBS)' install VERBOSE=1
+
+    '$(TARGET)-g++' \
+        -Wall -Wextra -Werror \
+        '$(2).cpp' -o '$(PREFIX)/$(TARGET)/bin/test-pfstools.exe' \
+        `'$(TARGET)-pkg-config' pfs --cflags --libs`
 endef
 
 $(PKG)_BUILD_SHARED =

--- a/src/readline.mk
+++ b/src/readline.mk
@@ -8,7 +8,7 @@ $(PKG)_CHECKSUM := 017b92dc7fd4e636a2b5c9265a77ccc05798c9e1
 $(PKG)_SUBDIR   := readline-$($(PKG)_VERSION)
 $(PKG)_FILE     := readline-$($(PKG)_VERSION).tar.gz
 $(PKG)_URL      := http://ftp.gnu.org/gnu/readline/$($(PKG)_FILE)
-$(PKG)_DEPS     := gcc pdcurses
+$(PKG)_DEPS     := gcc termcap
 
 define $(PKG)_UPDATE
     $(WGET) -q -O- 'http://tiswww.case.edu/php/chet/readline/rltop.html' | \
@@ -23,7 +23,6 @@ define $(PKG)_BUILD
         $(MXE_CONFIGURE_OPTS) \
         --enable-multibyte \
         --without-purify \
-        --with-curses \
-        LIBS='-lcurses'
-    $(MAKE) -C '$(1)' -j '$(JOBS)' install $(if $(BUILD_STATIC),SHARED_LIBS=,SHLIB_LIBS='-lcurses')
+        --without-curses
+    $(MAKE) -C '$(1)' -j '$(JOBS)' install
 endef

--- a/src/termcap.mk
+++ b/src/termcap.mk
@@ -1,0 +1,20 @@
+# This file is part of MXE.
+# See index.html for further information.
+
+PKG             := termcap
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 1.3.1
+$(PKG)_CHECKSUM := 42dd1e6beee04f336c884f96314f0c96cc2578be
+$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.gz
+$(PKG)_URL      := http://ftp.gnu.org/gnu/termcap/$($(PKG)_FILE)
+$(PKG)_DEPS     := gcc
+
+define $(PKG)_UPDATE
+    /bin/false
+endef
+
+define $(PKG)_BUILD
+    cd '$(1)' && autoreconf -fi && ./configure $(MXE_CONFIGURE_OPTS)
+    $(MAKE) -C '$(1)' -j '$(JOBS)' install oldincludedir=
+endef


### PR DESCRIPTION
An application using readline currently experiences runtime
problems. For example, backspace does not work. This is because
pdcurses, which readline currently uses to get information about a
terminal, does not really implement tgetent() and friends; they are only
stubs. Google "pdcurses readline backspace" for more information.

First I tried using ncurses instead, but then the application crashes.
I did not try to debug.

I simply added libtermcap and made readline use that. Yes, it is
ancient, but it works fine...