### PR TITLE
nsis: increase NSIS_MAX_STRLEN to 8192

### DIFF
--- a/src/nsis.mk
+++ b/src/nsis.mk
@@ -24,6 +24,7 @@ define $(PKG)_BUILD
         `[ -d /usr/local/include ] && echo APPEND_CPPPATH=/usr/local/include` \
         `[ -d /usr/local/lib ]     && echo APPEND_LIBPATH=/usr/local/lib` \
         SKIPUTILS='NSIS Menu' \
+        NSIS_MAX_STRLEN=8192 \
         install
     $(INSTALL) -m755 '$(PREFIX)/$(TARGET)/bin/makensis' '$(PREFIX)/bin/$(TARGET)-makensis'
 endef


### PR DESCRIPTION
> Currently you can't change NSIS_MAX_STRLEN without re-compiling NSIS.
> This was a problem because some NSIS projects would require the special
> build and some wouldn't, and sometimes we'd compile a project that
> required the special build, with the normal MakeNSIS build.

(from http://nsis.sourceforge.net/SetReqStrLen:_Allow_compile_w/_8192_special_build_only)

See also http://nsis.sourceforge.net/Special_Builds#Large_strings