### PR TITLE
pkgconf: added option CACHE PATH for PKG_CONFIG_EXECUTABLE 

### DIFF
--- a/src/pkgconf.mk
+++ b/src/pkgconf.mk
@@ -33,7 +33,7 @@ define $(PKG)_BUILD
     chmod 0755 '$(PREFIX)/bin/$(TARGET)-pkg-config'
 
     # create cmake file
-    echo 'set(PKG_CONFIG_EXECUTABLE $(PREFIX)/bin/$(TARGET)-pkg-config)' \
+    echo 'set(PKG_CONFIG_EXECUTABLE $(PREFIX)/bin/$(TARGET)-pkg-config CACHE PATH "pkg-config executable")' \
     > '$(CMAKE_TOOLCHAIN_DIR)/pkgconf.cmake'
 
 endef


### PR DESCRIPTION
in pkgconf.cmake so that pkgconf can be found through cmake at first run.