### PR TITLE
MXE Plugins

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -1,0 +1,5 @@
+### MXE Plugins
+
+A collection of unsupported examples, experiments, tools, and utilities.
+
+Enjoy!

--- a/plugins/apps/keepassx-1-don-t-discard-config-set-by-qmake.patch
+++ b/plugins/apps/keepassx-1-don-t-discard-config-set-by-qmake.patch
@@ -1,0 +1,27 @@
+This file is part of MXE.
+See index.html for further information.
+
+From e941cfd42870fe214f8c44cd5e4d8ee6893b0904 Mon Sep 17 00:00:00 2001
+From: Boris Nagaev <bnagaev@gmail.com>
+Date: Fri, 25 Sep 2015 10:19:17 +0200
+Subject: [PATCH] don't discard CONFIG set by qmake
+
+See https://github.com/mxe/mxe/commit/6c561c5f3307944d7b6d7ec3de732b25bf69ed00
+---
+ src/src.pro |    2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/src.pro b/src/src.pro
+index 7644b93..827741d 100644
+--- a/src/src.pro
++++ b/src/src.pro
+@@ -1,5 +1,5 @@
+ 
+-CONFIG = qt uic resources thread stl warn_on
++CONFIG += qt uic resources thread stl warn_on
+ QT += xml
+ 
+ *-g++ : QMAKE_CXXFLAGS_WARN_ON += -Wno-sign-compare
+-- 
+1.7.10.4
+

--- a/plugins/apps/keepassx.mk
+++ b/plugins/apps/keepassx.mk
@@ -1,0 +1,27 @@
+# This file is part of MXE.
+# See index.html for further information.
+
+PKG             := keepassx
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 0.4.3
+$(PKG)_CHECKSUM := cd901a0611ce57e62cf6df7eeeb1b690b5232302bdad8626994eb54adcfa1e85
+$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.gz
+$(PKG)_URL      := https://www.keepassx.org/releases/$($(PKG)_FILE)
+$(PKG)_WEBSITE  := https://www.keepassx.org
+$(PKG)_MAKEFILE := $(realpath $(lastword $(MAKEFILE_LIST)))
+$(PKG)_OWNER    := https://github.com/starius
+$(PKG)_DEPS     := gcc qt
+
+define $(PKG)_UPDATE
+$(WGET) -q -O- 'https://www.keepassx.org/downloads/' | \
+    $(SED) -n 's,.*keepassx-\([0-9][^"]*\)\.tar.*,\1,p' | \
+    head -1
+endef
+
+define $(PKG)_BUILD
+    cd '$(1)' && '$(TARGET)-qmake-qt4' \
+        "PREFIX=$(PREFIX)/$(TARGET)/bin/"
+    $(MAKE) -C '$(1)' -j '$(JOBS)'
+    $(MAKE) -C '$(1)' -j 1 install
+endef

