### PR TITLE
debian: Add dependency for libtool-bin

### DIFF
--- a/index.html
+++ b/index.html
@@ -633,7 +633,7 @@ USE_OSGPLUGIN(&lt;plugin2&gt;)
     <!-- http://www.debian.org/distrib/packages#search_packages -->
     <pre>apt-get install \
     autoconf automake autopoint bash bison bzip2 cmake flex gettext \
-    git g++ gperf intltool libffi-dev libtool libltdl-dev \
+    git g++ gperf intltool libffi-dev libtool-bin libltdl-dev \
     libssl-dev libxml-parser-perl make openssl patch perl \
     pkg-config python ruby scons sed unzip wget xz-utils</pre>
 


### PR DESCRIPTION
In Debian Jessie, the libtool binary was separated out
into the libtool-bin package:

  https://packages.debian.org/jessie/libtool-bin