### PR TITLE
New package: enet library

### DIFF
--- a/index.html
+++ b/index.html
@@ -1207,6 +1207,10 @@ local-pkg-list: $(LOCAL_PKG_LIST)</pre>
         <td class="website"><a href="http://eigen.tuxfamily.org/">eigen</a></td>
     </tr>
     <tr>
+        <td class="package">enet</td>
+        <td class="website"><a href="https://github.com/lsalzman/enet">enet</a></td>
+    </tr>
+    <tr>
         <td class="package">exiv2</td>
         <td class="website"><a href="http://www.exiv2.org/">Exiv2</a></td>
     </tr>

--- a/src/enet-test.c
+++ b/src/enet-test.c
@@ -1,0 +1,26 @@
+/*
+ * This file is part of MXE.
+ * See index.html for further information.
+ */
+
+#include <enet/enet.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(int argc, char** argv)
+{
+    /* Suppress unused warnings, __attribute__((unused)) doesn't seam to work
+     */
+    (void)argc;
+    (void)argv;
+
+    if (enet_initialize() != 0)
+    {
+        fprintf(stderr, "An error occurred while initializing ENet.\n");
+        return EXIT_FAILURE;
+    }
+    atexit (enet_deinitialize);
+
+    return EXIT_SUCCESS;
+}
+

--- a/src/enet.mk
+++ b/src/enet.mk
@@ -1,0 +1,53 @@
+# This file is part of MXE.
+# See index.html for further information.
+
+PKG             := enet
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 5f476546edabdf37509cd3448d1a616f5eca535d
+$(PKG)_CHECKSUM := 1c49f074d611b3e00c79abd94cb1df8f1b4bb013ebd20e0d03015ddac955ff16
+$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
+$(PKG)_FILE     := $($(PKG)_SUBDIR).tar.gz
+$(PKG)_GITHUB   := https://github.com//lsalzman/enet
+$(PKG)_URL      := $($(PKG)_GITHUB)/archive/$($(PKG)_VERSION).tar.gz
+$(PKG)_DEPS     := gcc
+
+define $(PKG)_UPDATE
+    echo 'TODO: write update script for $(PKG).' >&2;
+    echo $($(PKG)_VERSION)
+endef
+
+define $(PKG)_BUILD
+
+    # Configure
+    mkdir '$(1).build'
+    cd '$(1).build' && cmake \
+      -DCMAKE_TOOLCHAIN_FILE='$(CMAKE_TOOLCHAIN_FILE)' \
+      '$(1)'
+
+
+    # Build
+    $(MAKE) -C '$(1).build' -j '$(JOBS)'
+
+
+    # Install include files
+    $(INSTALL) -D '$(1)/include/enet/callbacks.h' '$(PREFIX)/$(TARGET)/include/enet/callbacks.h'
+    $(INSTALL) -D '$(1)/include/enet/enet.h'      '$(PREFIX)/$(TARGET)/include/enet/enet.h'
+    $(INSTALL) -D '$(1)/include/enet/list.h'      '$(PREFIX)/$(TARGET)/include/enet/list.h'
+    $(INSTALL) -D '$(1)/include/enet/protocol.h'  '$(PREFIX)/$(TARGET)/include/enet/protocol.h'
+    $(INSTALL) -D '$(1)/include/enet/time.h'      '$(PREFIX)/$(TARGET)/include/enet/time.h'
+    $(INSTALL) -D '$(1)/include/enet/types.h'     '$(PREFIX)/$(TARGET)/include/enet/types.h'
+    $(INSTALL) -D '$(1)/include/enet/unix.h'      '$(PREFIX)/$(TARGET)/include/enet/unix.h'
+    $(INSTALL) -D '$(1)/include/enet/utility.h'   '$(PREFIX)/$(TARGET)/include/enet/utility.h'
+    $(INSTALL) -D '$(1)/include/enet/win32.h'     '$(PREFIX)/$(TARGET)/include/enet/win32.h'
+
+    # Install library
+    $(INSTALL) -D '$(1).build/libenet.a'            '$(PREFIX)/$(TARGET)/lib/libenet.a'
+
+
+    # Build test executable
+    '$(TARGET)-gcc' \
+        -W -Wall -Werror -ansi -pedantic \
+        '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-enet.exe' \
+        -lenet -lws2_32 -lwinmm
+
+endef

--- a/versions.json
+++ b/versions.json
@@ -44,6 +44,7 @@
     "devil": "1.7.8",
     "dlfcn-win32": "1.0.0",
     "eigen": "3.2.5",
+    "enet": "5f476546edabdf37509cd3448d1a616f5eca535d",
     "exiv2": "0.24",
     "expat": "2.1.0",
     "faad2": "2.7",


### PR DESCRIPTION
ENet's purpose is to provide a relatively thin, simple and robust network communication layer on top of UDP (User Datagram Protocol).The primary feature it provides is optional reliable, in-order delivery of packets. ENet omits certain higher level networking features such as authentication, lobbying, server discovery, encryption, or other similar tasks that are particularly application specific so that the library remains flexible, portable, and easily embeddable.

Patch contains an `enet-test.c` program and was compiled and tested on Debian Jessie with the following targets

 * x86_64-w64-mingw32.static
 * i686-w64-mingw32.static
 * x86_64-w64-mingw32.shared
 * i686-w64-mingw32.shared