### PR TITLE
fftw: compile with combined thread libraries

### DIFF
--- a/src/fftw.mk
+++ b/src/fftw.mk
@@ -21,13 +21,15 @@ endef
 define $(PKG)_BUILD
     cd '$(1)' && ./configure \
         $(MXE_CONFIGURE_OPTS) \
-        --enable-threads
+        --enable-threads \
+        --with-combined-threads
     $(MAKE) -C '$(1)' -j '$(JOBS)' bin_PROGRAMS= sbin_PROGRAMS= noinst_PROGRAMS=
     $(MAKE) -C '$(1)' -j 1 install bin_PROGRAMS= sbin_PROGRAMS= noinst_PROGRAMS=
 
     cd '$(1)' && ./configure \
         $(MXE_CONFIGURE_OPTS) \
         --enable-threads \
+        --with-combined-threads \
         --enable-long-double
     $(MAKE) -C '$(1)' -j '$(JOBS)' bin_PROGRAMS= sbin_PROGRAMS= noinst_PROGRAMS=
     $(MAKE) -C '$(1)' -j 1 install bin_PROGRAMS= sbin_PROGRAMS= noinst_PROGRAMS=
@@ -35,6 +37,7 @@ define $(PKG)_BUILD
     cd '$(1)' && ./configure \
         $(MXE_CONFIGURE_OPTS) \
         --enable-threads \
+        --with-combined-threads \
         --enable-float
     $(MAKE) -C '$(1)' -j '$(JOBS)' bin_PROGRAMS= sbin_PROGRAMS= noinst_PROGRAMS=
     $(MAKE) -C '$(1)' -j 1 install bin_PROGRAMS= sbin_PROGRAMS= noinst_PROGRAMS=


### PR DESCRIPTION
From fftw-3.3.4/Makefile.am:

> when using combined thread libraries (necessary on Windows), we want
> to build threads/ first, because libfftw3_threads is added to
> libfftw3.
>
> Otherwise, we want to build libfftw3_threads after libfftw3
> so that we can track the fact that libfftw3_threads depends upon
> libfftw3.
>
> This is the inescapable result of combining three bad ideas
> (threads, Windows, and shared libraries).

When compiling with combined threads, all thread related functions
are added to main libraries (libfftw3, libfftw3f, libfftw3l). I have
checked their existance in libfftw3-3.dll by using nm.

close #872

^^ Instead of adding -lfftw3_threads to fftw*.pc files, add
thread related functions to main fftw3 lib.