### PR TITLE
check-requirements: check for native gdk-pixbuf

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ WGET       := wget --no-check-certificate \
 REQUIREMENTS := autoconf automake autopoint bash bison bzip2 cmake flex \
                 $(BUILD_CC) $(BUILD_CXX) gperf intltoolize $(LIBTOOL) \
                 $(LIBTOOLIZE) $(MAKE) openssl $(PATCH) $(PERL) python \
-                ruby scons $(SED) $(SORT) unzip wget xz 7za
+                ruby scons $(SED) $(SORT) unzip wget xz 7za gdk-pixbuf-csource
 
 PREFIX     := $(PWD)/usr
 LOG_DIR    := $(PWD)/log


### PR DESCRIPTION
Check with command `gdk-pixbuf-csource --help`.

`make check-requirements` succeeds on the machine with native `gdk-pixbuf` installed.
`make check-requirements` fails on the machine without native `gdk-pixbuf` installed:
```
$ make check-requirements
[create settings.mk]
[using autodetected 6 job(s)]
[check requirements]
Missing requirement: gdk-pixbuf-csource

Please have a look at "index.html" to ensure
that your system meets all requirements.

Makefile:300: recipe for target '/mxe/usr/installed/check-requirements' failed
make: *** [/mxe/usr/installed/check-requirements] Error 1
```

see #927