### PR TITLE
add packages gtk3 and gtkmm3

### DIFF
--- a/index.html
+++ b/index.html
@@ -612,6 +612,10 @@ USE_OSGPLUGIN(&lt;plugin2&gt;)
         <td><a href="http://tukaani.org/xz/">XZ Utils</a></td>
         <td></td>
     </tr>
+    <tr>
+        <td><a href="http://www.gdk-pixbuf.org/">gdk-pixbuf</a></td>
+        <td></td>
+    </tr>
     </table>
 
     <h3 id="requirements-debian">Debian and derivatives</h3>
@@ -619,8 +623,8 @@ USE_OSGPLUGIN(&lt;plugin2&gt;)
     <!-- http://www.debian.org/distrib/packages#search_packages -->
     <pre>apt-get install \
     autoconf automake autopoint bash bison bzip2 cmake flex \
-    gettext git g++ gperf intltool libffi-dev libtool \
-    libltdl-dev libssl-dev libxml-parser-perl make openssl \
+    gettext git g++ gperf intltool libffi-dev libgdk-pixbuf2.0-dev \
+    libtool libltdl-dev libssl-dev libxml-parser-perl make openssl \
     p7zip-full patch perl pkg-config python ruby scons sed \
     unzip wget xz-utils</pre>
 
@@ -644,7 +648,7 @@ USE_OSGPLUGIN(&lt;plugin2&gt;)
     <!-- https://admin.fedoraproject.org/pkgdb/ -->
     <pre>yum install \
     autoconf automake bash bison bzip2 cmake flex gcc-c++ \
-    gettext git gperf intltool make sed libffi-devel \
+    gdk-pixbuf-devel gettext git gperf intltool make sed libffi-devel \
     libtool openssl-devel p7zip patch perl pkgconfig \
     python ruby scons unzip wget xz</pre>
 
@@ -658,7 +662,7 @@ USE_OSGPLUGIN(&lt;plugin2&gt;)
     <!-- http://www.freshports.org/ -->
     <pre>pkg_add -r \
     automake autoconf bash bison cmake coreutils flex \
-    gettext git glib20 gmake gperf gsed intltool libffi \
+    gdk-pixbuf2 gettext git glib20 gmake gperf gsed intltool libffi \
     libtool openssl p5-XML-Parser p7zip patch perl \
     pkgconf python ruby scons unzip wget</pre>
 
@@ -696,7 +700,7 @@ USE_OSGPLUGIN(&lt;plugin2&gt;)
     <!-- http://www.frugalware.org/packages -->
     <pre>pacman-g2 -S \
     autoconf automake bash bzip2 bison cmake flex gcc \
-    gettext git gperf intltool make sed libffi libtool \
+    gdk-pixbuf2 gettext git gperf intltool make sed libffi libtool \
     openssl patch perl perl-xml-parser pkgconfig python \
     ruby scons unzip wget xz xz-lzma</pre>
 
@@ -718,7 +722,7 @@ USE_OSGPLUGIN(&lt;plugin2&gt;)
     sys-devel/patch dev-lang/perl dev-perl/XML-Parser \
     dev-util/pkgconfig dev-lang/python dev-lang/ruby \
     dev-util/scons app-arch/unzip net-misc/wget \
-    app-arch/xz-utils</pre>
+    app-arch/xz-utils x11-libs/gdk-pixbuf</pre>
 
     <h3 id="requirements-macos">Mac OS X</h3>
 
@@ -734,7 +738,7 @@ USE_OSGPLUGIN(&lt;plugin2&gt;)
     </p>
     <!-- http://www.macports.org/ports.php -->
     <pre>sudo port install \
-    glib2 intltool p5-xml-parser p7zip gpatch scons wget xz</pre>
+    gdk-pixbuf2 glib2 intltool p5-xml-parser p7zip gpatch scons wget xz</pre>
     <h5 id="requirements-macos-method-2">Method 2 - Rudix</h5>
     <p>
     Install <a href="http://rudix.org/">Rudix</a> you can make it with following command
@@ -745,6 +749,8 @@ USE_OSGPLUGIN(&lt;plugin2&gt;)
     then run:
     </p>
     <pre>sudo rudix install glib pkg-config scons wget xz</pre>
