### PR TITLE
Update OpenCSG to version 1.4.0.

### DIFF
--- a/src/opencsg-1-fixes.patch
+++ b/src/opencsg-1-fixes.patch
@@ -3,44 +3,45 @@ See index.html for further information.
 
 Contains ad hoc patches for cross building.
 
-From 71c4f0a34399fd74d4e39f9985a4c2c56f8b9a43 Mon Sep 17 00:00:00 2001
-From: MXE
-Date: Sat, 22 Oct 2011 01:29:03 +0200
-Subject: [PATCH] configure for MXE
-
-
-diff --git a/example/example.pro b/example/example.pro
-index 8891a28..02c1fe0 100644
---- a/example/example.pro
-+++ b/example/example.pro
-@@ -1,10 +1,11 @@
- TEMPLATE	= app
- TARGET		= opencsgexample
+diff -ur OpenCSG-1.4.0.orig/example/example.pro OpenCSG-1.4.0/example/example.pro
+--- OpenCSG-1.4.0.orig/example/example.pro	2014-09-15 22:25:33.000000000 +0200
++++ OpenCSG-1.4.0/example/example.pro	2015-03-22 14:08:27.706916987 +0100
+@@ -1,10 +1,10 @@
+ TEMPLATE = app
+ TARGET = opencsgexample
  
--CONFIG	 	+= opengl warn_on release
-+CONFIG	 	+= opengl warn_on release link_pkgconfig
- INCLUDEPATH += ../glew/include ../include
+-CONFIG += opengl warn_on release
++CONFIG += opengl warn_on release link_pkgconfig
+ CONFIG -= qt
+ INCLUDEPATH += ../include
+-LIBS += -L../lib -lopencsg -lGLEW
++LIBS += -L../lib -lopencsg
  
--LIBS        += -L../lib -lopencsg -lglut -L../glew/lib -lGLEW
-+LIBS        += -L../lib -lopencsg
-+PKGCONFIG	+= glew glut
+ INSTALLDIR = /usr/local
+ INSTALLS += target
+@@ -15,7 +15,8 @@
+   LIBS += -framework GLUT -L/opt/local/lib
+ }
+ else {
+-  LIBS += -lGLU -lglut
++  LIBS += -lglut
++  PKGCONFIG += glew glut
+ }
  
- HEADERS		= displaylistPrimitive.h
- SOURCES		= displaylistPrimitive.cpp main.cpp
-diff --git a/src/src.pro b/src/src.pro
-index db5e1fb..4c664ab 100644
---- a/src/src.pro
-+++ b/src/src.pro
-@@ -3,7 +3,8 @@ TARGET		= opencsg
- VERSION     = 1.3.1
- DESTDIR     = ../lib
+ HEADERS = displaylistPrimitive.h
+diff -ur OpenCSG-1.4.0.orig/src/src.pro OpenCSG-1.4.0/src/src.pro
+--- OpenCSG-1.4.0.orig/src/src.pro	2014-09-15 22:25:33.000000000 +0200
++++ OpenCSG-1.4.0/src/src.pro	2015-03-22 14:05:18.275029066 +0100
+@@ -2,10 +2,10 @@
+ TARGET = opencsg
+ VERSION = 1.4.0
  
--CONFIG		+= opengl warn_on release
-+CONFIG		+= opengl warn_on release staticlib link_pkgconfig
-+PKGCONFIG	+= glew glut
- INCLUDEPATH += ../include ../glew/include ../
+-CONFIG += opengl warn_on release
++CONFIG += opengl warn_on release link_pkgconfig
+ INCLUDEPATH += ../include ../
+ CONFIG -= qt
+-LIBS += -lGLEW
++PKGCONFIG += glew glut
  
- HEADERS		= ../include/opencsg.h \
--- 
-1.7.7
-
+ DESTDIR = ../lib
+ INSTALLDIR = /usr/local

--- a/src/opencsg.mk
+++ b/src/opencsg.mk
@@ -3,8 +3,8 @@
 
 PKG             := opencsg
 $(PKG)_IGNORE   :=
-$(PKG)_VERSION  := 1.3.2
-$(PKG)_CHECKSUM := e2b4abf169ae3e319eb5f6d9ae6136fa96710a05
+$(PKG)_VERSION  := 1.4.0
+$(PKG)_CHECKSUM := 2c2592a9f625ec1c7a3d208403ea2ac1cae2f972
 $(PKG)_SUBDIR   := OpenCSG-$($(PKG)_VERSION)
 $(PKG)_FILE     := OpenCSG-$($(PKG)_VERSION).tar.gz
 $(PKG)_URL      := http://www.opencsg.org/$($(PKG)_FILE)


### PR DESCRIPTION
This updates OpenCSG to the latest library version.

The existing patch that modifies the qmake files did not apply anymore, so I've updated that by applying the changes to the new project files manually.

* Checked with `i686-w64-mingw32.static` and `x86_64-w64-mingw32.static` targets
* Works with the OpenSCAD build