### PR TITLE
Build pkg fix filenames with spaces

### DIFF
--- a/tools/build-pkg.lua
+++ b/tools/build-pkg.lua
@@ -122,6 +122,16 @@ local function shell(cmd)
     return text
 end
 
+local function fileExists(name)
+    local f = io.open(name, "r")
+    if f ~= nil then
+        io.close(f)
+        return true
+    else
+        return false
+    end
+end
+
 -- return several tables describing packages
 -- * list of packages
 -- * map from package to list of deps
@@ -227,7 +237,9 @@ local function gitStatus()
         local status, file = line:match('(..) (.*)')
         status = trim(status)
         file = 'usr/' .. file
-        if not isBlacklisted(file) then
+        if not fileExists(file) then
+            log('Missing file: %q', file)
+        elseif not isBlacklisted(file) then
             if status == 'A' then
                 table.insert(new_files, file)
             elseif status == 'M' then

--- a/tools/build-pkg.lua
+++ b/tools/build-pkg.lua
@@ -236,6 +236,10 @@ local function gitStatus()
     for line in git_st:lines() do
         local status, file = line:match('(..) (.*)')
         status = trim(status)
+        if file:sub(1, 1) == '"' then
+            -- filename with a space is quoted by git
+            file = file:sub(2, -2)
+        end
         file = 'usr/' .. file
         if not fileExists(file) then
             log('Missing file: %q', file)


### PR DESCRIPTION
see #842 

Broken symlinks detected:

```
usr/bin/i686-w64-mingw32.static-llvm-config
usr/i686-w64-mingw32.static/lib/libharfbuzz_too.a
usr/i686-w64-mingw32.static/bin/gda-list-config.exe
usr/i686-w64-mingw32.static/bin/gda-list-server-op.exe
usr/i686-w64-mingw32.static/bin/gda-sql.exe
usr/bin/i686-w64-mingw32.static-lrelease
```

(Only for `i686-w64-mingw32.static`.)