+    Note: <b>gdk-pixbuf2</b> is not installed in method 2,
+    so you can not build <b>gtk3</b>.
     <h4 id="requirements-macos-step-2">Step 2</h4>
     <p>
     After installing pre-requirement run from within the mxe directory:
@@ -763,7 +769,7 @@ USE_OSGPLUGIN(&lt;plugin2&gt;)
     <!-- http://software.opensuse.org/131/en -->
     <pre>zypper install -R \
     autoconf automake bash bison bzip2 cmake flex gcc-c++ \
-    gettext-tools git gperf intltool libffi-devel libtool \
+    gdk-pixbuf-devel gettext-tools git gperf intltool libffi-devel libtool \
     make openssl libopenssl-devel p7zip patch perl \
     perl-XML-Parser pkg-config python ruby scons sed unzip \
     wget xz</pre>
@@ -1393,6 +1399,10 @@ local-pkg-list: $(LOCAL_PKG_LIST)</pre>
         <td class="website"><a href="http://www.gtk.org/">GTK+</a></td>
     </tr>
     <tr>
+        <td class="package">gtk3</td>
+        <td class="website"><a href="http://www.gtk.org/">GTK+</a></td>
+    </tr>
+    <tr>
         <td class="package">gtkglarea</td>
         <td class="website"><a href="http://www.mono-project.com/GtkGLArea/">GtkGLArea</a></td>
     </tr>
@@ -1410,6 +1420,10 @@ local-pkg-list: $(LOCAL_PKG_LIST)</pre>
     </tr>
     <tr>
         <td class="package">gtkmm2</td>
+        <td class="website"><a href="http://www.gtkmm.org/">GTKMM</a></td>
+    </tr>
+    <tr>
+        <td class="package">gtkmm3</td>
         <td class="website"><a href="http://www.gtkmm.org/">GTKMM</a></td>
     </tr>
     <tr>

--- a/src/glib-2-remove-runtime-warning-gtkapplication.patch
+++ b/src/glib-2-remove-runtime-warning-gtkapplication.patch
@@ -1,0 +1,24 @@
+This file is part of MXE.
+See index.html for further information.
+
+Remove an annoying runtime warning that pops up when using GtkApplication
+in Gtk+ 3 programs.
+
+--- a/gio/gdbusaddress.c	2014-06-28 19:02:43.000000000 +0200
++++ b/gio/gdbusaddress.c	2015-08-12 20:26:45.931228430 +0200
+@@ -1325,6 +1325,7 @@
+ __declspec(dllexport) void CALLBACK
+ g_win32_run_session_bus (HWND hwnd, HINSTANCE hinst, char *cmdline, int nCmdShow)
+ {
++  /*
+   GDBusDaemon *daemon;
+   GMainLoop *loop;
+   const char *address;
+@@ -1354,6 +1355,7 @@
+ 
+   g_main_loop_unref (loop);
+   g_object_unref (daemon);
++  */
+ }
+ 
+ static gchar *