--- a/plugins/custom-qt-min/overrides.mk
+++ b/plugins/custom-qt-min/overrides.mk
@@ -1,0 +1,82 @@
+# This file is part of MXE.
+# See index.html for further information.
+
+# MXE provides a fully featured build of Qt. Some users want more control...
+# http://lists.nongnu.org/archive/html/mingw-cross-env-list/2013-08/msg00010.html
+# http://lists.nongnu.org/archive/html/mingw-cross-env-list/2012-05/msg00019.html
+#
+# build of qt and deps is (say):  25 mins with 12.5 MB test program
+# custom with minimal deps is:     4 mins with  7.6 MB test program
+# custom min deps and cflags is:   4 mins with  5.9 MB test program
+#
+# make qt MXE_PLUGIN_DIRS='plugins/custom-qt-min'
+
+qt_DEPS := gcc
+
+define qt_BUILD
+    $(SED) -i 's,\(^QMAKE_CFLAGS_RELEASE\).*,\1 = -pipe -Os -fomit-frame-pointer -momit-leaf-frame-pointer -fdata-sections -ffunction-sections,g' '$(1)/mkspecs/win32-g++/qmake.conf'
+    cd '$(1)' && QTDIR='$(1)' ./bin/syncqt
+    cd '$(1)' && \
+        ./configure \
+        -opensource \
+        -confirm-license \
+        -fast \
+        -xplatform win32-g++-4.6 \
+        -device-option CROSS_COMPILE=$(TARGET)- \
+        -device-option PKG_CONFIG='$(TARGET)-pkg-config' \
+        -force-pkg-config \
+        -release \
+        -static \
+        -prefix '$(PREFIX)/$(TARGET)/qt' \
+        -prefix-install \
+        -make libs \
+        -nomake demos \
+        -nomake docs \
+        -nomake examples \
+        -nomake tools \
+        -nomake translations \
+        -no-accessibility \
+        -no-audio-backend \
+        -no-dbus \
+        -no-declarative \
+        -no-exceptions \
+        -no-gif \
+        -no-glib \
+        -no-gstreamer \
+        -no-iconv \
+        -no-libjpeg \
+        -no-libmng \
+        -no-libpng \
+        -no-libtiff \
+        -no-multimedia \
+        -no-opengl \
+        -no-openssl \
+        -no-phonon \
+        -no-phonon-backend \
+        -no-qt3support \
+        -no-reduce-exports \
+        -no-rpath \
+        -no-script \
+        -no-scripttools \
+        -no-sql-mysql \
+        -no-sql-odbc \
+        -no-sql-psql \
+        -no-sql-sqlite \
+        -no-sql-tds \
+        -no-stl \
+        -no-svg \
+        -no-webkit \
+        -no-xmlpatterns \
+        -qt-zlib \
+        -v
+
+    $(MAKE) -C '$(1)' -j '$(JOBS)'
+    rm -rf '$(PREFIX)/$(TARGET)/qt'
+    $(MAKE) -C '$(1)' -j 1 install
+
+    mkdir            '$(1)/test-qt'
+    cd               '$(1)/test-qt' && '$(PREFIX)/$(TARGET)/qt/bin/qmake' '$(PWD)/$(2).pro'
+    $(MAKE)       -C '$(1)/test-qt' -j '$(JOBS)'
+    $(INSTALL) -m755 '$(1)/test-qt/release/test-qt.exe' '$(PREFIX)/$(TARGET)/bin/'
+
+endef

--- a/plugins/gcc52/gcc52-overlay.mk
+++ b/plugins/gcc52/gcc52-overlay.mk
@@ -1,0 +1,25 @@
+# This file is part of MXE.
+# See index.html for further information.
+
+# override relevant cloog, isl, and gcc variables changed in:
+# https://github.com/mxe/mxe/pull/965
+#
+# simply expanded variables (*_SUBDIR, *_FILE, etc.) need to be set
+# libmysqlclient patch changes don't adversely affect 5.2 series
+
+PKG             := cloog
+$(PKG)_TARGETS  := $(MXE_TARGETS)
+
+PKG             := isl
+$(PKG)_VERSION  := 0.14
+$(PKG)_CHECKSUM := 7e3c02ff52f8540f6a85534f54158968417fd676001651c8289c705bd0228f36
+$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.bz2
+$(PKG)_URL      := http://isl.gforge.inria.fr/$($(PKG)_FILE)
+
+PKG             := gcc
+$(PKG)_VERSION  := 5.2.0
+$(PKG)_CHECKSUM := 5f835b04b5f7dd4f4d2dc96190ec1621b8d89f2dc6f638f9f8bc1b1014ba8cad
+$(PKG)_SUBDIR   := gcc-$($(PKG)_VERSION)
+$(PKG)_FILE     := gcc-$($(PKG)_VERSION).tar.bz2
+$(PKG)_URL      := http://ftp.gnu.org/pub/gnu/gcc/gcc-$($(PKG)_VERSION)/$($(PKG)_FILE)

