### PR TITLE
Add qhttpengine library.

### DIFF
--- a/index.html
+++ b/index.html
@@ -2122,6 +2122,10 @@ local-pkg-list: $(LOCAL_PKG_LIST)</pre>
         <td class="website"><a href="http://fallabs.com/qdbm/">QDBM</a></td>
     </tr>
     <tr>
+        <td class="package">qhttpengine</td>
+        <td class="website"><a href="https://github.com/nitroshare/qhttpengine">qhttpengine</a></td>
+    </tr>
+    <tr>
         <td class="package">qjson</td>
         <td class="website"><a href="http://qjson.sourceforge.net/">QJson</a></td>
     </tr>

--- a/src/qhttpengine.mk
+++ b/src/qhttpengine.mk
@@ -1,0 +1,20 @@
+# This file is part of MXE.
+# See index.html for further information.
+
+PKG             := qhttpengine
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 0.1.0
+$(PKG)_CHECKSUM := 427d13e34606c1a4a5f0a74c76fc82e816d625aa
+$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.gz
+$(PKG)_URL      := https://github.com/nitroshare/qhttpengine/archive/$($(PKG)_VERSION).tar.gz
+$(PKG)_DEPS     := gcc qtbase
+
+define $(PKG)_BUILD
+    mkdir '$(1)/build'
+    cd '$(1)/build' && cmake .. \
+        -DCMAKE_TOOLCHAIN_FILE='$(CMAKE_TOOLCHAIN_FILE)' \
+        -DBUILD_STATIC=$(if $(BUILD_STATIC),ON,OFF)
+
+    $(MAKE) -C '$(1)/build' -j '$(JOBS)' install
+endef


### PR DESCRIPTION
QHttpEngine is a small, lightweight library that provides a set of classes for creating HTTP servers. It is based on Qt 5 and will be used in the next version of [NitroShare](https://github.com/nitroshare/nitroshare-desktop) to provide a local API.

The library can be built both as a static and shared library and I have tested both. Because the library uses the CMake `find_package()` command, it is necessary to provide CMake with the path to `Qt5NetworkConfig.cmake`. I have done this via:

    -DCMAKE_PREFIX_PATH='$(PREFIX)/$(TARGET)/qt5/lib/cmake'