--- a/src/gtk3-1-fixes.patch
+++ b/src/gtk3-1-fixes.patch
@@ -1,0 +1,139 @@
+This file is part of MXE.
+See index.html for further information.
+
+Contains ad hoc patches for cross building.
+
+
+---
+These were adapted from the gtk2 patchset.
+
+--- a/configure
++++ b/configure
+@@ -7005,15 +7005,15 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
+ 
+ if test "$os_win32" = "yes"; then
+   if test x$enable_static = xyes -o x$enable_static = x; then
+-    { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: Disabling static library build, must build as DLL on Windows." >&5
+-$as_echo "$as_me: WARNING: Disabling static library build, must build as DLL on Windows." >&2;}
+-    enable_static=no
++    { $as_echo "(disabled warning)" >&5
++$as_echo "(disabled warning)" >&2;}
++    enable_static=yes
+   fi
+   if test x$enable_shared = xno; then
+-    { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: Enabling shared library build, must build as DLL on Windows." >&5
+-$as_echo "$as_me: WARNING: Enabling shared library build, must build as DLL on Windows." >&2;}
++    { $as_echo "(disabled warning)" >&5
++$as_echo "(disabled warning)" >&2;}
+   fi
+-  enable_shared=yes
++  enable_shared=no
+ fi
+ 
+ 
+--- a/gdk/win32/gdkmain-win32.c	2015-07-25 23:15:29.947190754 +0200
++++ b/gdk/win32/gdkmain-win32.c	2015-07-25 23:15:55.723190733 +0200
+@@ -64,7 +64,7 @@
+ };
+ 
+ BOOL WINAPI
+-DllMain (HINSTANCE hinstDLL,
++gdk_DllMain (HINSTANCE hinstDLL,
+ 	 DWORD     dwReason,
+ 	 LPVOID    reserved)
+ {
+--- a/gtk/gtkwin32.c	2015-07-25 23:20:57.735190485 +0200
++++ b/gtk/gtkwin32.c	2015-07-25 23:21:13.447190472 +0200
+@@ -42,7 +42,7 @@
+ static HMODULE gtk_dll;
+ 
+ BOOL WINAPI
+-DllMain (HINSTANCE hinstDLL,
++gtk_DllMain (HINSTANCE hinstDLL,
+          DWORD     fdwReason,
+          LPVOID    lpvReserved)
+ {
+--- a/gtk+-3.0.pc.in	2015-07-26 16:55:29.755170491 +0200
++++ b/gtk+-3.0.pc.in	2015-07-26 16:56:23.655170447 +0200
+@@ -12,5 +12,5 @@
+ Version: @VERSION@
+ Requires: gdk-@GTK_API_VERSION@ @GTK_PACKAGES@
+ Requires.private: @GTK_PRIVATE_PACKAGES@
+-Libs: -L${libdir} -lgtk-3 @GTK_EXTRA_LIBS@
++Libs: -L${libdir} -lgtk-3 @GTK_DEP_LIBS@ -lwinspool -lcomctl32 -lcomdlg32
+ Cflags: -I${includedir}/gtk-@GTK_API_VERSION@ @GTK_EXTRA_CFLAGS@
+---
+Here there were two problems, one is that util/extract-strings.exe
+was being cross-built while it should be built locally, the other is
+that in fact it wasn't even being built because of some problem with
+makefile variables (PROGRAMS appears to be empty even if it is set to
+a nonempty value).
+
+--- a/util/Makefile.in	2014-10-21 17:03:07.000000000 +0200
++++ b/util/Makefile.in	2014-12-27 23:12:40.910506266 +0100
+@@ -107,9 +107,8 @@
+ am__v_lt_ = $(am__v_lt_@AM_DEFAULT_V@)
+ am__v_lt_0 = --silent
+ am__v_lt_1 = 
+-extract_strings_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC \
+-	$(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=link $(CCLD) \
+-	$(extract_strings_CFLAGS) $(CFLAGS) $(AM_LDFLAGS) $(LDFLAGS) \
++extract_strings_LINK = $(CC_FOR_BUILD) \
++	$(extract_strings_CFLAGS) $(CFLAGS_FOR_BUILD) $(AM_LDFLAGS) $(LDFLAGS_FOR_BUILD) \
+ 	-o $@
+ AM_V_P = $(am__v_P_@AM_V@)
+ am__v_P_ = $(am__v_P_@AM_DEFAULT_V@)
+@@ -485,7 +484,7 @@
+ 
+ extract-strings$(EXEEXT): $(extract_strings_OBJECTS) $(extract_strings_DEPENDENCIES) $(EXTRA_extract_strings_DEPENDENCIES) 
+ 	@rm -f extract-strings$(EXEEXT)
+-	$(AM_V_CCLD)$(extract_strings_LINK) $(extract_strings_OBJECTS) $(extract_strings_LDADD) $(LIBS)
++	$(AM_V_CCLD)$(extract_strings_LINK) $(extract_strings_OBJECTS) $(extract_strings_LDADD)
+ 
+ mostlyclean-compile:
+ 	-rm -f *.$(OBJEXT)
+@@ -517,7 +516,7 @@
+ @am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LTCOMPILE) -c -o $@ $<
+ 
+ extract_strings-extract-strings.o: extract-strings.c
+-@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(extract_strings_CFLAGS) $(CFLAGS) -MT extract_strings-extract-strings.o -MD -MP -MF $(DEPDIR)/extract_strings-extract-strings.Tpo -c -o extract_strings-extract-strings.o `test -f 'extract-strings.c' || echo '$(srcdir)/'`extract-strings.c
++@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC_FOR_BUILD) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS_FOR_BUILD) $(extract_strings_CFLAGS) $(CFLAGS_FOR_BUILD) -MT extract_strings-extract-strings.o -MD -MP -MF $(DEPDIR)/extract_strings-extract-strings.Tpo -c -o extract_strings-extract-strings.o `test -f 'extract-strings.c' || echo '$(srcdir)/'`extract-strings.c
+ @am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/extract_strings-extract-strings.Tpo $(DEPDIR)/extract_strings-extract-strings.Po
+ @AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='extract-strings.c' object='extract_strings-extract-strings.o' libtool=no @AMDEPBACKSLASH@
+ @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@@ -620,7 +619,7 @@
+ 	done
+ check-am: all-am
+ check: check-am
+-all-am: Makefile $(PROGRAMS)
++all-am: Makefile extract-strings$(EXEEXT)
+ installdirs:
+ install: install-am
+ install-exec: install-exec-am
+---
+This one fixes "cd $builddir" failing because neither $builddir nor
+$HOME were set
+
+--- a/configure	2015-07-24 21:19:46.839151097 +0200
++++ b/configure	2015-07-24 21:20:13.655151075 +0200
+@@ -23215,7 +23215,7 @@
+        NATIVE_GDKPIXBUF_LIBS=`$PKG_CONFIG_FOR_BUILD --libs gdk-pixbuf-2.0`
+        # This is the native gtk-update-icon-cache which will be used at
+        # build time, NOT the one installed on the target host.
+-       GTK_UPDATE_ICON_CACHE="`cd $builddir && pwd`/gtk/native/native-update-icon-cache$BUILD_EXEEXT"
++       GTK_UPDATE_ICON_CACHE="`pwd`/gtk/native/native-update-icon-cache$BUILD_EXEEXT"
+ 
+ 
+ 
+---
+Not sure what happens when this line is commented out.
+
+--- a/gtk/a11y/gtkaccessibility.c	2014-08-15 16:38:05.000000000 +0200
++++ b/gtk/a11y/gtkaccessibility.c	2015-07-26 17:43:36.647168119 +0200
+@@ -991,5 +991,5 @@
+   atk_bridge_adaptor_init (NULL, NULL);
+ #endif
+ 
+-  atk_misc_instance = g_object_new (GTK_TYPE_MISC_IMPL, NULL);
++  /* atk_misc_instance = g_object_new (GTK_TYPE_MISC_IMPL, NULL); */
+ }

--- a/src/gtk3-test.c
+++ b/src/gtk3-test.c
@@ -1,0 +1,34 @@
+/*
+ * This file is part of MXE.
+ * See index.html for further information.
+ */
+
+#include <gtk/gtk.h>
+
+static void activate(GtkApplication *app)
+{
+  GtkWidget *window;
+  GtkWidget *button;
+
+  window = gtk_application_window_new(app);
+  button = gtk_button_new_with_label("Hello World");
+
+  g_signal_connect_swapped(button, "clicked",
+			   G_CALLBACK(gtk_widget_destroy), window);
+  gtk_container_add(GTK_CONTAINER(window), button);
+
+  gtk_widget_show_all(window);
+}
+
+int main(int argc, char *argv[])
+{
+  GtkApplication *app;
+  int status;
+
+  app = gtk_application_new(NULL, G_APPLICATION_FLAGS_NONE);
+  g_signal_connect(app, "activate", G_CALLBACK(activate), NULL);
+  status = g_application_run(G_APPLICATION(app), argc, argv);
+  g_object_unref(app);
+
+  return status;
+}

--- a/src/gtk3.mk
+++ b/src/gtk3.mk
@@ -1,0 +1,41 @@
+# This file is part of MXE.
+# See index.html for further information.
+
+PKG             := gtk3
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 3.14.4
+$(PKG)_CHECKSUM := ff4a257226842d11eaaa6ca798ae72e8eaab8bbe
+$(PKG)_SUBDIR   := gtk+-$($(PKG)_VERSION)
+$(PKG)_FILE     := gtk+-$($(PKG)_VERSION).tar.xz
+$(PKG)_URL      := http://ftp.gnome.org/pub/gnome/sources/gtk+/$(call SHORT_PKG_VERSION,$(PKG))/$($(PKG)_FILE)
+$(PKG)_DEPS     := gcc gettext libpng jpeg tiff jasper glib atk pango cairo gdk-pixbuf
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- 'http://git.gnome.org/browse/gtk+/refs/tags' | \
+    grep '<a href=' | \
+    $(SED) -n 's,.*<a[^>]*>\([0-9]*\.[0-9]*[02468]\.[^<]*\)<.*,\1,p' | \
+    grep '^3\.' | \
+    head -1
+endef
+
+define $(PKG)_BUILD
+    cd '$(1)' && ./configure \
+        $(MXE_CONFIGURE_OPTS) \
+        --enable-explicit-deps \
+        --disable-glibtest \
+        --disable-modules \
+        --disable-cups \
+        --disable-test-print-backend \
+        --disable-gtk-doc \
+        --disable-man \
+        --with-included-immodules \
+        --without-x
+    $(MAKE) -C '$(1)' -j '$(JOBS)' install bin_PROGRAMS= sbin_PROGRAMS= noinst_PROGRAMS=
+
+    '$(TARGET)-gcc' \
+        -W -Wall -Werror -ansi \
+        '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-gtk3.exe' \
+        `'$(TARGET)-pkg-config' gtk+-3.0 --cflags --libs`
+endef
+
+$(PKG)_BUILD_SHARED =

--- a/src/gtkmm3-test.cpp
+++ b/src/gtkmm3-test.cpp
@@ -1,0 +1,21 @@
+/*
+ * This file is part of MXE.
+ * See index.html for further information.
+ */
+
+#include <gtkmm/application.h>
+#include <gtkmm/button.h>
+#include <gtkmm/window.h>
+
+int main(int argc, char *argv[])
+{
+  Glib::RefPtr<Gtk::Application> app = Gtk::Application::create(argc, argv);
+
+  Gtk::Window window;
+  Gtk::Button button("Hello World");
+  button.signal_clicked().connect(sigc::mem_fun(window, &Gtk::Window::close));
+  window.add(button);
+  window.show_all();
+
+  return app->run(window);
+}

--- a/src/gtkmm3.mk
+++ b/src/gtkmm3.mk
@@ -1,0 +1,37 @@
+# This file is part of MXE.
+# See index.html for further information.
+
+PKG             := gtkmm3
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 3.14.0
+$(PKG)_CHECKSUM := cc3948dcb9a83e4c55b0fa37535eb52d61531286
+$(PKG)_SUBDIR   := gtkmm-$($(PKG)_VERSION)
+$(PKG)_FILE     := gtkmm-$($(PKG)_VERSION).tar.xz
+$(PKG)_URL      := http://ftp.gnome.org/pub/gnome/sources/gtkmm/$(call SHORT_PKG_VERSION,$(PKG))/$($(PKG)_FILE)
+$(PKG)_DEPS     := gcc gtk3 libsigc++ pangomm cairomm atkmm
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- 'http://git.gnome.org/browse/gtkmm/refs/tags' | \
+    grep '<a href=' | \
+    $(SED) -n 's,.*<a[^>]*>\([0-9]*\.[0-9]*[02468]\.[^<]*\)<.*,\1,p' | \
+    grep '^3\.' | \
+    head -1
+endef
+
+define $(PKG)_BUILD
+    cd '$(1)' && ./configure \
+        --host='$(TARGET)' \
+        --build="`config.guess`" \
+        --disable-shared \
+        --prefix='$(PREFIX)/$(TARGET)' \
+        MAKE=$(MAKE)
+    $(MAKE) -C '$(1)' -j '$(JOBS)' bin_PROGRAMS= sbin_PROGRAMS= noinst_PROGRAMS=
+    $(MAKE) -C '$(1)' -j 1 install bin_PROGRAMS= sbin_PROGRAMS= noinst_PROGRAMS= doc_install='# DISABLED: doc-install.pl'
+
+    '$(TARGET)-g++' \
+        -W -Wall -Werror -pedantic -std=c++0x \
+        '$(2).cpp' -o '$(PREFIX)/$(TARGET)/bin/test-gtkmm3.exe' \
+        `'$(TARGET)-pkg-config' gtkmm-3.0 --cflags --libs`
+endef
+
+$(PKG)_BUILD_SHARED =


### PR DESCRIPTION
Pango has been updated to 1.37.4 in 24cf97dbdd62ece0ea0b39cf33694a8804352bd1

Side effects:
  * mute function g_win32_run_session_bus of glib (see the thread)
  * add new external dependency: gdk-pixbuf

Original thread:
https://lists.nongnu.org/archive/html/mingw-cross-env-list/2015-08/msg00009.html