### PR TITLE
Revert "package agg: use mxe pkg mirror until project relocates"

### DIFF
--- a/src/agg.mk
+++ b/src/agg.mk
@@ -7,15 +7,10 @@ $(PKG)_VERSION  := 2.5
 $(PKG)_CHECKSUM := 08f23da64da40b90184a0414369f450115cdb328
 $(PKG)_SUBDIR   := agg-$($(PKG)_VERSION)
 $(PKG)_FILE     := agg-$($(PKG)_VERSION).tar.gz
-$(PKG)_URL      := $(PKG_MIRROR)/$($(PKG)_FILE)
+$(PKG)_URL      := http://www.antigrain.com/$($(PKG)_FILE)
 $(PKG)_DEPS     := gcc freetype sdl
 
 define $(PKG)_UPDATE
-    echo 'TODO: package agg is moving: https://github.com/mxe/mxe/issues/386' >&2;
-    echo $(agg_VERSION)
-endef
-
-define $(PKG)_UPDATE_OLD
     $(WGET) -q -O- 'http://www.antigrain.com/download/index.html' | \
     $(SED) -n 's,.*<A href="http://www.antigrain.com/agg-\([0-9.]*\).tar.gz".*,\1,p' | \
     head -1


### PR DESCRIPTION
This reverts commit c9afbabda56635bb1f2f49090a0c2091d4ab1340.

AGG project's site was restored.

See #386