### PR TITLE
qhttpengine: decrease required cmake ver

### DIFF
--- a/src/qhttpengine-1-decrease-required-cmake-ver.patch
+++ b/src/qhttpengine-1-decrease-required-cmake-ver.patch
@@ -1,0 +1,51 @@
+This file is part of MXE.
+See index.html for further information.
+
+From ecc6fd682b2bef9aca06ce3f8ac3e6178faf4640 Mon Sep 17 00:00:00 2001
+From: Boris Nagaev <bnagaev@gmail.com>
+Date: Sun, 6 Sep 2015 03:45:19 +0200
+Subject: [PATCH] decrease required cmake ver.
+
+2.8.11 -> 2.8.9
+
+Debian Wheezy has CMake version 2.8.9
+
+To make it possible, CMake command target_include_directories
+was replaced with command include_directories.
+---
+ CMakeLists.txt     |    2 +-
+ src/CMakeLists.txt |    8 +++-----
+ 2 files changed, 4 insertions(+), 6 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ec32cd8..0e7ba11 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 2.8.11)
++cmake_minimum_required(VERSION 2.8.9)
+ project(QHttpEngine)
+ 
+ if(NOT (CMAKE_MAJOR_VERSION VERSION_LESS 3))
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 83f9a4c..0313dc3 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -28,11 +28,9 @@ endif()
+ 
+ qt5_use_modules(QHttpEngine Network)
+ 
+-target_include_directories(QHttpEngine PUBLIC
+-    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>"
+-    "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>"
+-    "$<INSTALL_INTERFACE:${INCLUDE_INSTALL_DIR}>"
+-)
++include_directories(${CMAKE_CURRENT_SOURCE_DIR})
++include_directories(${CMAKE_CURRENT_BINARY_DIR})
++include_directories(${INCLUDE_INSTALL_DIR})
+ 
+ set_target_properties(QHttpEngine PROPERTIES
+     DEFINE_SYMBOL QT_NO_SIGNALS_SLOTS_KEYWORDS
+-- 
+1.7.10.4
+


### PR DESCRIPTION
Fix build for CMake 2.8.9, which is used in Debian Wheezy.