### PR TITLE
Fixed errors in mman-win32.mk

### DIFF
--- a/src/mman-win32.mk
+++ b/src/mman-win32.mk
@@ -4,8 +4,8 @@
 PKG             := mman-win32
 $(PKG)_IGNORE   :=
 $(PKG)_VERSION  := 378ed6b69bb7220511dd9cd0973c22b3f6773ce7
-$(PKG)_CHECKSUM := f2e54393f530b35d1736fa98a5a29d7d3a0ce76b
-$(PKG)_SUBDIR   := mman-win32-master
+$(PKG)_CHECKSUM := 489969397e78c99e0ca89652e3c6f3981d676b79
+$(PKG)_SUBDIR   := mman-win32-$($(PKG)_VERSION)
 $(PKG)_FILE     := mman-win32-$($(PKG)_VERSION).tar.gz
 $(PKG)_URL      := https://github.com/witwall/mman-win32/archive/$($(PKG)_VERSION).tar.gz
 $(PKG)_DEPS     := gcc


### PR DESCRIPTION
This has been tested and works fine now.

I tried to rebuild every package today while I was away. There were a few errors on the last adjustments in mman-win32.mk. They've now been resolved. Changes to other packages may be coming up.