### PR TITLE
fix project path for vmime extra file

### DIFF
--- a/src/vmime.mk
+++ b/src/vmime.mk
@@ -35,7 +35,7 @@ define $(PKG)_BUILD
         -DVMIME_TLS_SUPPORT_LIB_IS_OPENSSL=OFF \
         -DVMIME_SHARED_PTR_USE_CXX=ON \
         -DCXX11_COMPILER_FLAGS=ON \
-        -C../../src/vmime-TryRunResults.cmake \
+        -C '$(PWD)/src/vmime-TryRunResults.cmake' \
         .
 
     $(MAKE) -C '$(1)' -j '$(JOBS)'


### PR DESCRIPTION
vmime uses a file from the src-directory of mxe but references it using
a relative path that is only working if the temporary build directory is
inside the mxe project path at the fixed position.