### PR TITLE
Boost compilation fix from https://gcc.gnu.org/ml/gcc-patches/2015-06…

### DIFF
--- a/src/gcc-codecvt.patch
+++ b/src/gcc-codecvt.patch
@@ -1,0 +1,27 @@
+diff --git a/libstdc++-v3/config/abi/pre/gnu.ver b/libstdc++-v3/config/abi/pre/gnu.ver
+index 2da04e4..d42cd37 100644
+--- a/libstdc++-v3/config/abi/pre/gnu.ver
++++ b/libstdc++-v3/config/abi/pre/gnu.ver
+@@ -542,6 +542,9 @@ GLIBCXX_3.4 {
+     # std::codecvt_byname
+     _ZNSt14codecvt_bynameI[cw]c11__mbstate_tEC[12]EPKc[jmy];
+     _ZNSt14codecvt_bynameI[cw]c11__mbstate_tED*;
++#if defined (_WIN32) && !defined (__CYGWIN__)
++    _ZNSt14codecvt_bynameI[cw]ciE[CD]*;
++#endif
+ 
+     # std::collate
+     _ZNSt7collateI[cw]*;
+@@ -1821,9 +1824,9 @@ GLIBCXX_3.4.21 {
+     _ZNKSt8time_getI[cw]St19istreambuf_iteratorI[cw]St11char_traitsI[cw]EEE6do_getES3_S3_RSt8ios_baseRSt12_Ios_IostateP2tmcc;
+ 
+     # codecvt<char16_t, char, mbstate_t>, codecvt<char32_t, char, mbstate_t>
+-    _ZNKSt7codecvtID[is]c11__mbstate_t*;
+-    _ZNSt7codecvtID[is]c11__mbstate_t*;
+-    _ZT[ISV]St7codecvtID[is]c11__mbstate_tE;
++    _ZNKSt7codecvtID[is]c*;
++    _ZNSt7codecvtID[is]c*;
++    _ZT[ISV]St7codecvtID[is]c*E;
+ 
+     extern "C++"
+     {


### PR DESCRIPTION
This allows the current version of Boost to compile cleanly on 32-bit and 64-bit. Seems to have been broken since gcc 5.0 or so.

Original patch from https://gcc.gnu.org/ml/gcc-patches/2015-06/msg00590.html
