### PR TITLE
Fixes for clean build environment

### DIFF
--- a/src/glib.mk
+++ b/src/glib.mk
@@ -29,7 +29,13 @@ define $(PKG)_NATIVE_BUILD
         --disable-nls
     $(MAKE) -C '$(1).native/$(libiconv_SUBDIR)' -j '$(JOBS)'
 
-    # native build for glib-genmarshal, without gettext and zlib
+    # native build of zlib...
+    cd '$(1).native' && $(call UNPACK_PKG_ARCHIVE,zlib)
+    cd '$(1).native/$(zlib_SUBDIR)' && ./configure \
+        --static
+    $(MAKE) -C '$(1).native/$(zlib_SUBDIR)' -j '$(JOBS)'
+
+    # native build for glib-genmarshal, without gettext
     cd '$(1).native' && ./configure \
         --disable-shared \
         --prefix='$(PREFIX)/$(TARGET)' \
@@ -42,8 +48,8 @@ define $(PKG)_NATIVE_BUILD
         --disable-dtrace \
         --with-libiconv=gnu \
         --with-pcre=internal \
-        CPPFLAGS='-I$(1).native/$(libiconv_SUBDIR)/include' \
-        LDFLAGS='-L$(1).native/$(libiconv_SUBDIR)/lib/.libs'
+        CPPFLAGS='-I$(1).native/$(libiconv_SUBDIR)/include -I$(1).native/$(zlib_SUBDIR)' \
+        LDFLAGS='-L$(1).native/$(libiconv_SUBDIR)/lib/.libs -L$(1).native/$(zlib_SUBDIR)'
     $(SED) -i 's,#define G_ATOMIC.*,,' '$(1).native/config.h'
     $(MAKE) -C '$(1).native/glib'    -j '$(JOBS)'
     $(MAKE) -C '$(1).native/gthread' -j '$(JOBS)'

--- a/src/qtbase.mk
+++ b/src/qtbase.mk
@@ -29,6 +29,7 @@ define $(PKG)_BUILD
             -device-option CROSS_COMPILE=${TARGET}- \
             -device-option PKG_CONFIG='${TARGET}-pkg-config' \
             -force-pkg-config \
+            -no-use-gold-linker \
             -release \
             -static \
             -prefix '$(PREFIX)/$(TARGET)/qt5' \

--- a/src/sdl2_gfx.mk
+++ b/src/sdl2_gfx.mk
@@ -18,7 +18,7 @@ define $(PKG)_UPDATE
 endef
 
 define $(PKG)_BUILD
-    cd '$(1)' && ./configure \
+    cd '$(1)' && ./autogen.sh && ./configure \
         $(MXE_CONFIGURE_OPTS) \
         --with-sdl-prefix='$(PREFIX)/$(TARGET)' \
         SDL_LIBS="`$(TARGET)-pkg-config --libs sdl2 | $(SED) -e 's/-lmingw32//' -e 's/-lSDL2main//'`" \


### PR DESCRIPTION
These are some fixes necessary in a (reasonably) clean build environment. Tested on an fresh Debian wheezy install.

- glib doesn't build without zlib any more, so provide a native version when building native glib tools
- sdl2_gfx tries to run aclocal-1.?? when running make since the timestamps between configure and Makefile.* are strange, so we rebuild everything with the installed automake tools...
- Somehow, sometimes, qtbase decides to link using gold, but gold only works for ELF. This can be fixed by disabling gold altogether...
 