### PR TITLE
Implementation for MXE_GET_GITHUB_TAG_SHA

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,6 +123,12 @@ define MXE_GET_GITHUB_SHA
     head -1
 endef
 
+define MXE_GET_GITHUB_TAG_SHA
+    $(WGET) -q -O- 'https://api.github.com/repos/$(strip $(1))/git/refs/tags/' | \
+    $(SED) -n 's#.*"sha": "\([^"]\{10\}\).*#\1#p' | \
+    tail -1
+endef
+
 # use a minimal whitelist of safe environment variables
 ENV_WHITELIST := PATH LANG MAKE% MXE% %PROXY %proxy
 unexport $(filter-out $(ENV_WHITELIST),$(shell env | cut -d '=' -f1))


### PR DESCRIPTION
This is identical to MXE_GET_GITHUB_SHA. This will grab the SHA based on the latest tag.

Example of usage:

    $(PKG)_UPDATE = $(call MXE_GET_GITHUB_TAG_SHA, owner/repository)