### PR TITLE
add package libmysqlclient

### DIFF
--- a/index.html
+++ b/index.html
@@ -1725,6 +1725,10 @@ local-pkg-list: $(LOCAL_PKG_LIST)</pre>
         <td class="website"><a href="http://www.musepack.net/">libmpcdec</a></td>
     </tr>
     <tr>
+        <td class="package">libmysqlclient</td>
+        <td class="website"><a href="https://dev.mysql.com/downloads/connector/c/">libmysqlclient</a></td>
+    </tr>
+    <tr>
         <td class="package">libntlm</td>
         <td class="website"><a href="http://www.nongnu.org/libntlm/">Libntlm</a></td>
     </tr>

--- a/src/libmysqlclient-1-use-comp-err-tool-built-in-native-build.patch
+++ b/src/libmysqlclient-1-use-comp-err-tool-built-in-native-build.patch
@@ -1,0 +1,50 @@
+This file is part of MXE.
+See index.html for further information.
+
+From 69b0fe0b531fd93bd757f0df188a620aad2a5755 Mon Sep 17 00:00:00 2001
+From: Boris Nagaev <bnagaev@gmail.com>
+Date: Sun, 6 Sep 2015 22:34:47 +0100
+Subject: [PATCH 1/5] use comp_err tool built in native build
+
+See http://www.vtk.org/Wiki/CMake_Cross_Compiling#Using_executables_in_the_build_created_during_the_build
+---
+ extra/CMakeLists.txt | 16 ++++++++++++++++
+ 1 file changed, 16 insertions(+)
+
+diff --git a/extra/CMakeLists.txt b/extra/CMakeLists.txt
+index ac28c62..b2cbb75 100644
+--- a/extra/CMakeLists.txt
++++ b/extra/CMakeLists.txt
+@@ -20,13 +20,29 @@ ${ZLIB_INCLUDE_DIR})
+ # Default install component for the files here
+ SET(MYSQL_INSTALL_COMPONENT Development)
+ 
++# See https://bugs.mysql.com/bug.php?id=61340
++# See http://www.vtk.org/Wiki/CMake_Cross_Compiling
++
++# when crosscompiling import the executable targets from a file
++IF(CMAKE_CROSSCOMPILING)
++  SET(IMPORT_COMP_ERR "IMPORTFILE-NOTFOUND"
++  CACHE FILEPATH "Point it to the export file from a native build")
++  INCLUDE(${IMPORT_COMP_ERR})
++ENDIF(CMAKE_CROSSCOMPILING)
++
++# only build the generator if not crosscompiling
++# export the generator target to a file, so it can be imported
++#  (see above) by another build
++# the IF() is not necessary, but makes the intention clearer
+ IF(NOT CMAKE_CROSSCOMPILING)
+  ADD_EXECUTABLE(comp_err comp_err.c)
+  TARGET_LINK_LIBRARIES(comp_err mysys mysys_ssl)
+  SET_TARGET_PROPERTIES(comp_err PROPERTIES LINKER_LANGUAGE CXX)
++ EXPORT(TARGETS comp_err FILE ${CMAKE_BINARY_DIR}/ImportCompErr.cmake)
+ ENDIF()
+ 
+ 
++# then use the target name as COMMAND, CMake >= 2.6 knows how to handle this
+ ADD_CUSTOM_COMMAND(OUTPUT ${PROJECT_BINARY_DIR}/include/mysqld_error.h 
+                    ${PROJECT_BINARY_DIR}/sql/share/english/errmsg.sys
+                    COMMAND comp_err
+-- 
+2.1.4
+

--- a/src/libmysqlclient-2-fix-extra-qualification-handshake.patch
+++ b/src/libmysqlclient-2-fix-extra-qualification-handshake.patch
@@ -1,0 +1,29 @@
+This file is part of MXE.
+See index.html for further information.
+
+From 088fa6af785209f6b6230dcba5b26583a68be6fc Mon Sep 17 00:00:00 2001
+From: Boris Nagaev <bnagaev@gmail.com>
+Date: Sun, 6 Sep 2015 22:53:33 +0100
+Subject: [PATCH 2/5] fix extra qualification 'Handshake::'
+
+Compilation error.
+---
+ libmysql/authentication_win/handshake.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libmysql/authentication_win/handshake.h b/libmysql/authentication_win/handshake.h
+index 14b1386..395af36 100644
+--- a/libmysql/authentication_win/handshake.h
++++ b/libmysql/authentication_win/handshake.h
+@@ -100,7 +100,7 @@ public:
+   Handshake(const char *ssp, side_t side);
+   virtual ~Handshake();
+ 
+-  int Handshake::packet_processing_loop();
++  int packet_processing_loop();
+ 
+   bool virtual is_complete() const
+   {
+-- 
+2.1.4
+

--- a/src/libmysqlclient-3-fix-case-in-headers-and-libs.patch
+++ b/src/libmysqlclient-3-fix-case-in-headers-and-libs.patch
@@ -1,0 +1,70 @@
+This file is part of MXE.
+See index.html for further information.
+
+From cbbcedc1a44012a46498c26885702915a0093a6c Mon Sep 17 00:00:00 2001
+From: Boris Nagaev <bnagaev@gmail.com>
+Date: Mon, 7 Sep 2015 22:59:18 +0100
+Subject: [PATCH 3/5] fix case in headers and libs (should be lowercase)
+
+---
+ extra/yassl/src/yassl_int.cpp                | 2 +-
+ include/mysql/psi/mysql_socket.h             | 2 +-
+ libmysql/authentication_win/CMakeLists.txt   | 2 +-
+ libmysql/authentication_win/plugin_client.cc | 2 +-
+ 4 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/extra/yassl/src/yassl_int.cpp b/extra/yassl/src/yassl_int.cpp
+index 2993a1a..04b1fda 100644
+--- a/extra/yassl/src/yassl_int.cpp
++++ b/extra/yassl/src/yassl_int.cpp
+@@ -20,7 +20,7 @@
+ // First include (the generated) my_config.h, to get correct platform defines.
+ #include "my_config.h"
+ #ifdef _WIN32
+-#include<Windows.h>
++#include<windows.h>
+ #else
+ #include <pthread.h>
+ #endif
+diff --git a/include/mysql/psi/mysql_socket.h b/include/mysql/psi/mysql_socket.h
+index 41a7cb4..5f6d91d 100644
+--- a/include/mysql/psi/mysql_socket.h
++++ b/include/mysql/psi/mysql_socket.h
+@@ -29,7 +29,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ #ifdef _WIN32
+   #include <ws2def.h>
+   #include <winsock2.h>
+-  #include <MSWSock.h>
++  #include <mswsock.h>
+   #define SOCKBUF_T char
+ #else
+   #include <netinet/in.h>
+diff --git a/libmysql/authentication_win/CMakeLists.txt b/libmysql/authentication_win/CMakeLists.txt
+index f2979fb..83e5441 100644
+--- a/libmysql/authentication_win/CMakeLists.txt
++++ b/libmysql/authentication_win/CMakeLists.txt
+@@ -26,7 +26,7 @@ SET(HEADERS common.h handshake.h)
+ SET(PLUGIN_SOURCES plugin_client.cc handshake_client.cc log_client.cc common.cc handshake.cc)
+ 
+ ADD_CONVENIENCE_LIBRARY(auth_win_client ${PLUGIN_SOURCES} ${HEADERS})
+-TARGET_LINK_LIBRARIES(auth_win_client Secur32)
++TARGET_LINK_LIBRARIES(auth_win_client secur32)
+ 
+ # In IDE, group headers in a separate folder.
+ 
+diff --git a/libmysql/authentication_win/plugin_client.cc b/libmysql/authentication_win/plugin_client.cc
+index d25aae8..ecfee79 100644
+--- a/libmysql/authentication_win/plugin_client.cc
++++ b/libmysql/authentication_win/plugin_client.cc
+@@ -26,7 +26,7 @@
+ */
+ 
+ #ifdef _MSC_VER
+-#pragma comment(lib, "Secur32")
++#pragma comment(lib, "secur32")
+ #endif
+ 
+ static int win_auth_client_plugin_init(char*, size_t, int, va_list)
+-- 
+2.1.4
+

--- a/src/libmysqlclient-4-define-missing-types.patch
+++ b/src/libmysqlclient-4-define-missing-types.patch
@@ -1,0 +1,31 @@
+This file is part of MXE.
+See index.html for further information.
+
+From 8b8c6c188cca7c4ae995c803cffe82bef73c91a4 Mon Sep 17 00:00:00 2001
+From: Boris Nagaev <bnagaev@gmail.com>
+Date: Mon, 7 Sep 2015 23:01:35 +0100
+Subject: [PATCH 4/5] define missing types
+
+We do not use types CERT_NAME_BLOB and CRYPT_HASH_BLOB,
+though they are used in mprapi.h. And are not defined!
+---
+ mysys/my_gethwaddr.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/mysys/my_gethwaddr.c b/mysys/my_gethwaddr.c
+index 780c765..e2cd321 100644
+--- a/mysys/my_gethwaddr.c
++++ b/mysys/my_gethwaddr.c
+@@ -137,6 +137,9 @@ my_bool my_gethwaddr(uchar *to)
+ #define VOID void
+ #endif
+ 
++// mprapi.h uses these undefined types
++#define CERT_NAME_BLOB int
++#define CRYPT_HASH_BLOB int
+ #include <iphlpapi.h>
+ 
+ /*
+-- 
+2.1.4
+

--- a/src/libmysqlclient-5-macro-native-win32.patch
+++ b/src/libmysqlclient-5-macro-native-win32.patch
@@ -1,0 +1,131 @@
+This file is part of MXE.
+See index.html for further information.
+
+From 0d185ed2b345e57a5b07e7975650f7cef3977f27 Mon Sep 17 00:00:00 2001
+From: Boris Nagaev <bnagaev@gmail.com>
+Date: Mon, 7 Sep 2015 23:04:23 +0100
+Subject: [PATCH 5/5] macro NATIVE_WIN32 for stuff we don't have here
+
+Macro NATIVE_WIN32 is undefined in MXE. It is used instead of _WIN32
+in #ifdef's where working variant is Unix and not Win32:
+
+ * MXE has strtok_r, but not strtok_s
+ * MXE has sigset_t, mode_t timespec defined (do not redefine)
+ * MXE has Unix-like stacktrace reader
+---
+ include/m_string.h  |  2 +-
+ include/my_global.h | 13 +++++++++----
+ include/thr_cond.h  |  4 ++--
+ mysys/stacktrace.c  |  2 +-
+ 4 files changed, 13 insertions(+), 8 deletions(-)
+
+diff --git a/include/m_string.h b/include/m_string.h
+index e1576af..5417192 100644
+--- a/include/m_string.h
++++ b/include/m_string.h
+@@ -127,7 +127,7 @@ static inline ulonglong my_strtoull(const char *nptr, char **endptr, int base)
+ 
+ static inline char *my_strtok_r(char *str, const char *delim, char **saveptr)
+ {
+-#if defined _WIN32
++#if NATIVE_WIN32
+   return strtok_s(str, delim, saveptr);
+ #else
+   return strtok_r(str, delim, saveptr);
+diff --git a/include/my_global.h b/include/my_global.h
+index acadb44..c71b9c2 100644
+--- a/include/my_global.h
++++ b/include/my_global.h
+@@ -25,6 +25,8 @@
+ #define __STDC_FORMAT_MACROS	/* Enable C99 printf format macros */
+ #define _USE_MATH_DEFINES       /* Get access to M_PI, M_E, etc. in math.h */
+ 
++#define NATIVE_WIN32 (defined(_WIN32) && !defined(__MINGW32__))
++
+ #ifdef _WIN32
+ /* Include common headers.*/
+ # include <winsock2.h>
+@@ -205,7 +207,7 @@ C_MODE_START
+ typedef int	(*qsort_cmp)(const void *,const void *);
+ typedef int	(*qsort_cmp2)(const void*, const void *,const void *);
+ C_MODE_END
+-#ifdef _WIN32
++#if NATIVE_WIN32
+ typedef int       socket_len_t;
+ typedef int       sigset_t;
+ typedef int       mode_t;
+@@ -646,6 +648,9 @@ static inline struct tm *gmtime_r(const time_t *clock, struct tm *res)
+   return res;
+ }
+ 
++#endif
++
++#if NATIVE_WIN32
+ 
+ /*
+   Declare a union to make sure FILETIME is properly aligned
+@@ -671,7 +676,7 @@ C_MODE_END
+ 
+ static inline void set_timespec_nsec(struct timespec *abstime, ulonglong nsec)
+ {
+-#ifndef _WIN32
++#if !NATIVE_WIN32
+   ulonglong now= my_getsystime() + (nsec / 100);
+   abstime->tv_sec=   now / 10000000ULL;
+   abstime->tv_nsec= (now % 10000000ULL) * 100 + (nsec % 100);
+@@ -697,7 +702,7 @@ static inline void set_timespec(struct timespec *abstime, ulonglong sec)
+ */
+ static inline int cmp_timespec(struct timespec *ts1, struct timespec *ts2)
+ {
+-#ifndef _WIN32
++#if !NATIVE_WIN32
+   if (ts1->tv_sec > ts2->tv_sec ||
+       (ts1->tv_sec == ts2->tv_sec && ts1->tv_nsec > ts2->tv_nsec))
+     return 1;
+@@ -715,7 +720,7 @@ static inline int cmp_timespec(struct timespec *ts1, struct timespec *ts2)
+ 
+ static inline ulonglong diff_timespec(struct timespec *ts1, struct timespec *ts2)
+ {
+-#ifndef _WIN32
++#if !NATIVE_WIN32
+   return (ts1->tv_sec - ts2->tv_sec) * 1000000000ULL +
+     ts1->tv_nsec - ts2->tv_nsec;
+ #else
+diff --git a/include/thr_cond.h b/include/thr_cond.h
+index 480e936..bd8e394 100644
+--- a/include/thr_cond.h
++++ b/include/thr_cond.h
+@@ -39,7 +39,7 @@ typedef CONDITION_VARIABLE native_cond_t;
+ typedef pthread_cond_t native_cond_t;
+ #endif
+ 
+-#ifdef _WIN32
++#if NATIVE_WIN32
+ /**
+   Convert abstime to milliseconds
+ */
+@@ -104,7 +104,7 @@ static inline int native_cond_timedwait(native_cond_t *cond,
+                                         const struct timespec *abstime)
+ {
+ #ifdef _WIN32
+-  DWORD timeout= get_milliseconds(abstime);
++  DWORD timeout= abstime->tv_nsec / 1000000 + abstime->tv_sec * 1000;
+   if (!SleepConditionVariableCS(cond, mutex, timeout))
+     return ETIMEDOUT;
+   return 0;
+diff --git a/mysys/stacktrace.c b/mysys/stacktrace.c
+index 226d469..45d37b1 100644
+--- a/mysys/stacktrace.c
++++ b/mysys/stacktrace.c
+@@ -15,7 +15,7 @@
+ 
+ #include "my_stacktrace.h"
+ 
+-#ifndef _WIN32
++#if !NATIVE_WIN32
+ #include "my_pthread.h"
+ #include "m_string.h"
+ #include <signal.h>
+-- 
+2.1.4
+

--- a/src/libmysqlclient-5-macro-native-win32.patch
+++ b/src/libmysqlclient-5-macro-native-win32.patch
@@ -36,21 +36,12 @@ diff --git a/include/my_global.h b/include/my_global.h
 index acadb44..c71b9c2 100644
 --- a/include/my_global.h
 +++ b/include/my_global.h
-@@ -25,6 +25,8 @@
- #define __STDC_FORMAT_MACROS	/* Enable C99 printf format macros */
- #define _USE_MATH_DEFINES       /* Get access to M_PI, M_E, etc. in math.h */
- 
-+#define NATIVE_WIN32 (defined(_WIN32) && !defined(__MINGW32__))
-+
- #ifdef _WIN32
- /* Include common headers.*/
- # include <winsock2.h>
 @@ -205,7 +207,7 @@ C_MODE_START
  typedef int	(*qsort_cmp)(const void *,const void *);
  typedef int	(*qsort_cmp2)(const void*, const void *,const void *);
  C_MODE_END
 -#ifdef _WIN32
-+#if NATIVE_WIN32
++#ifdef _MSC_VER
  typedef int       socket_len_t;
  typedef int       sigset_t;
  typedef int       mode_t;
@@ -60,7 +51,7 @@ index acadb44..c71b9c2 100644
  
 +#endif
 +
-+#if NATIVE_WIN32
++#ifdef _MSC_VER
  
  /*
    Declare a union to make sure FILETIME is properly aligned
@@ -69,7 +60,7 @@ index acadb44..c71b9c2 100644
  static inline void set_timespec_nsec(struct timespec *abstime, ulonglong nsec)
  {
 -#ifndef _WIN32
-+#if !NATIVE_WIN32
++#ifndef _MSC_VER
    ulonglong now= my_getsystime() + (nsec / 100);
    abstime->tv_sec=   now / 10000000ULL;
    abstime->tv_nsec= (now % 10000000ULL) * 100 + (nsec % 100);
@@ -78,7 +69,7 @@ index acadb44..c71b9c2 100644
  static inline int cmp_timespec(struct timespec *ts1, struct timespec *ts2)
  {
 -#ifndef _WIN32
-+#if !NATIVE_WIN32
++#ifndef _MSC_VER
    if (ts1->tv_sec > ts2->tv_sec ||
        (ts1->tv_sec == ts2->tv_sec && ts1->tv_nsec > ts2->tv_nsec))
      return 1;
@@ -87,7 +78,7 @@ index acadb44..c71b9c2 100644
  static inline ulonglong diff_timespec(struct timespec *ts1, struct timespec *ts2)
  {
 -#ifndef _WIN32
-+#if !NATIVE_WIN32
++#ifndef _MSC_VER
    return (ts1->tv_sec - ts2->tv_sec) * 1000000000ULL +
      ts1->tv_nsec - ts2->tv_nsec;
  #else
@@ -100,7 +91,7 @@ index 480e936..bd8e394 100644
  #endif
  
 -#ifdef _WIN32
-+#if NATIVE_WIN32
++#ifdef _MSC_VER
  /**
    Convert abstime to milliseconds
  */
@@ -122,7 +113,7 @@ index 226d469..45d37b1 100644
  #include "my_stacktrace.h"
  
 -#ifndef _WIN32
-+#if !NATIVE_WIN32
++#ifndef _MSC_VER
  #include "my_pthread.h"
  #include "m_string.h"
  #include <signal.h>

--- a/src/libmysqlclient.mk
+++ b/src/libmysqlclient.mk
@@ -1,0 +1,39 @@
+# This file is part of MXE.
+# See index.html for further information.
+
+PKG             := libmysqlclient
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 6.1.6
+$(PKG)_CHECKSUM := 2444586365c2c58e7ca2397d4617e5fe19f9f246
+$(PKG)_SUBDIR   := mysql-connector-c-$($(PKG)_VERSION)-src
+$(PKG)_FILE     := $($(PKG)_SUBDIR).tar.gz
+$(PKG)_URL      := https://dev.mysql.com/get/Downloads/Connector-C/$($(PKG)_FILE)
+$(PKG)_DEPS     := gcc pthreads openssl
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- 'https://dev.mysql.com/downloads/connector/c/' | \
+    $(SED) -n 's,.*mysql-connector-c-\([0-9\.]\+\)-win.*,\1,p' | \
+    head -1
+endef
+
+define $(PKG)_BUILD
+    # native build for tool comp_err
+    # See https://bugs.mysql.com/bug.php?id=61340
+    mkdir '$(1).native'
+    cd '$(1).native' && cmake \
+         '$(1)'
+    $(MAKE) -C '$(1).native' -j '$(JOBS)' VERBOSE=1
+    # cross-compilation
+    mkdir '$(1).build'
+    cd '$(1).build' && cmake \
+        -DCMAKE_INSTALL_PREFIX=$(PREFIX)/$(TARGET) \
+        -DCMAKE_TOOLCHAIN_FILE='$(CMAKE_TOOLCHAIN_FILE)' \
+        -DIMPORT_COMP_ERR='$(1).native/ImportCompErr.cmake' \
+        -DHAVE_GCC_ATOMIC_BUILTINS=1 \
+        -DDISABLE_SHARED=1 \
+        '$(1)'
+    $(MAKE) -C '$(1).build' -j '$(JOBS)' VERBOSE=1
+    $(MAKE) -C '$(1).build' -j 1 install VERBOSE=1
+endef
+
+$(PKG)_BUILD_SHARED =


### PR DESCRIPTION
Based on proposal #755 

Shared build was disabled because of [linking errors](https://gist.githubusercontent.com/starius/a6f651506a90272714fb/raw/8a9e66971ffbf22256fd93cf9e2b94ae3782272e/libmysqlclient_i686-w64-mingw32.shared) in test executable, caused by stdcall/cdecl mismatch. Probably it can be fixed using by creating `def`-file or by passing `--add-stdcall-alias` or `--kill-at`. Help is appreciated. See http://stackoverflow.com/a/9032772

MySQL needs tool `comp_err` to generate header `mysqld_error.h`. This tool is generated by the build, so it is to be compiled natively. CMake has command `EXPORT` for this scenario. The package is built twice: (1) natively, for `comp_err`, which is exported to (2) cross-build, using `comp_err` in normal CMake commands like `ADD_CUSTOM_COMMAND`. Read more http://www.vtk.org/Wiki/CMake_Cross_Compiling#Using_executables_in_the_build_created_during_the_build