### PR TITLE
use better type for pointer cast

### DIFF
--- a/src/openscenegraph-3-fix-pointer-to-int-conversion-on-64bit.patch
+++ b/src/openscenegraph-3-fix-pointer-to-int-conversion-on-64bit.patch
@@ -14,12 +14,12 @@ diff --git a/src/osgPlugins/osgjs/WriteVisitor.cpp b/src/osgPlugins/osgjs/WriteV
 index 9f2b3c7..98e0c19 100644
 --- a/src/osgPlugins/osgjs/WriteVisitor.cpp
 +++ b/src/osgPlugins/osgjs/WriteVisitor.cpp
-@@ -225,7 +225,7 @@ JSONObject* createImage(osg::Image* image, bool inlineImages, int maxTextureDime
+@@ -225,8 +225,7 @@ JSONObject* createImage(osg::Image* image, bool inlineImages, int maxTextureDime
              // no image file so use this inline name image and create a file
              std::stringstream ss;
              ss << osgDB::getFilePath(baseName) << osgDB::getNativePathSeparator();
 -            ss << (long int)image << ".inline_conv_generated.png"; // write the pointer location
-+            ss << (long long int)image << ".inline_conv_generated.png"; // write the pointer location
++            ss << (intptr_t)image << ".inline_conv_generated.png"; // write the pointer location
              std::string filename = ss.str();
              if (osgDB::writeImageFile(*image, filename)) {
                  image->setFileName(filename);


### PR DESCRIPTION
there is an integer type that is guaranteed to be big enough to hold a pointer (but it's only available since C++11 and C99):
* [Fixed width integer types (since C++11) - cppreference.com](http://en.cppreference.com/w/cpp/types/integer])
* [Fixed width integer types (since C99) - cppreference.com](http://en.cppreference.com/w/c/types/integer])