### PR TITLE
index.html versions cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@
 /gits/
 /log*/
 /pkg
+/versions.json
 /wip/
 /tmp-*

--- a/Makefile
+++ b/Makefile
@@ -507,7 +507,7 @@ show-upstream-deps-%:
 
 .PHONY: clean
 clean:
-	rm -rf $(call TMP_DIR,*) $(PREFIX) build-matrix.html
+	rm -rf $(call TMP_DIR,*) $(PREFIX) build-matrix.html versions.json
 
 .PHONY: clean-pkg
 clean-pkg:
@@ -663,3 +663,12 @@ build-matrix.html: $(foreach PKG,$(PKGS), $(TOP_DIR)/src/$(PKG).mk)
 	@echo '</table>'                        >> $@
 	@echo '</body>'                         >> $@
 	@echo '</html>'                         >> $@
+
+
+versions.json: $(foreach PKG,$(PKGS), $(TOP_DIR)/src/$(PKG).mk)
+	@echo '{'                         > $@
+	@{$(foreach PKG,$(PKGS),          \
+	    echo '    "$(PKG)":           \
+	        "$($(PKG)_VERSION)",';)} >> $@
+	@echo '    "": null'             >> $@
+	@echo '}'                        >> $@

--- a/index.html
+++ b/index.html
@@ -2607,8 +2607,12 @@ local-pkg-list: $(LOCAL_PKG_LIST)</pre>
             request.onreadystatechange = function reqCallback() {
                 if (request.readyState === 4) {
                     if (request.status === 200) {
-                        var versions = JSON.parse(request.responseText);
-                        doneCallback(versions);
+                        try {
+                            var versions = JSON.parse(request.responseText);
+                            doneCallback(versions);
+                        } catch (e) {
+                            errCallback();
+                        }
                     } else {
                         errCallback();
                     }

--- a/index.html
+++ b/index.html
@@ -2601,6 +2601,21 @@ local-pkg-list: $(LOCAL_PKG_LIST)</pre>
                 })();
             }
         }
+        function loadVersionCache(doneCallback, errCallback) {
+            var request = new XMLHttpRequest();
+            request.open('GET', 'versions.json', true);
+            request.onreadystatechange = function reqCallback() {
+                if (request.readyState === 4) {
+                    if (request.status === 200) {
+                        var versions = JSON.parse(request.responseText);
+                        doneCallback(versions);
+                    } else {
+                        errCallback();
+                    }
+                }
+            }
+            request.send();
+        }
         function resolveVersions(versions) {
             var resolvedVersions = {};
             for (var package in versions) {
@@ -2625,9 +2640,13 @@ local-pkg-list: $(LOCAL_PKG_LIST)</pre>
         }
         (function main() {
             var packageElements = getPackageElements();
-            loadVersions(packageElements, function doneCallback(versions) {
-                var resolvedVersions = resolveVersions(versions);
-                showVersions(packageElements, resolvedVersions);
+            loadVersionCache(function doneCallback(versions) {
+                showVersions(packageElements, versions);
+            }, function errCallback() {
+                loadVersions(packageElements, function doneCallback(versions) {
+                    var resolvedVersions = resolveVersions(versions);
+                    showVersions(packageElements, resolvedVersions);
+                });
             });
         })();
     </script>

--- a/index.html
+++ b/index.html
@@ -2633,7 +2633,14 @@ local-pkg-list: $(LOCAL_PKG_LIST)</pre>
             for (package in packageElements) {
                 var element = packageElements[package];
                 var version = resolvedVersions[package];
+                var shorten = version.length > 12;
+                if (shorten) {
+                    version = version.substring(0, 12);
+                }
                 var versionEscaped = version.replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;');
+                if (shorten) {
+                    versionEscaped += '&hellip;';
+                }
                 var versionHtml = '<td class="version">' + versionEscaped + '</td>';
                 element.insertAdjacentHTML('afterend', versionHtml);
             }


### PR DESCRIPTION
Currentl, the index page pulls version information from all the *.mk files, which is quite a lot of data and requests. This introduces a cache for this data:

- A makefile target to generate the cache
- JavaScript code that reads the cache and falls back to the old style, if it isn't found
- A bit unrelated: Shorten long version numbers, like in build-matrix.

On my slow DSL connection, this is the difference for loading index.html:
Without cache: 372 Requests, 779,42 KB, 37,30 s
With cache: 6 Requests, 198,27 KB, 5,11 s

I don't know how useful this is for mxe.cc, but it may be possible to move the GitHub Pages hosting to another branch (gh-pages) and commit versions.json there...

Test page: http://buildbox.23.gs/mxe/#packages