### PR TITLE
Add package termcap, and make readline use it instead of pdcurses.

### DIFF
--- a/index.html
+++ b/index.html
@@ -2410,6 +2410,10 @@ local-pkg-list: $(LOCAL_PKG_LIST)</pre>
         <td class="website"><a href="http://teem.sourceforge.net/">Teem</a></td>
     </tr>
     <tr>
+        <td class="package">termcap</td>
+        <td class="website"><a href="https://www.gnu.org/software/termutils/">Termcap</a></td>
+    </tr>
+    <tr>
         <td class="package">theora</td>
         <td class="website"><a href="http://theora.org/">Theora</a></td>
     </tr>

--- a/src/readline.mk
+++ b/src/readline.mk
@@ -8,7 +8,7 @@ $(PKG)_CHECKSUM := 017b92dc7fd4e636a2b5c9265a77ccc05798c9e1
 $(PKG)_SUBDIR   := readline-$($(PKG)_VERSION)
 $(PKG)_FILE     := readline-$($(PKG)_VERSION).tar.gz
 $(PKG)_URL      := http://ftp.gnu.org/gnu/readline/$($(PKG)_FILE)
-$(PKG)_DEPS     := gcc pdcurses
+$(PKG)_DEPS     := gcc termcap
 
 define $(PKG)_UPDATE
     $(WGET) -q -O- 'http://tiswww.case.edu/php/chet/readline/rltop.html' | \
@@ -23,7 +23,6 @@ define $(PKG)_BUILD
         $(MXE_CONFIGURE_OPTS) \
         --enable-multibyte \
         --without-purify \
-        --with-curses \
-        LIBS='-lcurses'
-    $(MAKE) -C '$(1)' -j '$(JOBS)' install $(if $(BUILD_STATIC),SHARED_LIBS=,SHLIB_LIBS='-lcurses')
+        --without-curses
+    $(MAKE) -C '$(1)' -j '$(JOBS)' install
 endef

--- a/src/termcap.mk
+++ b/src/termcap.mk
@@ -1,0 +1,20 @@
+# This file is part of MXE.
+# See index.html for further information.
+
+PKG             := termcap
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 1.3.1
+$(PKG)_CHECKSUM := 42dd1e6beee04f336c884f96314f0c96cc2578be
+$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.gz
+$(PKG)_URL      := http://ftp.gnu.org/gnu/termcap/$($(PKG)_FILE)
+$(PKG)_DEPS     := gcc
+
+define $(PKG)_UPDATE
+    /bin/false
+endef
+
+define $(PKG)_BUILD
+    cd '$(1)' && autoreconf -fi && ./configure $(MXE_CONFIGURE_OPTS)
+    $(MAKE) -C '$(1)' -j '$(JOBS)' install oldincludedir=
+endef


### PR DESCRIPTION
This fixes runtime problems with applications using readline.
For example, backspace does not work. This is because
pdcurses, which readline currently uses to get information about a
terminal, does not really implement tgetent() and friends; they are only
stubs. Google "pdcurses readline backspace" for more information.

First I tried using ncurses instead, but then the application crashes.
I did not try to debug.

I simply added libtermcap and made readline use that. Yes, it is
ancient, but it works fine...