### PR TITLE
a52dec: rm aclocal.m4

### DIFF
--- a/src/a52dec.mk
+++ b/src/a52dec.mk
@@ -17,7 +17,7 @@ define $(PKG)_UPDATE
 endef
 
 define $(PKG)_BUILD
-    cd '$(1)' && autoreconf -fi # The autotools files came with a52dec are _ancient_
+    cd '$(1)' && rm aclocal.m4 && autoreconf -fi # The autotools files came with a52dec are _ancient_
     cd '$(1)' && ./configure CFLAGS=-std=gnu89 \
         $(MXE_CONFIGURE_OPTS)
     $(MAKE) -C '$(1)' -j '$(JOBS)' bin_PROGRAMS= sbin_PROGRAMS= noinst_PROGRAMS=


### PR DESCRIPTION
aclocal.m4 generated with old version of libtool break the build

https://lists.nongnu.org/archive/html/mingw-cross-env-list/2015-08/msg00021.html

close #798