### PR TITLE
muparser: update upstream URL and version to 2.2.5

### DIFF
--- a/src/muparser.mk
+++ b/src/muparser.mk
@@ -3,17 +3,16 @@
 
 PKG             := muparser
 $(PKG)_IGNORE   :=
-$(PKG)_VERSION  := 2.2.3
-$(PKG)_CHECKSUM := dfe831b69392ab0b1eb59d3601b7b1575554a85057cf2f234f64f930c4148902
-$(PKG)_SUBDIR   := $(PKG)_v$(subst .,_,$($(PKG)_VERSION))
-$(PKG)_FILE     := $(PKG)_v$(subst .,_,$($(PKG)_VERSION)).zip
-$(PKG)_URL      := http://$(SOURCEFORGE_MIRROR)/project/$(PKG)/$(PKG)/Version $($(PKG)_VERSION)/$($(PKG)_FILE)
+$(PKG)_VERSION  := 2.2.5
+$(PKG)_CHECKSUM := 0666ef55da72c3e356ca85b6a0084d56b05dd740c3c21d26d372085aa2c6e708
+$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
+$(PKG)_FILE     := $($(PKG)_SUBDIR).tar.gz
+$(PKG)_URL      := https://github.com/beltoforion/$(PKG)/archive/v$($(PKG)_VERSION).tar.gz
 $(PKG)_DEPS     := gcc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'http://sourceforge.net/projects/muparser/files/muparser/' | \
-    $(SED) -n 's,.*Version%20\([0-9][^"]*\)/".*,\1,p' | \
-    head -1
+    $(call MXE_GET_GITHUB_TAGS, beltoforion/muparser) | \
+    $(SED) 's,^v,,g'
 endef
 
 define $(PKG)_BUILD


### PR DESCRIPTION
[Original muparser location](http://sourceforge.net/projects/muparser/) forwards to [Google Code](https://code.google.com/p/muparser/), which in turn forwards to [Github](https://github.com/beltoforion/muparser).

Version 2.2.3 can't be found on Github, that is why it was updated to 2.2.5.

Updater script updated as well.

Build passes on Debian Jessie.