### PR TITLE
build-pkg: add MXE_CONF_PKGS to deps of packages

### DIFF
--- a/tools/build-pkg.lua
+++ b/tools/build-pkg.lua
@@ -180,7 +180,9 @@ print-deps:
 	@$(foreach pkg,$(PKGS),echo \
 		for-build-pkg $(pkg) \
 		$(subst $(SPACE),-,$($(pkg)_VERSION)) \
-		$($(pkg)_DEPS);)]]
+		$($(pkg)_DEPS) \
+		$(if $(call set_is_not_member,$(pkg),$(MXE_CONF_PKGS)), \
+		$(MXE_CONF_PKGS));)]]
     local deps_mk_file = io.open('deps.mk', 'w')
     deps_mk_file:write(deps_mk_content)
     deps_mk_file:close()


### PR DESCRIPTION
`mxe-conf` is a special package added to dependencies of other packages implicitly, not via `$(PKG)_DEPS`. Tool `build-pkg` used to find dependencies in `$(PKG)_DEPS` only. Now it looks in $(MXE_CONF_PKGS) as well. This code was adopted from `PKG_TARGET_RULE`.

see #890