### PR TITLE
build-pkg: pkgs with broken deps are also broken

### DIFF
--- a/tools/build-pkg.lua
+++ b/tools/build-pkg.lua
@@ -336,6 +336,7 @@ local function buildPackages(pkgs, pkg2deps)
                 log('The package is broken: ' .. pkg)
             end
         else
+            broken[pkg] = true
             local msg = 'Package %s depends on broken %s'
             log(msg:format(pkg, brokenDep(pkg)))
         end


### PR DESCRIPTION
Bad behaviour prior to this commit:

1. The package is broken: pango
2. Package sdl_pango depends on broken pango
3. When t4k_common (which depends on sdl_pango) is built, pango is tried to build again.

This issue was caused by the error fixed in this commit: if a package A depends on a broken package B, then the package A is also BROKEN. So if a package C depends on package A, then all of them are broken:
```
(*)B <- A <- C
```
B is not "rebuilt" for C.