### PR TITLE
Fix 64 bit build of various packages

### DIFF
--- a/src/dcmtk.mk
+++ b/src/dcmtk.mk
@@ -30,6 +30,7 @@ define $(PKG)_BUILD
         --with-zlib \
         --without-libwrap \
         CXX='$(TARGET)-g++' \
+        CXXFLAGS="-fpermissive" \
         RANLIB='$(TARGET)-ranlib' \
         AR='$(TARGET)-ar' \
         ARFLAGS=cru \
@@ -37,7 +38,5 @@ define $(PKG)_BUILD
         ac_cv_my_c_rightshift_unsigned=no
     $(MAKE) -C '$(1)' -j '$(JOBS)' install-lib
 endef
-
-$(PKG)_BUILD_x86_64-w64-mingw32 =
 
 $(PKG)_BUILD_SHARED =

--- a/src/gdal.mk
+++ b/src/gdal.mk
@@ -19,7 +19,7 @@ define $(PKG)_UPDATE
     head -1
 endef
 
-define $(PKG)_CONFIGURE
+define $(PKG)_BUILD
     cd '$(1)' && autoreconf -fi
     # The option '--without-threads' means native win32 threading without pthread.
     cd '$(1)' && ./configure \
@@ -44,7 +44,9 @@ define $(PKG)_CONFIGURE
         --with-expat='$(PREFIX)/$(TARGET)' \
         --with-sqlite3='$(PREFIX)/$(TARGET)' \
         --with-gta='$(PREFIX)/$(TARGET)' \
+        --with-hdf4='$(PREFIX)/$(TARGET)' \
         --with-hdf5='$(PREFIX)/$(TARGET)' \
+        --with-netcdf='$(PREFIX)/$(TARGET)' \
         --with-libjson-c='$(PREFIX)/$(TARGET)' \
         --without-odbc \
         --without-xerces \
@@ -72,35 +74,18 @@ define $(PKG)_CONFIGURE
         --without-perl \
         --without-php \
         --without-ruby \
-        --without-python
-endef
-
-define $(PKG)_MAKE
-    $(MAKE) -C '$(1)'       -j '$(JOBS)' lib-target
-    $(MAKE) -C '$(1)'       -j '$(JOBS)' install-lib
-    $(MAKE) -C '$(1)/port'  -j '$(JOBS)' install
-    $(MAKE) -C '$(1)/gcore' -j '$(JOBS)' install
-    $(MAKE) -C '$(1)/frmts' -j '$(JOBS)' install
-    $(MAKE) -C '$(1)/alg'   -j '$(JOBS)' install
-    $(MAKE) -C '$(1)/ogr'   -j '$(JOBS)' install OGR_ENABLED=
-    $(MAKE) -C '$(1)/apps'  -j '$(JOBS)' install BIN_LIST=
-    ln -sf '$(PREFIX)/$(TARGET)/bin/gdal-config' '$(PREFIX)/bin/$(TARGET)-gdal-config'
-endef
-
-define $(PKG)_BUILD_x86_64-w64-mingw32
-    $($(PKG)_CONFIGURE) \
-        LIBS="-ljpeg -lsecur32 `'$(TARGET)-pkg-config' --libs openssl libtiff-4`"
-    $($(PKG)_MAKE)
-endef
-
-define $(PKG)_BUILD_i686-w64-mingw32
-    $($(PKG)_CONFIGURE) \
-        --with-netcdf='$(PREFIX)/$(TARGET)' \
+        --without-python \
+        CPPFLAGS="-DH4_BUILT_AS_STATIC_LIB=1" \
         LIBS="-ljpeg -lsecur32 -lportablexdr `'$(TARGET)-pkg-config' --libs openssl libtiff-4`"
-    $($(PKG)_MAKE)
+        $(MAKE) -C '$(1)'       -j '$(JOBS)' lib-target
+        $(MAKE) -C '$(1)'       -j '$(JOBS)' install-lib
+        $(MAKE) -C '$(1)/port'  -j '$(JOBS)' install
+        $(MAKE) -C '$(1)/gcore' -j '$(JOBS)' install
+        $(MAKE) -C '$(1)/frmts' -j '$(JOBS)' install
+        $(MAKE) -C '$(1)/alg'   -j '$(JOBS)' install
+        $(MAKE) -C '$(1)/ogr'   -j '$(JOBS)' install OGR_ENABLED=
+        $(MAKE) -C '$(1)/apps'  -j '$(JOBS)' install BIN_LIST=
+        ln -sf '$(PREFIX)/$(TARGET)/bin/gdal-config' '$(PREFIX)/bin/$(TARGET)-gdal-config'
 endef
 
-# Can't use $(PKG)_BUILD_SHARED here as $(PKG)_BUILD_i686-w64-mingw32 has a
-# higher precedence.
-$(PKG)_BUILD_i686-w64-mingw32.shared =
-$(PKG)_BUILD_x86_64-w64-mingw32.shared =
+$(PKG)_BUILD_SHARED =

--- a/src/hdf4.mk
+++ b/src/hdf4.mk
@@ -19,7 +19,7 @@ endef
 
 define $(PKG)_BUILD
     cd '$(1)' && $(LIBTOOLIZE) --force
