### PR TITLE
add package pire

### DIFF
--- a/index.html
+++ b/index.html
@@ -2036,6 +2036,10 @@ local-pkg-list: $(LOCAL_PKG_LIST)</pre>
         <td class="website"><a href="http://code.google.com/p/picomodel/">picomodel</a></td>
     </tr>
     <tr>
+        <td class="package">pire</td>
+        <td class="website"><a href="https://github.com/yandex/pire">PIRE</a></td>
+    </tr>
+    <tr>
         <td class="package">pixman</td>
         <td class="website"><a href="http://cairographics.org/">pixman</a></td>
     </tr>

--- a/src/pire-1-remove-custom-isatty.patch
+++ b/src/pire-1-remove-custom-isatty.patch
@@ -1,0 +1,41 @@
+This file is part of MXE.
+See index.html for further information.
+
+From 615d59e9c9afb76ccb8ece3a773bea13304ee1eb Mon Sep 17 00:00:00 2001
+From: Boris Nagaev <bnagaev@gmail.com>
+Date: Sat, 25 Jul 2015 16:39:52 +0300
+Subject: [PATCH] remove custom isatty
+
+Fix the following problem:
+
+In file included from mxe/usr/i686-w64-mingw32.static/include/unistd.h:10:0,
+                 from inline.cpp:588:
+mxe/usr/i686-w64-mingw32.static/include/io.h:319:37: error: conflicting declaration of 'int isatty(int)' with 'C' linkage
+   int __cdecl isatty(int _FileHandle) __MINGW_ATTRIB_DEPRECATED_MSVC2005;
+                                     ^
+inline.lpp:40:12: note: previous declaration with 'C++' linkage
+ static int isatty(int) { return 0; }
+            ^
+make[5]: *** [inline.o] Error 1
+---
+ pire/inline.lpp | 4 ----
+ 1 file changed, 4 deletions(-)
+
+diff --git a/pire/inline.lpp b/pire/inline.lpp
+index e5f6b55..25ef388 100644
+--- a/pire/inline.lpp
++++ b/pire/inline.lpp
+@@ -36,10 +36,6 @@ ystring filename = "";
+ int line = 1;
+ yvector<ystring> args;
+ 
+-#ifdef _WIN32
+-static int isatty(int) { return 0; }
+-#endif
+-
+ class Die {
+ public:
+ 	Die() {
+-- 
+1.9.1
+

--- a/src/pire-2-disable-samples-inline.patch
+++ b/src/pire-2-disable-samples-inline.patch
@@ -1,0 +1,39 @@
+This file is part of MXE.
+See index.html for further information.
+
+From 31ed00623baaa2f62ed3b0749f9acecc94ece85d Mon Sep 17 00:00:00 2001
+From: Boris Nagaev <bnagaev@gmail.com>
+Date: Sat, 25 Jul 2015 17:15:43 +0300
+Subject: [PATCH] disable samples/inline
+
+This sample requires running pire_inline, which is impossible
+in case of cross-compilation.
+---
+ configure.ac        | 1 -
+ samples/Makefile.am | 1 -
+ 2 files changed, 2 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index e185cb9..eafe6bb 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -101,7 +101,6 @@ AC_CONFIG_FILES([
+ 	tools/Makefile
+ 	tools/bench/Makefile
+ 	samples/Makefile
+-	samples/inline/Makefile
+ 	samples/blacklist/Makefile
+ 	samples/pigrep/Makefile
+ ])
+diff --git a/samples/Makefile.am b/samples/Makefile.am
+index 32adaf3..1acc17e 100644
+--- a/samples/Makefile.am
++++ b/samples/Makefile.am
+@@ -1,4 +1,3 @@
+ SUBDIRS = \
+-	inline \
+ 	blacklist \
+ 	pigrep
+-- 
+1.9.1
+

--- a/src/pire.mk
+++ b/src/pire.mk
@@ -1,0 +1,21 @@
+# This file is part of MXE.
+# See index.html for further information.
+
+PKG             := pire
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 0.0.5
+$(PKG)_CHECKSUM := fc5f451043c6fc1034f104463a4b9c6c1c46c00c
+$(PKG)_SUBDIR   := pire-release-$($(PKG)_VERSION)
+$(PKG)_FILE     := pire-$($(PKG)_VERSION).tar.gz
+$(PKG)_URL      := https://github.com/yandex/pire/archive/release-$($(PKG)_VERSION).tar.gz
+$(PKG)_DEPS     := gcc
+
+define $(PKG)_BUILD
+    cd '$(1)' && autoreconf -fi -I'$(PREFIX)/$(TARGET)/share/aclocal'
+    cd '$(1)' && ac_cv_func_malloc_0_nonnull=yes ./configure \
+        $(MXE_CONFIGURE_OPTS) \
+        --enable-extra \
+        PKG_CONFIG='$(PREFIX)/bin/$(TARGET)-pkg-config'
+    $(MAKE) -C '$(1)' -j '$(JOBS)'
+    $(MAKE) -C '$(1)' -j 1 install
+endef


### PR DESCRIPTION
PIRE is Perl Incompatible Regular Expressions library.
This library is aimed at checking a huge amount of text against
relatively many regular expressions. Roughly speaking, it can
just check whether given text maches the certain regexp, but
can do it really fast (more than 400 MB/s on our hardware is
common). Even more, multiple regexps can be combined together,
giving capability to check the text against apx. 10 regexps in
a single pass (and mantaining the same speed).

Pire was developed in Yandex (http://company.yandex.ru/) as a
part of its web crawler.

Homepage: https://github.com/yandex/pire