### PR TITLE
Enable ISO C90 inline for i686-w64-mingw32.shared

### DIFF
--- a/src/a52dec.mk
+++ b/src/a52dec.mk
@@ -18,7 +18,7 @@ endef
 
 define $(PKG)_BUILD
     cd '$(1)' && autoreconf -fi # The autotools files came with a52dec are _ancient_
-    cd '$(1)' && ./configure \
+    cd '$(1)' && ./configure CFLAGS=-std=gnu89 \
         $(MXE_CONFIGURE_OPTS)
     $(MAKE) -C '$(1)' -j '$(JOBS)' bin_PROGRAMS= sbin_PROGRAMS= noinst_PROGRAMS=
     $(MAKE) -C '$(1)' -j 1 install bin_PROGRAMS= sbin_PROGRAMS= noinst_PROGRAMS=


### PR DESCRIPTION
Otherwise imaxabs() and other functions in _mingw.h will not
be inlined and produce link error