--- a/plugins/native/autoconf.mk
+++ b/plugins/native/autoconf.mk
@@ -1,0 +1,31 @@
+# This file is part of MXE.
+# See index.html for further information.
+
+PKG             := autoconf
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 2.69
+$(PKG)_CHECKSUM := 64ebcec9f8ac5b2487125a86a7760d2591ac9e1d3dbd59489633f9de62a57684
+$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.xz
+$(PKG)_URL      := http://ftp.gnu.org/pub/gnu/autoconf/$($(PKG)_FILE)
+$(PKG)_URL_2    := ftp://ftp.gnu.org/pub/gnu/autoconf/$($(PKG)_FILE)
+$(PKG)_WEBSITE  := http://www.gnu.org/software/autoconf
+$(PKG)_MAKEFILE := $(realpath $(lastword $(MAKEFILE_LIST)))
+$(PKG)_OWNER    := https://github.com/tonytheodore
+$(PKG)_TARGETS  := $(BUILD)
+$(PKG)_DEPS     := m4
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- 'http://ftp.gnu.org/gnu/autoconf/?C=M;O=D' | \
+    $(SED) -n 's,.*<a href="autoconf-\([0-9][^"]*\)\.tar.*,\1,p' | \
+    $(SORT) -V | \
+    tail -1
+endef
+
+define $(PKG)_BUILD_$(BUILD)
+    mkdir '$(1).build'
+    cd    '$(1).build' && '$(1)/configure' \
+        --prefix='$(PREFIX)/$(TARGET)'
+    $(MAKE) -C '$(1).build' -j '$(JOBS)'
+    $(MAKE) -C '$(1).build' -j 1 install
+endef

--- a/plugins/native/automake.mk
+++ b/plugins/native/automake.mk
@@ -1,0 +1,31 @@
+# This file is part of MXE.
+# See index.html for further information.
+
+PKG             := automake
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 1.15
+$(PKG)_CHECKSUM := 7946e945a96e28152ba5a6beb0625ca715c6e32ac55f2e353ef54def0c8ed924
+$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.gz
+$(PKG)_URL      := http://ftp.gnu.org/pub/gnu/automake/$($(PKG)_FILE)
+$(PKG)_URL_2    := ftp://ftp.gnu.org/pub/gnu/automake/$($(PKG)_FILE)
+$(PKG)_WEBSITE  := http://www.gnu.org/software/automake
+$(PKG)_MAKEFILE := $(realpath $(lastword $(MAKEFILE_LIST)))
+$(PKG)_OWNER    := https://github.com/tonytheodore
+$(PKG)_TARGETS  := $(BUILD)
+$(PKG)_DEPS     := autoconf
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- 'http://ftp.gnu.org/gnu/automake/?C=M;O=D' | \
+    $(SED) -n 's,.*<a href="automake-\([0-9][^"]*\)\.tar.*,\1,p' | \
+    $(SORT) -V | \
+    tail -1
+endef
+
+define $(PKG)_BUILD_$(BUILD)
+    mkdir '$(1).build'
+    cd    '$(1).build' && '$(1)/configure' \
+        --prefix='$(PREFIX)/$(TARGET)'
+    $(MAKE) -C '$(1).build' -j '$(JOBS)' man1_MANS=
+    $(MAKE) -C '$(1).build' -j 1 install man1_MANS=
+endef

--- a/plugins/native/bison.mk
+++ b/plugins/native/bison.mk
@@ -1,0 +1,31 @@
+# This file is part of MXE.
+# See index.html for further information.
+
+PKG             := bison
+$(PKG)_IGNORE   := 3%
+$(PKG)_VERSION  := 2.7.1
+$(PKG)_CHECKSUM := b409adcbf245baadb68d2f66accf6fdca5e282cafec1b865f4b5e963ba8ea7fb
+$(PKG)_SUBDIR   := bison-$($(PKG)_VERSION)
+$(PKG)_FILE     := bison-$($(PKG)_VERSION).tar.xz
+$(PKG)_URL      := http://ftp.gnu.org/pub/gnu/bison/$($(PKG)_FILE)
+$(PKG)_URL_2    := ftp://ftp.gnu.org/pub/gnu/bison/$($(PKG)_FILE)
+$(PKG)_WEBSITE  := http://www.gnu.org/software/bison
+$(PKG)_MAKEFILE := $(realpath $(lastword $(MAKEFILE_LIST)))
+$(PKG)_OWNER    := https://github.com/tonytheodore
+$(PKG)_TARGETS  := $(BUILD)
+$(PKG)_DEPS     := flex
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- 'http://ftp.gnu.org/gnu/bison/?C=M;O=D' | \
+    $(SED) -n 's,.*<a href="bison-\([0-9][^"]*\)\.tar.*,\1,p' | \
+    $(SORT) -V | \
+    tail -1
+endef
+
+define $(PKG)_BUILD_$(BUILD)
+    mkdir '$(1).build'
+    cd    '$(1).build' && '$(1)/configure' \
+        --prefix='$(PREFIX)/$(TARGET)'
+    $(MAKE) -C '$(1).build' -j '$(JOBS)'
+    $(MAKE) -C '$(1).build' -j 1 install
+endef

