### PR TITLE
fix libgcrypt on x86_64 (automake < 1.12)

### DIFF
--- a/src/libgcrypt-3-no-serial-tests.patch
+++ b/src/libgcrypt-3-no-serial-tests.patch
@@ -1,0 +1,48 @@
+This file is part of MXE.
+See index.html for further information.
+
+Fix libgcrypt build under x86_64
+See https://www.redhat.com/archives/libguestfs/2013-February/msg00102.html
+
+From e19ba5689148df7cdcb6c515f44a897cc3a08418 Mon Sep 17 00:00:00 2001
+From: Boris Nagaev <bnagaev@gmail.com>
+Date: Sun, 28 Jun 2015 17:17:25 +0200
+Subject: [PATCH] configure.ac: no serial-tests if automake < 1.12
+
+---
+ configure.ac |   19 ++++++++++++++++++-
+ 1 file changed, 18 insertions(+), 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index ab98441..a015787 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -71,7 +71,24 @@ VERSION=$PACKAGE_VERSION
+ 
+ AC_CONFIG_AUX_DIR([build-aux])
+ AC_CONFIG_SRCDIR([src/libgcrypt.vers])
+-AM_INIT_AUTOMAKE([serial-tests dist-bzip2])
++
++dnl Initialize automake.  automake < 1.12 didn't have serial-tests and
++dnl gives an error if it sees this, but for automake >= 1.13
++dnl serial-tests is required so we have to include it.  Solution is to
++dnl test for the version of automake (by running an external command)
++dnl and provide it if necessary.  Note we have to do this entirely using
++dnl m4 macros since automake queries this macro by running
++dnl 'autoconf --trace ...'.
++m4_define([serial_tests], [
++    m4_esyscmd([automake --version |
++                head -1 |
++                awk '{split ($NF,a,"."); if (a[1] == 1 && a[2] >= 12) { '\
++                    'print "serial-tests" }}'
++    ])
++])
++dnl NB: Do not [quote] this parameter.
++AM_INIT_AUTOMAKE(serial_tests dist-bzip2)
++
+ AC_CONFIG_HEADER(config.h)
+ AC_CONFIG_MACRO_DIR([m4])
+ AC_CONFIG_LIBOBJ_DIR([compat])
+-- 
+1.7.10.4
+


### PR DESCRIPTION
automake < 1.12 didn't have serial-tests and gives an error if it sees this, but for automake >= 1.13 serial-tests is required so we have to include it. Solution is to test for the version of automake (by running an external command) and provide serial-tests if necessary. I've tested this successfully for all targets with automake 1.11.6. Could someone test it with automake >= 1.13, please?

See #681
See https://www.redhat.com/archives/libguestfs/2013-February/msg00102.html