### PR TITLE
QtWebKit depends on SQLite even if SQLite support is turned off in QtBase

### DIFF
--- a/src/qtwebkit.mk
+++ b/src/qtwebkit.mk
@@ -8,7 +8,7 @@ $(PKG)_CHECKSUM := 402cd585ed7fea63b338fa6f89aec8b21db3564a
 $(PKG)_SUBDIR    = $(subst qtbase,qtwebkit,$(qtbase_SUBDIR))
 $(PKG)_FILE      = $(subst qtbase,qtwebkit,$(qtbase_FILE))
 $(PKG)_URL       = $(subst qtbase,qtwebkit,$(qtbase_URL))
-$(PKG)_DEPS     := gcc qtbase qtmultimedia qtquick1
+$(PKG)_DEPS     := gcc qtbase qtmultimedia qtquick1 sqlite
 
 define $(PKG)_UPDATE
     echo $(qtbase_VERSION)


### PR DESCRIPTION
The package qtwebkit will fail to build if sqlite hasn't been built. Normally, sqlite is pulled in by qtbase, but if it's disabled there, qtwebkit still needs it.