-    cd '$(1)' && autoreconf --install
+    cd '$(1)' && autoreconf --force --install
     cd '$(1)' && ./configure \
         --host='$(TARGET)' \
         --build="`config.guess`" \
@@ -33,7 +33,5 @@ define $(PKG)_BUILD
     $(MAKE) -C '$(1)'/mfhdf/libsrc -j '$(JOBS)'
     $(MAKE) -C '$(1)'/mfhdf/libsrc -j 1 install
 endef
-
-$(PKG)_BUILD_x86_64-w64-mingw32 =
 
 $(PKG)_BUILD_SHARED =

--- a/src/imagemagick.mk
+++ b/src/imagemagick.mk
@@ -39,6 +39,4 @@ define $(PKG)_BUILD
         `'$(TARGET)-pkg-config' ImageMagick++ --cflags --libs`
 endef
 
-$(PKG)_BUILD_x86_64-w64-mingw32 =
-
 $(PKG)_BUILD_SHARED =

--- a/src/netcdf.mk
+++ b/src/netcdf.mk
@@ -32,14 +32,10 @@ define $(PKG)_BUILD
         --enable-netcdf-4 \
         --enable-hdf4 \
         --prefix='$(PREFIX)/$(TARGET)' \
-        CPPFLAGS="-D_DLGS_H" \
+        CPPFLAGS="-DWIN32_LEAN_AND_MEAN -DH4_BUILT_AS_STATIC_LIB=1" \
         LIBS="-lmfhdf -ldf -lportablexdr -lws2_32"
     $(MAKE) -C '$(1)' -j '$(JOBS)'
     $(MAKE) -C '$(1)' -j 1 install
 endef
-
-$(PKG)_BUILD_x86_64-w64-mingw32 =
-$(PKG)_BUILD_i686-w64-mingw32 = $(subst --enable-hdf4, --disable-hdf4,\
-                                $(subst -lmfhdf -ldf,,$($(PKG)_BUILD)))
 
 $(PKG)_BUILD_SHARED =

--- a/src/openexr-1-fix-aligned-alloc.patch
+++ b/src/openexr-1-fix-aligned-alloc.patch
@@ -1,0 +1,38 @@
+diff -uNr openexr-2.1.0.orig/IlmImf/ImfSystemSpecific.h openexr-2.1.0/IlmImf/ImfSystemSpecific.h
+--- openexr-2.1.0.orig/IlmImf/ImfSystemSpecific.h	2013-10-21 21:02:22.000000000 +0200
++++ openexr-2.1.0/IlmImf/ImfSystemSpecific.h	2015-01-07 15:31:25.851288890 +0100
+@@ -58,6 +58,20 @@
+ #define EXR_FORCEINLINE inline
+ #define EXR_RESTRICT __restrict
+ 
++#ifdef __MINGW32__
++
++static void* EXRAllocAligned(size_t size, size_t alignment)
++{
++    return _aligned_malloc(size, alignment);
++}
++
++static void EXRFreeAligned(void* ptr)
++{
++    return _aligned_free(ptr);
++}
++
++#else
++
+ static void* EXRAllocAligned(size_t size, size_t alignment)
+ {
+     void* ptr = 0;
+@@ -65,12 +79,12 @@
+     return ptr;
+ }
+ 
+-
+ static void EXRFreeAligned(void* ptr)
+ {
+     free(ptr);
+ }
+ 
++#endif
+ #elif defined _MSC_VER
+ 
+ #define EXR_FORCEINLINE __forceinline

--- a/src/openexr.mk
+++ b/src/openexr.mk
@@ -38,7 +38,8 @@ define $(PKG)_BUILD
         --disable-threading \
         --disable-posix-sem \
         --disable-ilmbasetest \
-        PKG_CONFIG='$(PREFIX)/bin/$(TARGET)-pkg-config'
+        PKG_CONFIG='$(PREFIX)/bin/$(TARGET)-pkg-config' \
+        CXXFLAGS="-fpermissive"
     # build the code generator manually
     cd '$(1)/IlmImf' && g++ \
         -I'$(1)/ilmbase/include/OpenEXR' \
@@ -54,5 +55,3 @@ define $(PKG)_BUILD
         '$(2).cpp' -o '$(PREFIX)/$(TARGET)/bin/test-openexr.exe' \
         `'$(TARGET)-pkg-config' OpenEXR --cflags --libs`
 endef
-
-$(PKG)_BUILD_x86_64-w64-mingw32 =

--- a/src/portablexdr.mk
+++ b/src/portablexdr.mk
@@ -21,8 +21,6 @@ define $(PKG)_BUILD
     cd '$(1)' && ./configure \
         $(MXE_CONFIGURE_OPTS) \
         AR='$(TARGET)-ar'
-    $(MAKE) -C '$(1)' -j '$(JOBS)'
+    $(MAKE) -C '$(1)' -j '$(JOBS)' libportablexdr_la_CFLAGS="-Wall -fno-strict-aliasing"
     $(MAKE) -C '$(1)' -j 1 install
 endef
-
-$(PKG)_BUILD_x86_64-w64-mingw32 =


### PR DESCRIPTION
This enables 64 bit builds for a number of packages: dcmtk, portablexdr, hdf4, netcdf, openexr, imagemagick.
The gdal package profits from this: since now hdf4 is available for 32 and 64 bit, the build rules do not have to be separate anymore.