### PR TITLE
Add qtbase patch to allow building without JPEG or PNG support

### DIFF
--- a/src/qtbase-2.patch
+++ b/src/qtbase-2.patch
@@ -1,0 +1,88 @@
+From 7f282aa9f718389199b95b7f53ecd6401172fcc6 Mon Sep 17 00:00:00 2001
+From: Oswald Buddenhagen <oswald.buddenhagen@theqtcompany.com>
+Date: Fri, 24 Jul 2015 13:18:29 +0200
+Subject: [PATCH 1/1] fix build with no built-in image handlers
+
+the handlers' .pri files added $$PWD to INCLUDEPATH to make the files
+self-contained when used externally, but this polluted the include path
+of the gui module itself, thus hiding incorrect use of QPA includes.
+
+Task-number: QTBUG-47400
+Change-Id: I576469a71e8ded0b409d62687999c0fa884613f9
+---
+ src/gui/image/qgifhandler.pri          | 1 -
+ src/gui/image/qjpeghandler.pri         | 1 -
+ src/gui/image/qpnghandler.pri          | 1 -
+ src/gui/painting/qbrush.cpp            | 2 +-
+ src/plugins/imageformats/gif/gif.pro   | 1 +
+ src/plugins/imageformats/jpeg/jpeg.pro | 1 +
+ 6 files changed, 3 insertions(+), 4 deletions(-)
+
+diff --git a/src/gui/image/qgifhandler.pri b/src/gui/image/qgifhandler.pri
+index 6eb0751..ec33101 100644
+--- a/src/gui/image/qgifhandler.pri
++++ b/src/gui/image/qgifhandler.pri
+@@ -1,4 +1,3 @@
+ # common to plugin and built-in forms
+-INCLUDEPATH *= $$PWD
+ HEADERS += $$PWD/qgifhandler_p.h
+ SOURCES += $$PWD/qgifhandler.cpp
+diff --git a/src/gui/image/qjpeghandler.pri b/src/gui/image/qjpeghandler.pri
+index c8de33d..de40c67 100644
+--- a/src/gui/image/qjpeghandler.pri
++++ b/src/gui/image/qjpeghandler.pri
+@@ -1,5 +1,4 @@
+ # common to plugin and built-in forms
+-INCLUDEPATH *= $$PWD
+ HEADERS += $$PWD/qjpeghandler_p.h
+ SOURCES += $$PWD/qjpeghandler.cpp
+ contains(QT_CONFIG, system-jpeg) {
+diff --git a/src/gui/image/qpnghandler.pri b/src/gui/image/qpnghandler.pri
+index aca7e2c..9ab175d 100644
+--- a/src/gui/image/qpnghandler.pri
++++ b/src/gui/image/qpnghandler.pri
+@@ -1,4 +1,3 @@
+-INCLUDEPATH *= $$PWD
+ HEADERS += $$PWD/qpnghandler_p.h
+ SOURCES += $$PWD/qpnghandler.cpp
+ contains(QT_CONFIG, system-png) {
+diff --git a/src/gui/painting/qbrush.cpp b/src/gui/painting/qbrush.cpp
+index 670717c..c3a0f5c 100644
+--- a/src/gui/painting/qbrush.cpp
++++ b/src/gui/painting/qbrush.cpp
+@@ -35,7 +35,7 @@
+ #include "qpixmap.h"
+ #include "qbitmap.h"
+ #include "qpixmapcache.h"
+-#include "qplatformpixmap.h"
++#include <qpa/qplatformpixmap.h>
+ #include "qdatastream.h"
+ #include "qvariant.h"
+ #include "qline.h"
+diff --git a/src/plugins/imageformats/gif/gif.pro b/src/plugins/imageformats/gif/gif.pro
+index 898f06e..2a5048b 100644
+--- a/src/plugins/imageformats/gif/gif.pro
++++ b/src/plugins/imageformats/gif/gif.pro
+@@ -5,6 +5,7 @@ PLUGIN_CLASS_NAME = QGifPlugin
+ load(qt_plugin)
+ 
+ include(../../../gui/image/qgifhandler.pri)
++INCLUDEPATH += ../../../gui/image
+ SOURCES += $$PWD/main.cpp
+ HEADERS += $$PWD/main.h
+ OTHER_FILES += gif.json
+diff --git a/src/plugins/imageformats/jpeg/jpeg.pro b/src/plugins/imageformats/jpeg/jpeg.pro
+index 45bf7bb..e33fde1 100644
+--- a/src/plugins/imageformats/jpeg/jpeg.pro
++++ b/src/plugins/imageformats/jpeg/jpeg.pro
+@@ -9,6 +9,7 @@ QT += core-private
+ QTDIR_build:REQUIRES = "!contains(QT_CONFIG, no-jpeg)"
+ 
+ include(../../../gui/image/qjpeghandler.pri)
++INCLUDEPATH += ../../../gui/image
+ SOURCES += main.cpp
+ HEADERS += main.h
+ OTHER_FILES += jpeg.json
+-- 
+2.3.5
+


### PR DESCRIPTION
This allows qtbase to build successfully when configured with -no-libpng or -no-libjpeg. See the following for more information:

http://buildroot-busybox.2317881.n4.nabble.com/PATCH-v2-qt-qt5base-Fix-INCLUDE-PATH-when-no-JPEG-PNG-support-tt107094.html#none

https://codereview.qt-project.org/gitweb?p=qt/qtbase.git;a=commitdiff;h=7f282aa9f718389199b95b7f53ecd6401172fcc6;hp=954f0d93976362d29044439e4eaa11d2dff16624