### PR TITLE
add packages lzma and upx

### DIFF
--- a/index.html
+++ b/index.html
@@ -2451,8 +2451,8 @@ local-pkg-list: $(LOCAL_PKG_LIST)</pre>
         <td class="website"><a href="http://www.twolame.org/">TwoLAME</a></td>
     </tr>
     <tr>
-         <td class="package">ucl</td>
-         <td class="website"><a href="http://www.oberhumer.com/opensource/ucl/">UCL</a></td>
+        <td class="package">ucl</td>
+        <td class="website"><a href="http://www.oberhumer.com/opensource/ucl/">UCL</a></td>
     </tr>
     <tr>
         <td class="package">unrtf</td>

--- a/index.html
+++ b/index.html
@@ -1859,6 +1859,10 @@ local-pkg-list: $(LOCAL_PKG_LIST)</pre>
         <td class="website"><a href="http://luajit.org/luajit.html">LuaJIT</a></td>
     </tr>
     <tr>
+        <td class="package">lzma</td>
+        <td class="website"><a href="http://www.7-zip.org/sdk.html">LZMA SDK</a></td>
+    </tr>
+    <tr>
         <td class="package">lzo</td>
         <td class="website"><a href="http://www.oberhumer.com/opensource/lzo/">lzo</a></td>
     </tr>

--- a/index.html
+++ b/index.html
@@ -2459,6 +2459,10 @@ local-pkg-list: $(LOCAL_PKG_LIST)</pre>
         <td class="website"><a href="https://www.gnu.org/software/unrtf/">unRTF</a></td>
     </tr>
     <tr>
+        <td class="package">upx</td>
+        <td class="website"><a href="http://upx.sourceforge.net/">UPX</a></td>
+    </tr>
+    <tr>
         <td class="package">vamp-plugin-sdk</td>
         <td class="website"><a href="http://vamp-plugins.org/">Vamp Plugins SDK</a></td>
     </tr>

--- a/src/lzma-1-include-stdio.h.patch
+++ b/src/lzma-1-include-stdio.h.patch
@@ -1,0 +1,27 @@
+This file is part of MXE.
+See index.html for further information.
+
+From dd3c0c213571d2ff8acbb3b19966cfa4d6bff3cc Mon Sep 17 00:00:00 2001
+From: Boris Nagaev <bnagaev@gmail.com>
+Date: Sun, 30 Aug 2015 14:26:24 +0200
+Subject: [PATCH] include stdio.h
+
+---
+ CPP/7zip/Common/FileStreams.cpp |    1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/CPP/7zip/Common/FileStreams.cpp b/CPP/7zip/Common/FileStreams.cpp
+index de49911..7609c56 100755
+--- a/CPP/7zip/Common/FileStreams.cpp
++++ b/CPP/7zip/Common/FileStreams.cpp
+@@ -1,6 +1,7 @@
+ // FileStreams.cpp
+ 
+ #include "StdAfx.h"
++#include <stdio.h>
+ 
+ #ifndef _WIN32
+ #include <fcntl.h>
+-- 
+1.7.10.4
+

--- a/src/lzma-2-mystring-include-windows.patch
+++ b/src/lzma-2-mystring-include-windows.patch
@@ -1,0 +1,28 @@
+This file is part of MXE.
+See index.html for further information.
+
+From 7798a70fa69dc4994cc25f82ec3e9b2b368d50fe Mon Sep 17 00:00:00 2001
+From: Boris Nagaev <bnagaev@gmail.com>
+Date: Sun, 30 Aug 2015 14:46:10 +0200
+Subject: [PATCH] MyString: include windows.h
+
+Functions CharUpperA, CharPrev etc
+---
+ CPP/Common/MyString.h |    1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/CPP/Common/MyString.h b/CPP/Common/MyString.h
+index 7db8a37..297986f 100755
+--- a/CPP/Common/MyString.h
++++ b/CPP/Common/MyString.h
+@@ -4,6 +4,7 @@
+ #define __COMMON_STRING_H
+ 
+ #include <string.h>
++#include <windows.h>
+ 
+ #include "MyVector.h"
+ 
+-- 
+1.7.10.4
+

