### PR TITLE
fix pcl build

### DIFF
--- a/src/pcl-1-cmake-policy-cmp0017.patch
+++ b/src/pcl-1-cmake-policy-cmp0017.patch
@@ -1,0 +1,28 @@
+This file is part of MXE.
+See index.html for further information.
+
+From 0a5d7e96ad3d5ce39284968258fe78f39fe5f4ca Mon Sep 17 00:00:00 2001
+From: Boris Nagaev <bnagaev@gmail.com>
+Date: Thu, 27 Aug 2015 08:16:41 +0200
+Subject: [PATCH] cmake_policy CMP0017
+
+---
+ CMakeLists.txt |    2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f0a5600..ea9ebcf 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -5,6 +5,8 @@ if(POLICY CMP0048)
+   cmake_policy(SET CMP0048 OLD) # do not use VERSION option in project() command
+ endif()
+ 
++cmake_policy(SET CMP0017 NEW)
++
+ set(CMAKE_CONFIGURATION_TYPES "Debug;Release" CACHE STRING "possible configurations" FORCE)
+ 
+ # In case the user does not setup CMAKE_BUILD_TYPE, assume it's RelWithDebInfo
+-- 
+1.7.10.4
+


### PR DESCRIPTION
Add "cmake_policy(SET CMP0017 NEW)" to CMakeLists.txt

$ cmake --help-policy CMP0017

> Starting with CMake 2.8.4, if a cmake-module shipped with CMake (i.e.
> located in the CMake module directory) calls include() or
> find_package(), the files located in the the CMake module directory
> are preferred over the files in CMAKE_MODULE_PATH.  This makes sure
> that the modules belonging to CMake always get those files included
> which they expect, and against which they were developed and tested.
> In call other cases, the files found in CMAKE_MODULE_PATH still take
> precedence over the ones in the CMake module directory.  The OLD
> behaviour is to always prefer files from CMAKE_MODULE_PATH over files
> from the CMake modules directory.

Error message:
```
CMake Error at /usr/share/cmake-2.8/Modules/FindPackageHandleStandardArgs.cmake:97 (MESSAGE):
  Could NOT find PkgConfig (missing: PKG_CONFIG_EXECUTABLE) (found version
  "0.28")
Call Stack (most recent call first):
  /usr/share/cmake-2.8/Modules/FindPackageHandleStandardArgs.cmake:288 (_FPHSA_FAILURE_MESSAGE)
  /usr/share/cmake-2.8/Modules/FindPkgConfig.cmake:102 (find_package_handle_standard_args)
  /usr/lib/mxe/src/cmake/FindTIFF.cmake:5 (find_package)
  /usr/share/cmake-2.8/Modules/Qt4ConfigDependentSettings.cmake:86 (find_package)
  /usr/share/cmake-2.8/Modules/FindQt4.cmake:1053 (INCLUDE)
  CMakeLists.txt:336 (find_package)
```
close #734