### PR TITLE
Enable shared build for PhysicsFS

### DIFF
--- a/src/physfs.mk
+++ b/src/physfs.mk
@@ -20,7 +20,10 @@ endef
 define $(PKG)_BUILD
     cd '$(1)' && cmake . \
         -DCMAKE_TOOLCHAIN_FILE='$(CMAKE_TOOLCHAIN_FILE)' \
-        -DPHYSFS_BUILD_SHARED=FALSE \
+        $(if $(BUILD_SHARED), \
+            -DPHYSFS_BUILD_SHARED=TRUE \
+            -DPHYSFS_BUILD_STATIC=FALSE, \
+            -DPHYSFS_BUILD_SHARED=FALSE) \
         -DPHYSFS_INTERNAL_ZLIB=FALSE \
         -DPHYSFS_BUILD_TEST=FALSE \
         -DPHYSFS_BUILD_WX_TEST=FALSE
@@ -33,5 +36,3 @@ define $(PKG)_BUILD
 endef
 
 $(PKG)_BUILD_x86_64-w64-mingw32 =
-
-$(PKG)_BUILD_SHARED =


### PR DESCRIPTION
This pull request enables a shared library build for PhysicsFS.

The following are all true in my MXE instance:

1. test-physfs.exe links and successfully runs under Wine 1.6.
2. In a shared build, only libphysfs.dll is present in `bin` and an import library is present in `lib`
3. In a static build, neither the DLL nor the import library are present

The definition of `$(PKG)_BUILD_SHARED` is largely copied from the existing build definition, with a few tweaks to turn off the static build.  I'd appreciate any suggestions to reduce the copy-paste.