--- a/src/lzma.mk
+++ b/src/lzma.mk
@@ -1,0 +1,42 @@
+# This file is part of MXE.
+# See index.html for further information.
+
+PKG             := lzma
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 920
+$(PKG)_CHECKSUM := 8ac221acdca8b6f6dd110120763af42b3707363752fc04e63c7bbff76774a445
+$(PKG)_SUBDIR   := .
+$(PKG)_FILE     := lzma$(subst .,,$($(PKG)_VERSION)).tar.bz2
+$(PKG)_URL      := http://www.7-zip.org/a/$($(PKG)_FILE)
+$(PKG)_DEPS     := gcc
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- 'http://www.7-zip.org/sdk.html' | \
+    $(SED) -n 's,.*lzma\([0-9][^"]*\)\.tar.*,\1,p' | \
+    head -1
+endef
+
+define $(PKG)_BUILD
+    $(MAKE) all -C '$(1)/C/Util/Lzma' \
+        -f makefile.gcc -j '$(JOBS)' \
+        'PROG=lzma.exe' \
+        'CC=$(TARGET)-gcc' \
+        'CXX=$(TARGET)-g++' \
+        'LD=$(TARGET)-ld' \
+        'AR=$(TARGET)-ar' \
+        'PKG_CONFIG=$(TARGET)-pkg-config'
+    $(MAKE) all -C '$(1)/CPP/7zip/Bundles/LzmaCon' \
+        -f makefile.gcc -j '$(JOBS)' \
+        'IS_MINGW=1' \
+        'PROG=lzma.exe' \
+        'CXX=$(TARGET)-g++ -O2 -Wall' \
+        'CXX_C=$(TARGET)-gcc -O2 -Wall' \
+        'CC=$(TARGET)-gcc' \
+        'LD=$(TARGET)-ld' \
+        'AR=$(TARGET)-ar' \
+        'PKG_CONFIG=$(TARGET)-pkg-config'
+    cp '$(1)/C/Util/Lzma/lzma.exe' \
+        '$(PREFIX)/$(TARGET)/bin/lzma.exe'
+    cp '$(1)/CPP/7zip/Bundles/LzmaCon/lzma.exe' \
+        '$(PREFIX)/$(TARGET)/bin/lzma-cxx.exe'
+endef

--- a/src/upx-1-fix-logging.patch
+++ b/src/upx-1-fix-logging.patch
@@ -1,0 +1,52 @@
+This file is part of MXE.
+See index.html for further information.
+
+From a9c84ba7518ea4cc92cf4b391f609c3f6ade0974 Mon Sep 17 00:00:00 2001
+From: Boris Nagaev <bnagaev@gmail.com>
+Date: Sun, 30 Aug 2015 16:13:06 +0200
+Subject: [PATCH] fix logging
+
+Set logging function to simple fprintf.
+---
+ src/c_init.cpp |    3 ++-
+ src/console.h  |    3 +--
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/src/c_init.cpp b/src/c_init.cpp
+index 542b066..a1ce500 100644
+--- a/src/c_init.cpp
++++ b/src/c_init.cpp
+@@ -141,7 +141,7 @@ console_t console_init =
+     intro
+ };
+ 
+-
++/*
+ void __acc_cdecl_va con_fprintf(FILE *f, const char *format, ...)
+ {
+     va_list args;
+@@ -156,6 +156,7 @@ void __acc_cdecl_va con_fprintf(FILE *f, const char *format, ...)
+     assert(con != me);
+     con->print0(f,buf);
+ }
++*/
+ 
+ #endif /* USE_CONSOLE */
+ 
+diff --git a/src/console.h b/src/console.h
+index eeee36e..4a2c4c0 100644
+--- a/src/console.h
++++ b/src/console.h
+@@ -123,8 +123,7 @@ console_t;
+ 
+ 
+ #if defined(__GNUC__)
+-void __acc_cdecl_va con_fprintf(FILE *f, const char *format, ...)
+-        __attribute__((__format__(printf,2,3)));
++#define con_fprintf fprintf
+ #else
+ void __acc_cdecl_va con_fprintf(FILE *f, const char *format, ...);
+ #endif
+-- 
+1.7.10.4
+

--- a/src/upx.mk
+++ b/src/upx.mk
@@ -1,0 +1,34 @@
+# This file is part of MXE.
+# See index.html for further information.
+
+PKG             := upx
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 3.91
+$(PKG)_CHECKSUM := 527ce757429841f51675352b1f9f6fc8ad97b18002080d7bf8672c466d8c6a3c
+$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)-src
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION)-src.tar.bz2
+$(PKG)_URL      := http://upx.sourceforge.net/download/$($(PKG)_FILE)
+$(PKG)_DEPS     := gcc ucl zlib lzma
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- 'http://upx.sourceforge.net/' | \
+    $(SED) -n 's,.*upx-\([0-9][^"]*\)\-src.tar.*,\1,p' | \
+    head -1
+endef
+
+define $(PKG)_BUILD
+    $(call PREPARE_PKG_SOURCE,ucl,$(1))
+    mkdir '$(1)/lzma'
+    $(call PREPARE_PKG_SOURCE,lzma,$(1)/lzma)
+    UPX_UCLDIR='$(1)/$(ucl_SUBDIR)' \
+        UPX_LZMADIR='$(1)/lzma' \
+        UPX_LZMA_VERSION=0x$(subst .,,$(lzma_VERSION)) \
+        $(MAKE) -C '$(1)' -j '$(JOBS)' all \
+        'CXX=$(TARGET)-g++' \
+        'CC=$(TARGET)-gcc' \
+        'LD=$(TARGET)-ld' \
+        'AR=$(TARGET)-ar' \
+        'PKG_CONFIG=$(TARGET)-pkg-config' \
+        'exeext=.exe'
+    cp '$(1)/src/upx.exe' '$(PREFIX)/$(TARGET)/bin/'
+endef


### PR DESCRIPTION
**UPX** is a free, portable, extendable, high-performance executable packer for several executable formats.
http://upx.sourceforge.net

The **LZMA SDK** provides the documentation, samples, header files, libraries, and tools you need to develop applications that use LZMA compression.
http://www.7-zip.org/sdk.html

UPX depends on source of [UCL](http://www.oberhumer.com/opensource/ucl/) and LZMA. Tarballs with source of these packages are unpacked when UPX is built.