### PR TITLE
Add fix for Polarssl CVE-2015-1182

### DIFF
--- a/src/polarssl-1-CVE20151182.patch
+++ b/src/polarssl-1-CVE20151182.patch
@@ -1,0 +1,20 @@
+This file is part of MXE.
+See index.html for further information.
+
+Security fix for CVE-2015-1182 from:
+https://polarssl.org/tech-updates/security-advisories/polarssl-security-advisory-2014-04
+
+
+diff --git a/library/asn1parse.c b/library/asn1parse.c
+index a3a2b56..e2117bf 100644
+--- a/library/asn1parse.c
++++ b/library/asn1parse.c
+@@ -278,6 +278,8 @@ int asn1_get_sequence_of( unsigned char **p,
+             if( cur->next == NULL )
+                 return( POLARSSL_ERR_ASN1_MALLOC_FAILED );
+
++            memset( cur->next, 0, sizeof( asn1_sequence ) );
++
+             cur = cur->next;
+         }
+     }


### PR DESCRIPTION
Temporary patch this until a new release of polarssl is made available. See:
https://polarssl.org/tech-updates/security-advisories/polarssl-security-advisory-2014-04