### PR TITLE
Add pthreads.cmake file generation

### DIFF
--- a/src/pthreads.mk
+++ b/src/pthreads.mk
@@ -24,4 +24,8 @@ PTHREADS_TEST = \
     '$(TARGET)-gcc' \
         -W -Wall -Werror -ansi -pedantic \
         '$(TOP_DIR)/src/pthreads-test.c' -o '$(PREFIX)/$(TARGET)/bin/test-pthreads.exe' \
-        `'$(TARGET)-pkg-config' --libs pthreads`
+        `'$(TARGET)-pkg-config' --libs pthreads` && \
+    (echo 'SET( THREADS_PTHREAD_ARG '; \
+     echo '"PLEASE_FILL_OUT-FAILED_TO_RUN" '; \
+     echo 'CACHE STRING "Result from TRY_RUN" FORCE)';) \
+     > '$(CMAKE_TOOLCHAIN_DIR)/pthreads.cmake'


### PR DESCRIPTION
A workaround for the TRY_RUN error in FindThreads.cmake when cross-compiling with mxe and CMake.

Similarly to:
https://github.com/osrf/rba_scripts/issues/5