--- a/plugins/native/coreutils.mk
+++ b/plugins/native/coreutils.mk
@@ -1,0 +1,32 @@
+# This file is part of MXE.
+# See index.html for further information.
+
+PKG             := coreutils
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 8.23
+$(PKG)_CHECKSUM := ec43ca5bcfc62242accb46b7f121f6b684ee21ecd7d075059bf650ff9e37b82d
+$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.xz
+$(PKG)_URL      := http://ftp.gnu.org/pub/gnu/$(PKG)/$($(PKG)_FILE)
+$(PKG)_URL_2    := ftp://ftp.gnu.org/pub/gnu/$(PKG)/$($(PKG)_FILE)
+$(PKG)_WEBSITE  := https://www.gnu.org/software/coreutils
+$(PKG)_MAKEFILE := $(realpath $(lastword $(MAKEFILE_LIST)))
+$(PKG)_OWNER    := https://github.com/tonytheodore
+$(PKG)_TARGETS  := $(BUILD)
+
+$(PKG)_DEPS_$(BUILD) := gettext gmp libiconv libtool
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- 'http://ftp.gnu.org/gnu/coreutils/?C=M;O=D' | \
+    $(SED) -n 's,.*<a href="coreutils-\([0-9][^"]*\)\.tar.*,\1,p' | \
+    $(SORT) -V | \
+    tail -1
+endef
+
+define $(PKG)_BUILD_$(BUILD)
+    mkdir '$(1).build'
+    cd    '$(1).build' && '$(1)/configure' \
+        --prefix='$(PREFIX)/$(TARGET)'
+    $(MAKE) -C '$(1).build' -j '$(JOBS)' man1_MANS=
+    $(MAKE) -C '$(1).build' -j 1 install man1_MANS=
+endef

--- a/plugins/native/flex.mk
+++ b/plugins/native/flex.mk
@@ -1,0 +1,31 @@
+# This file is part of MXE.
+# See index.html for further information.
+
+PKG             := flex
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 2.5.39
+$(PKG)_CHECKSUM := add2b55f3bc38cb512b48fad7d72f43b11ef244487ff25fc00aabec1e32b617f
+$(PKG)_SUBDIR   := flex-$($(PKG)_VERSION)
+$(PKG)_FILE     := flex-$($(PKG)_VERSION).tar.bz2
+$(PKG)_URL      := http://$(SOURCEFORGE_MIRROR)/project/flex/$($(PKG)_FILE)
+$(PKG)_WEBSITE  := http://flex.sourceforge.net
+$(PKG)_MAKEFILE := $(realpath $(lastword $(MAKEFILE_LIST)))
+$(PKG)_OWNER    := https://github.com/tonytheodore
+$(PKG)_TARGETS  := $(BUILD)
+$(PKG)_DEPS     :=
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- 'http://sourceforge.net/projects/flex/files/' | \
+    grep -i 'flex/files/' | \
+    $(SED) -n 's,.*/flex-\([0-9\.]*\)\.tar.*/.*,\1,p' | \
+    head -1
+endef
+
+define $(PKG)_BUILD_$(BUILD)
+    mkdir '$(1).build'
+    cd    '$(1).build' && '$(1)/configure' \
+        --prefix='$(PREFIX)/$(TARGET)' \
+        --disable-shared
+    $(MAKE) -C '$(1).build' -j '$(JOBS)'
+    $(MAKE) -C '$(1).build' -j 1 install
+endef

