### PR TITLE
mingw-w64: enable secure API

### DIFF
--- a/src/mingw-w64.mk
+++ b/src/mingw-w64.mk
@@ -23,7 +23,8 @@ define $(PKG)_BUILD_mingw-w64
         --host='$(TARGET)' \
         --prefix='$(PREFIX)/$(TARGET)' \
         --enable-sdk=all \
-        --enable-idl
+        --enable-idl \
+        --enable-secure-api
     $(MAKE) -C '$(1).headers-build' install
 endef
 


### PR DESCRIPTION
In that case MINGW_HAS_SECURE_API is defined and mingw can compile against additional versions of strcpy, strcat... suffixed with '_s'. 