### PR TITLE
fix suitesparse download URL

### DIFF
--- a/src/suitesparse.mk
+++ b/src/suitesparse.mk
@@ -6,12 +6,12 @@ $(PKG)_VERSION  := 4.2.1
 $(PKG)_CHECKSUM := 2fec3bf93314bd14cbb7470c0a2c294988096ed6
 $(PKG)_SUBDIR   := SuiteSparse
 $(PKG)_FILE     := SuiteSparse-$($(PKG)_VERSION).tar.gz
-$(PKG)_URL      := http://www.cise.ufl.edu/research/sparse/SuiteSparse/$($(PKG)_FILE)
+$(PKG)_URL      := http://faculty.cse.tamu.edu/davis/SuiteSparse/$($(PKG)_FILE)
 $(PKG)_URL_2    := https://distfiles.macports.org/SuiteSparse/$($(PKG)_FILE)
 $(PKG)_DEPS     := gcc blas lapack
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'http://www.cise.ufl.edu/research/sparse/SuiteSparse/' | \
+    $(WGET) -q -O- 'http://faculty.cse.tamu.edu/davis/suitesparse.html' | \
     $(SED) -n 's,.*SuiteSparse-\([0-9][^"]*\)\.tar.*,\1,p' | \
     head -1
 endef


### PR DESCRIPTION
Old URL is 404. Parent URL redirects to http://faculty.cse.tamu.edu/davis/research.html