### PR TITLE
Don't use git when building libgcrypt.

### DIFF
--- a/src/libgcrypt-2-no-git.patch
+++ b/src/libgcrypt-2-no-git.patch
@@ -1,0 +1,34 @@
+This file is part of MXE.
+See index.html for further information.
+
+Contains ad hoc patches for cross building.
+
+From bb6a01f7a13be69e9ba395977dacd2ac0b9efbcd Mon Sep 17 00:00:00 2001
+From: MXE
+Date: Fri, 12 Jun 2015 14:53:55 -0700
+Subject: [PATCH] Don't call git to determine the revision.
+
+
+diff --git a/configure.ac b/configure.ac
+index d9a1670..ab98441 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -38,13 +38,10 @@ m4_define(mym4_version_micro, [3])
+ # processing is done by autoconf and not during the configure run.
+ m4_define(mym4_version,
+           [mym4_version_major.mym4_version_minor.mym4_version_micro])
+-m4_define([mym4_revision],
+-          m4_esyscmd([git rev-parse --short HEAD | tr -d '\n\r']))
++m4_define([mym4_revision], [4091])
+ m4_define([mym4_revision_dec],
+           m4_esyscmd_s([echo $((0x$(echo ]mym4_revision[|head -c 4)))]))
+-m4_define([mym4_betastring],
+-          m4_esyscmd_s([git describe --match 'libgcrypt-[0-9].*[0-9]' --long|\
+-                        awk -F- '$3!=0{print"-beta"$3}']))
++m4_define([mym4_betastring], [])
+ m4_define([mym4_isgit],m4_if(mym4_betastring,[],[no],[yes]))
+ m4_define([mym4_full_version],[mym4_version[]mym4_betastring])
+ 
+-- 
+2.1.4
+


### PR DESCRIPTION
When reconfiguring libgcrypt using `autoconf`, libgcrypt calls `git` to determine what revision hash and number it's on. Most people won't see an issue, because the build directory is, by default, in a subdirectory of the mxe repo and `git` will use mxe's revision log and hashes. However, if the build directory is changed to `/dev/shm` for I/O performance reasons, then because there is no git repo there, the build will fail.

Specifically, `autoconf` will go through and ignore the error, but when building `versioninfo.rc` using `windres`, the version number will be listed as `1,6,3,` because revision number (hard-coded to 4091 below) will be blank, resulting in a syntax error.