### PR TITLE
mman-win32.mk download .tar.gz rather than .zip

### DIFF
--- a/src/mman-win32.mk
+++ b/src/mman-win32.mk
@@ -7,7 +7,7 @@ $(PKG)_VERSION  := 378ed6b69bb7220511dd9cd0973c22b3f6773ce7
 $(PKG)_CHECKSUM := f2e54393f530b35d1736fa98a5a29d7d3a0ce76b
 $(PKG)_SUBDIR   := mman-win32-master
 $(PKG)_FILE     := mman-win32-$($(PKG)_VERSION).tar.gz
-$(PKG)_URL      := https://github.com/witwall/mman-win32/archive/$($(PKG)_VERSION).zip
+$(PKG)_URL      := https://github.com/witwall/mman-win32/archive/$($(PKG)_VERSION).tar.gz
 $(PKG)_DEPS     := gcc
 
 $(PKG)_UPDATE = $(call MXE_GET_GITHUB_SHA, witwall/mman-win32, master)


### PR DESCRIPTION
Noticed this small error.