### PR TITLE
update Lua to 5.3.0 and LuaJIT to 2.0.4

### DIFF
--- a/src/lua.mk
+++ b/src/lua.mk
@@ -3,10 +3,10 @@
 
 PKG             := lua
 $(PKG)_IGNORE   :=
-$(PKG)_VERSION  := 5.2.3
+$(PKG)_VERSION  := 5.3.0
 # Shared version
-$(PKG)_SOVERS   := 52
-$(PKG)_CHECKSUM := 926b7907bc8d274e063d42804666b40a3f3c124c
+$(PKG)_SOVERS   := 53
+$(PKG)_CHECKSUM := 1c46d1c78c44039939e820126b86a6ae12dadfba
 $(PKG)_SUBDIR   := lua-$($(PKG)_VERSION)
 $(PKG)_FILE     := lua-$($(PKG)_VERSION).tar.gz
 $(PKG)_URL      := http://www.lua.org/ftp/$($(PKG)_FILE)

--- a/src/luabind-1-cmakelists.patch
+++ b/src/luabind-1-cmakelists.patch
@@ -12,7 +12,7 @@ new file mode 100644
 index 0000000..acc47ae
 --- /dev/null
 +++ b/CMakeLists.txt
-@@ -0,0 +1,29 @@
+@@ -0,0 +1,27 @@
 +cmake_minimum_required(VERSION 2.6)
 +project(luabind)
 +
@@ -32,8 +32,6 @@ index 0000000..acc47ae
 +
 +set(luabind_cxx_flags "-ftemplate-depth-128 -finline-functions")
 +set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${luabind_cxx_flags}")
-+
-+add_definitions(-DLUA_COMPAT_ALL)
 +
 +target_link_libraries(luabind ${LUA_LIBRARIES} luabind)
 +

--- a/src/luabind-7-compatibility-Lua-macro.patch
+++ b/src/luabind-7-compatibility-Lua-macro.patch
@@ -1,0 +1,36 @@
+This file is part of MXE.
+See index.html for further information.
+
+From 456cad416f81c985b726fbf63fd7734e472c8b5f Mon Sep 17 00:00:00 2001
+From: Boris Nagaev <bnagaev@gmail.com>
+Date: Thu, 14 May 2015 15:23:33 +0300
+Subject: [PATCH] compatibility Lua macro to config.hpp
+
+---
+ luabind/config.hpp |    11 +++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/luabind/config.hpp b/luabind/config.hpp
+index 609fb95..3535406 100644
+--- a/luabind/config.hpp
++++ b/luabind/config.hpp
+@@ -128,5 +128,16 @@ LUABIND_API void disable_super_deprecation();
+ 
+ } // namespace luabind
+ 
++#include <lua.hpp>
++
++#if LUA_VERSION_NUM > 501
++#define lua_objlen lua_rawlen
++#define lua_equal(L,idx1,idx2) lua_compare(L,(idx1),(idx2),LUA_OPEQ)
++#define lua_lessthan(L,idx1,idx2)       lua_compare(L,(idx1),(idx2),LUA_OPLT)
++#endif
++#if LUA_VERSION_NUM >= 501
++#define lua_strlen lua_objlen
++#endif
++
+ #endif // LUABIND_CONFIG_HPP_INCLUDED
+ 
+-- 
+1.7.10.4
+

--- a/src/luabind.mk
+++ b/src/luabind.mk
@@ -24,9 +24,8 @@ define $(PKG)_BUILD
     $(MAKE) -C '$(1).build' -j '$(JOBS)' VERBOSE=1 || $(MAKE) -C '$(1).build' -j 1 VERBOSE=1
     $(MAKE) -C '$(1).build' -j 1 install VERBOSE=1
 
-    # all programs using luabind should define LUA_COMPAT_ALL
     '$(TARGET)-g++' \
-        -W -Wall -DLUA_COMPAT_ALL \
+        -W -Wall \
         '$(2).cpp' -o '$(PREFIX)/$(TARGET)/bin/test-luabind.exe' \
         -llua -lluabind
 endef

--- a/src/luajit.mk
+++ b/src/luajit.mk
@@ -3,8 +3,8 @@
 
 PKG             := luajit
 $(PKG)_IGNORE   :=
-$(PKG)_VERSION  := 2.0.3
-$(PKG)_CHECKSUM := 2db39e7d1264918c2266b0436c313fbd12da4ceb
+$(PKG)_VERSION  := 2.0.4
+$(PKG)_CHECKSUM := 6e533675180300e85d12c4bbeea2d0e41ad21172
 $(PKG)_SUBDIR   := LuaJIT-$($(PKG)_VERSION)
 $(PKG)_FILE     := $($(PKG)_SUBDIR).tar.gz
 $(PKG)_URL      := http://luajit.org/download/$($(PKG)_FILE)


### PR DESCRIPTION
LuaJIT 2.0.4 was released on May 14, 2015. It has various bug fixes over 2.0.3 - an update is recommended. See [the changelog](http://luajit.org/changes.html).

Lua 5.3 was released on Jan 12, 2015. Its [main new features](http://www.lua.org/manual/5.3/readme.html#changes) are integers, bitwise operators, a basic utf-8 library, and support for both 64-bit and 32-bit platforms.

Package luabind was changed to be compatible with Lua 5.3.0:

 * do not use macro LUA_COMPAT_ALL. Lua 5.3 respects macros
   LUA_COMPAT_5_2 and LUA_COMPAT_5_1 and ignores macro
   LUA_COMPAT_ALL.

 * Instead, include needed compatibility defines into header
   luabind/config.hpp. Side effect of this is that C++ code
   using luabind doesn't need to define LUA_COMPAT_ALL.
   This definition was removed from the example of luabind.