--- a/plugins/native/gettext.mk
+++ b/plugins/native/gettext.mk
@@ -1,0 +1,14 @@
+# This file is part of MXE.
+# See index.html for further information.
+
+PKG                  := gettext
+$(PKG)_TARGETS       += $(BUILD)
+$(PKG)_DEPS_$(BUILD) := libiconv
+
+define $(PKG)_BUILD_$(BUILD)
+    mkdir '$(1).build'
+    cd    '$(1).build' && '$(1)/configure' \
+        --prefix='$(PREFIX)/$(TARGET)'
+    $(MAKE) -C '$(1).build' -j '$(JOBS)' man1_MANS=
+    $(MAKE) -C '$(1).build' -j 1 install man1_MANS=
+endef

--- a/plugins/native/gperf.mk
+++ b/plugins/native/gperf.mk
@@ -1,0 +1,31 @@
+# This file is part of MXE.
+# See index.html for further information.
+
+PKG             := gperf
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 3.0.4
+$(PKG)_CHECKSUM := 767112a204407e62dbc3106647cf839ed544f3cf5d0f0523aaa2508623aad63e
+$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.gz
+$(PKG)_URL      := http://ftp.gnu.org/pub/gnu/$(PKG)/$($(PKG)_FILE)
+$(PKG)_URL_2    := ftp://ftp.gnu.org/pub/gnu/$(PKG)/$($(PKG)_FILE)
+$(PKG)_WEBSITE  := https://www.gnu.org/software/gperf
+$(PKG)_MAKEFILE := $(realpath $(lastword $(MAKEFILE_LIST)))
+$(PKG)_OWNER    := https://github.com/tonytheodore
+$(PKG)_TARGETS  := $(BUILD)
+$(PKG)_DEPS     :=
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- 'http://ftp.gnu.org/gnu/gperf/?C=M;O=D' | \
+    $(SED) -n 's,.*<a href="gperf-\([0-9][^"]*\)\.tar.*,\1,p' | \
+    $(SORT) -V | \
+    tail -1
+endef
+
+define $(PKG)_BUILD_$(BUILD)
+    mkdir '$(1).build'
+    cd    '$(1).build' && '$(1)/configure' \
+        --prefix='$(PREFIX)/$(TARGET)'
+    $(MAKE) -C '$(1).build' -j '$(JOBS)'
+    $(MAKE) -C '$(1).build' -j 1 install
+endef

--- a/plugins/native/intltool.mk
+++ b/plugins/native/intltool.mk
@@ -1,0 +1,30 @@
+# This file is part of MXE.
+# See index.html for further information.
+
+PKG             := intltool
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 0.50.2
+$(PKG)_CHECKSUM := 67f25c5c6fb71d095793a7f895b245e65e829e8bde68c6c8b4c912144ff34406
+$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.gz
+$(PKG)_URL      := https://launchpad.net/intltool/trunk/$($(PKG)_VERSION)/+download/$($(PKG)_FILE)
+$(PKG)_WEBSITE  := http://freedesktop.org/wiki/Software/intltool
+$(PKG)_MAKEFILE := $(realpath $(lastword $(MAKEFILE_LIST)))
+$(PKG)_OWNER    := https://github.com/tonytheodore
+$(PKG)_TARGETS  := $(BUILD)
+$(PKG)_DEPS     :=
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- 'https://launchpad.net/intltool/+download' | \
+    $(SED) -n 's,.*https://launchpad.net/intltool/trunk/\([0-9][^"]*\)\/+download/intltool-\([0-9][^"]*\)\.tar.*,\1,p' | \
+    $(SORT) -V | \
+    tail -1
+endef
+
+define $(PKG)_BUILD_$(BUILD)
+    mkdir '$(1).build'
+    cd    '$(1).build' && '$(1)/configure' \
+        --prefix='$(PREFIX)/$(TARGET)'
+    $(MAKE) -C '$(1).build' -j '$(JOBS)' man1_MANS=
+    $(MAKE) -C '$(1).build' -j 1 install man1_MANS=
+endef

