### PR TITLE
add package libid3tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -1665,6 +1665,10 @@ local-pkg-list: $(LOCAL_PKG_LIST)</pre>
         <td class="website"><a href="https://www.gnu.org/software/libiconv/">libiconv</a></td>
     </tr>
     <tr>
+        <td class="package">libid3tag</td>
+        <td class="website"><a href="http://sourceforge.net/projects/mad/files/libid3tag/">libid3tag</a></td>
+    </tr>
+    <tr>
         <td class="package">libidn</td>
         <td class="website"><a href="https://www.gnu.org/software/libidn/">Libidn</a></td>
     </tr>

--- a/src/libid3tag.mk
+++ b/src/libid3tag.mk
@@ -1,0 +1,23 @@
+# This file is part of MXE.
+# See index.html for further information.
+
+PKG             := libid3tag
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 0.15.1b
+$(PKG)_CHECKSUM := 4d867e8a8436e73cd7762fe0e85958e35f1e4306
+$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.gz
+$(PKG)_URL      := http://$(SOURCEFORGE_MIRROR)/project/mad/$(PKG)/$($(PKG)_VERSION)/$($(PKG)_FILE)
+$(PKG)_DEPS     := gcc zlib
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- 'http://sourceforge.net/projects/mad/files/libid3tag/' | \
+    $(SED) -n 's,.*/\([0-9][^"]*\)/".*,\1,p' | \
+    head -1
+endef
+
+define $(PKG)_BUILD
+    cd '$(1)' && ./configure \
+        $(MXE_CONFIGURE_OPTS)
+    $(MAKE) -C '$(1)' -j '$(JOBS)' install LDFLAGS='-no-undefined'
+endef

--- a/src/libid3tag.mk
+++ b/src/libid3tag.mk
@@ -4,7 +4,7 @@
 PKG             := libid3tag
 $(PKG)_IGNORE   :=
 $(PKG)_VERSION  := 0.15.1b
-$(PKG)_CHECKSUM := 4d867e8a8436e73cd7762fe0e85958e35f1e4306
+$(PKG)_CHECKSUM := 63da4f6e7997278f8a3fef4c6a372d342f705051d1eeb6a46a86b03610e26151
 $(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
 $(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.gz
 $(PKG)_URL      := http://$(SOURCEFORGE_MIRROR)/project/mad/$(PKG)/$($(PKG)_VERSION)/$($(PKG)_FILE)
@@ -18,6 +18,9 @@ endef
 
 define $(PKG)_BUILD
     cd '$(1)' && ./configure \
-        $(MXE_CONFIGURE_OPTS)
+        $(MXE_CONFIGURE_OPTS) \
+        $(if $(BUILD_SHARED), \
+            lt_cv_deplibs_check_method='file_magic file format (pe-i386|pe-x86-64)' \
+            lt_cv_file_magic_cmd='$$OBJDUMP -f')
     $(MAKE) -C '$(1)' -j '$(JOBS)' install LDFLAGS='-no-undefined'
 endef


### PR DESCRIPTION
problems:
1)libid3tag.la files builds even for static compilers.
2)option LDFLAGS='-no-undefined' enable build libid3tag-0.dll only for i686-w64-mingw32.shared, not for x86_64-w64-mingw32.shared, log for x86_64-w64-mingw32.shared: https://gist.github.com/pavelvat/be9a6958b390aa1908d7
