### PR TITLE
build-pkg: add release to mxe-requirements version

### DIFF
--- a/tools/build-pkg.lua
+++ b/tools/build-pkg.lua
@@ -22,6 +22,8 @@ local GIT = 'git --work-tree=./usr/ --git-dir=./usr/.git '
 local BLACKLIST = {
     '^usr/installed/check%-requirements$',
     '^usr/share/',
+    '^usr/[^/]+/share/doc/',
+    '^usr/[^/]+/share/info/',
 }
 
 local COMMON_FILES = {

--- a/tools/build-pkg.lua
+++ b/tools/build-pkg.lua
@@ -435,7 +435,7 @@ Description: MXE requirements package
 
 local function makeMxeRequirementsDeb(release)
     local name = 'mxe-requirements'
-    local ver = getMxeVersion()
+    local ver = getMxeVersion() .. release
     -- dependencies
     local deps = {
         'autoconf', 'automake', 'autopoint', 'bash', 'bison',

--- a/tools/build-pkg.lua
+++ b/tools/build-pkg.lua
@@ -470,7 +470,7 @@ end
 
 local function makeCommonDeb(pkg, ver)
     local common_files = filterFiles(pkg, true)
-    local list_path = pkg .. '.common-list'
+    local list_path = ('common-%s.list'):format(pkg)
     saveFileList(list_path, common_files)
     local orig_target = target
     target = 'common'

--- a/tools/build-pkg.lua
+++ b/tools/build-pkg.lua
@@ -232,6 +232,10 @@ local function protectVersion(ver)
     end
 end
 
+local function listFile(pkg)
+    return pkg .. '.list'
+end
+
 local CONTROL = [[Package: %s
 Version: %s
 Section: devel
@@ -328,7 +332,7 @@ local function buildPackages(pkgs, pkg2deps)
         if not brokenDep(pkg) then
             local files = buildPackage(pkg)
             if isBuilt(pkg, files) then
-                saveFileList(pkg .. '.list', files)
+                saveFileList(listFile(pkg), files)
                 table.insert(unbroken, pkg)
             else
                 -- broken package
@@ -345,7 +349,7 @@ local function buildPackages(pkgs, pkg2deps)
 end
 
 local function filterFiles(pkg, filter_common)
-    local list = readFileList(pkg .. '.list')
+    local list = readFileList(listFile(pkg))
     local list2 = {}
     local common_list = COMMON_FILES[pkg]
     for _, installed_file in ipairs(list) do
@@ -359,7 +363,7 @@ end
 
 local function excludeCommon(pkg)
     local noncommon_files = filterFiles(pkg, false)
-    saveFileList(pkg .. '.list', noncommon_files)
+    saveFileList(listFile(pkg), noncommon_files)
 end
 
 local function makeCommonDeb(pkg, ver)
@@ -376,7 +380,7 @@ local function makeDebs(pkgs, pkg2deps, pkg2ver)
     for _, pkg in ipairs(pkgs) do
         local deps = assert(pkg2deps[pkg], pkg)
         local ver = assert(pkg2ver[pkg], pkg)
-        local list_path = pkg .. '.list'
+        local list_path = listFile(pkg)
         local add_common = false
         if COMMON_FILES[pkg] then
             if target == ARCH_FOR_COMMON then

--- a/tools/build-pkg.lua
+++ b/tools/build-pkg.lua
@@ -233,7 +233,7 @@ local function protectVersion(ver)
 end
 
 local function listFile(pkg)
-    return pkg .. '.list'
+    return ('%s-%s.list'):format(target, pkg)
 end
 
 local CONTROL = [[Package: %s

--- a/tools/build-pkg.lua
+++ b/tools/build-pkg.lua
@@ -61,7 +61,7 @@ local ARCH_FOR_COMMON = 'i686-w64-mingw32.static'
 local target -- used by many functions
 
 local function log(fmt, ...)
-    print(target, fmt:format(...))
+    print('[build-pkg]', target, fmt:format(...))
 end
 
 -- based on http://lua-users.org/wiki/SplitJoin

--- a/tools/build-pkg.lua
+++ b/tools/build-pkg.lua
@@ -62,6 +62,13 @@ local COMMON_FILES = {
 
 local ARCH_FOR_COMMON = 'i686-w64-mingw32.static'
 
+local TARGETS = {
+    'i686-w64-mingw32.static',
+    'x86_64-w64-mingw32.static',
+    'i686-w64-mingw32.shared',
+    'x86_64-w64-mingw32.shared',
+}
+
 local target -- used by many functions
 
 local function log(fmt, ...)
@@ -498,9 +505,8 @@ end
 assert(trim(shell('pwd')) == MXE_DIR,
     "Clone MXE to " .. MXE_DIR)
 gitInit()
-buildForTarget('i686-w64-mingw32.static')
-buildForTarget('x86_64-w64-mingw32.static')
-buildForTarget('i686-w64-mingw32.shared')
-buildForTarget('x86_64-w64-mingw32.shared')
+for _, t in ipairs(TARGETS) do
+    buildForTarget(t)
+end
 makeMxeRequirementsDeb('wheezy')
 makeMxeRequirementsDeb('jessie')

--- a/tools/build-pkg.lua
+++ b/tools/build-pkg.lua
@@ -60,8 +60,8 @@ local ARCH_FOR_COMMON = 'i686-w64-mingw32.static'
 
 local target -- used by many functions
 
-local function log(...)
-    print(target, ...)
+local function log(fmt, ...)
+    print(target, fmt:format(...))
 end
 
 -- based on http://lua-users.org/wiki/SplitJoin
@@ -337,12 +337,12 @@ local function buildPackages(pkgs, pkg2deps)
             else
                 -- broken package
                 broken[pkg] = true
-                log('The package is broken: ' .. pkg)
+                log('The package is broken: %s', pkg)
             end
         else
             broken[pkg] = true
-            local msg = 'Package %s depends on broken %s'
-            log(msg:format(pkg, brokenDep(pkg)))
+            log('Package %s depends on broken %s',
+                pkg, brokenDep(pkg))
         end
     end
     return unbroken


### PR DESCRIPTION
2.23 -> 2.23jessie | 2.23wheezy

Package mxe-requirements has different dependencies for
Wheezy and Jessie. APT server reprepro doesn't allow to
add two different packages with same name and version.