--- a/plugins/native/libiconv.mk
+++ b/plugins/native/libiconv.mk
@@ -1,0 +1,14 @@
+# This file is part of MXE.
+# See index.html for further information.
+
+PKG                  := libiconv
+$(PKG)_TARGETS       += $(BUILD)
+$(PKG)_DEPS_$(BUILD) :=
+
+define $(PKG)_BUILD_$(BUILD)
+    mkdir '$(1).build'
+    cd    '$(1).build' && '$(1)/configure' \
+        --prefix='$(PREFIX)/$(TARGET)'
+    $(MAKE) -C '$(1).build' -j '$(JOBS)' man1_MANS=
+    $(MAKE) -C '$(1).build' -j 1 install man1_MANS=
+endef

--- a/plugins/native/libtool.mk
+++ b/plugins/native/libtool.mk
@@ -1,0 +1,14 @@
+# This file is part of MXE.
+# See index.html for further information.
+
+PKG                  := libtool
+$(PKG)_TARGETS       += $(BUILD)
+$(PKG)_DEPS_$(BUILD) := autoconf automake
+
+define $(PKG)_BUILD_$(BUILD)
+    mkdir '$(1).build'
+    cd    '$(1).build' && '$(1)/configure' \
+        --prefix='$(PREFIX)/$(TARGET)'
+    $(MAKE) -C '$(1).build' -j '$(JOBS)'
+    $(MAKE) -C '$(1).build' -j 1 install
+endef

--- a/plugins/native/m4.mk
+++ b/plugins/native/m4.mk
@@ -1,0 +1,33 @@
+# This file is part of MXE.
+# See index.html for further information.
+
+PKG             := m4
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 1.4.17
+$(PKG)_CHECKSUM := f0543c3beb51fa6b3337d8025331591e0e18d8ec2886ed391f1aade43477d508
+$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.xz
+$(PKG)_URL      := http://ftp.gnu.org/pub/gnu/m4/$($(PKG)_FILE)
+$(PKG)_URL_2    := ftp://ftp.gnu.org/pub/gnu/m4/$($(PKG)_FILE)
+$(PKG)_WEBSITE  := http://www.gnu.org/software/m4
+$(PKG)_MAKEFILE := $(realpath $(lastword $(MAKEFILE_LIST)))
+$(PKG)_OWNER    := https://github.com/tonytheodore
+$(PKG)_TARGETS  := $(BUILD)
+$(PKG)_DEPS     :=
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- 'http://ftp.gnu.org/gnu/m4/?C=M;O=D' | \
+    $(SED) -n 's,.*<a href="m4-\([0-9][^"]*\)\.tar.*,\1,p' | \
+    $(SORT) -V | \
+    tail -1
+endef
+
+define $(PKG)_BUILD_$(BUILD)
+    # gets has been removed from recent glibc
+    $(SED) -i -e '/gets is a/d' '$(1)/lib/stdio.in.h'
+    mkdir '$(1).build'
+    cd    '$(1).build' && '$(1)/configure' \
+        --prefix='$(PREFIX)/$(TARGET)'
+    $(MAKE) -C '$(1).build' -j '$(JOBS)'
+    $(MAKE) -C '$(1).build' -j 1 install
+endef

--- a/plugins/native/make.mk
+++ b/plugins/native/make.mk
@@ -1,0 +1,32 @@
+# This file is part of MXE.
+# See index.html for further information.
+
+PKG             := make
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 4.1
+$(PKG)_CHECKSUM := 0bc7613389650ee6a24554b52572a272f7356164fd2c4132b0bcf13123e4fca5
+$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.bz2
+$(PKG)_URL      := http://ftp.gnu.org/pub/gnu/$(PKG)/$($(PKG)_FILE)
+$(PKG)_URL_2    := ftp://ftp.gnu.org/pub/gnu/$(PKG)/$($(PKG)_FILE)
+$(PKG)_WEBSITE  := http://www.gnu.org/software/make
+$(PKG)_MAKEFILE := $(realpath $(lastword $(MAKEFILE_LIST)))
+$(PKG)_OWNER    := https://github.com/tonytheodore
+$(PKG)_TARGETS  := $(BUILD)
+
+$(PKG)_DEPS_$(BUILD) := gettext
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- 'http://ftp.gnu.org/gnu/make/?C=M;O=D' | \
+    $(SED) -n 's,.*<a href="make-\([0-9][^"]*\)\.tar.*,\1,p' | \
+    $(SORT) -V | \
+    tail -1
+endef
+
+define $(PKG)_BUILD_$(BUILD)
+    mkdir '$(1).build'
+    cd    '$(1).build' && '$(1)/configure' \
+        --prefix='$(PREFIX)/$(TARGET)'
+    $(MAKE) -C '$(1).build' -j '$(JOBS)'
+    $(MAKE) -C '$(1).build' -j 1 install
+endef

--- a/plugins/native/sed.mk
+++ b/plugins/native/sed.mk
@@ -1,0 +1,32 @@
+# This file is part of MXE.
+# See index.html for further information.
+
+PKG             := sed
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 4.2.2
+$(PKG)_CHECKSUM := f048d1838da284c8bc9753e4506b85a1e0cc1ea8999d36f6995bcb9460cddbd7
+$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.bz2
+$(PKG)_URL      := http://ftp.gnu.org/pub/gnu/$(PKG)/$($(PKG)_FILE)
+$(PKG)_URL_2    := ftp://ftp.gnu.org/pub/gnu/$(PKG)/$($(PKG)_FILE)
+$(PKG)_WEBSITE  := https://www.gnu.org/software/sed
+$(PKG)_MAKEFILE := $(realpath $(lastword $(MAKEFILE_LIST)))
+$(PKG)_OWNER    := https://github.com/tonytheodore
+$(PKG)_TARGETS  := $(BUILD)
+
+$(PKG)_DEPS_$(BUILD) := gettext libiconv
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- 'http://ftp.gnu.org/gnu/sed/?C=M;O=D' | \
+    $(SED) -n 's,.*<a href="sed-\([0-9][^"]*\)\.tar.*,\1,p' | \
+    $(SORT) -V | \
+    tail -1
+endef
+
+define $(PKG)_BUILD_$(BUILD)
+    mkdir '$(1).build'
+    cd    '$(1).build' && '$(1)/configure' \
+        --prefix='$(PREFIX)/$(TARGET)'
+    $(MAKE) -C '$(1).build' -j '$(JOBS)' man1_MANS=
+    $(MAKE) -C '$(1).build' -j 1 install man1_MANS=
+endef


### PR DESCRIPTION
Following on from #881 and #925, this removes the optional native builds and provides a new way to handle such things.

Basic usage is to drop some `*.mk` files in a directory and set `MXE_PLUGIN_DIRS='path1 path2 ...'`. Building and updates work as expected, but I haven't tested heavily enough to expose any edge cases.

```
$ make keepassx MXE_PLUGIN_DIRS='plugins/apps' -j4
[using autodetected 6 job(s)]
[check requirements]
[build]     mxe-conf               x86_64-apple-darwin14.5.0
[done]      mxe-conf               x86_64-apple-darwin14.5.0                              312 KiB        0m7.361s
[build]     gmp                    x86_64-apple-darwin14.5.0
[build]     pkgconf                x86_64-apple-darwin14.5.0
...
[done]      freetds                i686-w64-mingw32.static                                138528 KiB     1m39.181s
[done]      postgresql             i686-w64-mingw32.static                                228680 KiB     1m6.607s
[build]     qt                     i686-w64-mingw32.static
[done]      qt                     i686-w64-mingw32.static                                1593572 KiB    11m48.140s
[build]     keepassx               i686-w64-mingw32.static
[done]      keepassx               i686-w64-mingw32.static                                71752 KiB      0m16.743s
```

Plugins are self-contained and should have the following lines (depending on what they're doing):

```
$(PKG)_WEBSITE  := http://www.gnu.org/software/automake
$(PKG)_MAKEFILE := $(lastword $(MAKEFILE_LIST))
$(PKG)_OWNER    := https://github.com/tonytheodore
```

Since the plugins are just makefiles, users will have almost unlimited flexibility to modify rules and keep those changes under source control (without having merge conflicts etc.). For the plugins in our tree, I've [tried to highlight that they aren't supported](https://github.com/tonytheodore/mxe/tree/plugins/plugins).

Naming, of course, can be changed.
