### PR TITLE
build-pkg: check shared targets install dlls; do not create empty packages

### DIFF
--- a/tools/build-pkg.lua
+++ b/tools/build-pkg.lua
@@ -112,6 +112,16 @@ local function sliceArray(list, nelements)
     return new_list
 end
 
+local function concatArrays(...)
+    local result = {}
+    for _, array in ipairs({...}) do
+        for _, elem in ipairs(array) do
+            table.insert(result, elem)
+        end
+    end
+    return result
+end
+
 local function isInString(substring, string)
     return string:find(substring, 1, true)
 end
@@ -352,6 +362,26 @@ local function checkFile(file, item)
     end
 end
 
+local function checkFileList(files, item)
+    local target, _ = parseItem(item)
+    if target:match('shared') then
+        local has_a, has_dll
+        for _, file in ipairs(files) do
+            file = file:lower()
+            if file:match('%.a') then
+                has_a = true
+            end
+            if file:match('%.dll') then
+                has_dll = true
+            end
+        end
+        if has_a and not has_dll then
+            log('Shared item %s installs .a file ' ..
+                'but no .dll', item)
+        end
+    end
+end
+
 -- builds package, returns list of new files
 local function buildItem(item, item2deps, file2item)
     local target, pkg = parseItem(item)
@@ -374,6 +404,7 @@ local function buildItem(item, item2deps, file2item)
         log('Item %s changes %s, created by %s',
             item, file, creator_item)
     end
+    checkFileList(concatArrays(new_files, changed_files), item)
     return new_files
 end
 

--- a/tools/build-pkg.lua
+++ b/tools/build-pkg.lua
@@ -43,7 +43,7 @@ local GIT = 'git --work-tree=./usr/ --git-dir=./usr/.git '
 
 local BLACKLIST = {
     '^usr/installed/check%-requirements$',
-    -- usr/share/cmake if useful
+    -- usr/share/cmake is useful
     '^usr/share/doc/',
     '^usr/share/info/',
     '^usr/share/man/',

--- a/tools/build-pkg.lua
+++ b/tools/build-pkg.lua
@@ -565,6 +565,13 @@ local function makeDebs(items, item2deps, item2ver, item2files)
         local ver = assert(item2ver[item], item)
         local files = assert(item2files[item], item)
         if not isEmpty(item, files) then
+            for _, dep in ipairs(deps) do
+                local dep_files = assert(item2files[dep], dep)
+                if isEmpty(dep, dep_files) then
+                    log('Non-empty item %s depends on ' ..
+                        'empty item %s', item, dep)
+                end
+            end
             makeDeb(item, files, deps, ver)
         end
     end

--- a/tools/build-pkg.lua
+++ b/tools/build-pkg.lua
@@ -521,6 +521,10 @@ local function isBuilt(item, files)
     return false
 end
 
+local function isEmpty(item, files)
+    return #files == 1
+end
+
 -- build all packages, save filelist to list file
 local function buildPackages(items, item2deps)
     local broken = {}
@@ -560,7 +564,9 @@ local function makeDebs(items, item2deps, item2ver, item2files)
         local deps = assert(item2deps[item], item)
         local ver = assert(item2ver[item], item)
         local files = assert(item2files[item], item)
-        makeDeb(item, files, deps, ver)
+        if not isEmpty(item, files) then
+            makeDeb(item, files, deps, ver)
+        end
     end
 end
 


### PR DESCRIPTION
See https://github.com/mxe/mxe/pull/966#issuecomment-153712570
```
$ grep '.a file but no' log                                                                                               
[build-pkg]     Shared item x86_64-w64-mingw32.shared~yasm installes .a file but no .dll
[build-pkg]     Shared item x86_64-w64-mingw32.shared~termcap installes .a file but no .dll
[build-pkg]     Shared item x86_64-w64-mingw32.shared~polarssl installes .a file but no .dll
[build-pkg]     Shared item x86_64-w64-mingw32.shared~nlopt installes .a file but no .dll
[build-pkg]     Shared item x86_64-w64-mingw32.shared~mman-win32 installes .a file but no .dll
[build-pkg]     Shared item x86_64-w64-mingw32.shared~aspell installes .a file but no .dll
[build-pkg]     Shared item i686-w64-mingw32.shared~yasm installes .a file but no .dll
[build-pkg]     Shared item i686-w64-mingw32.shared~termcap installes .a file but no .dll
[build-pkg]     Shared item i686-w64-mingw32.shared~polarssl installes .a file but no .dll
[build-pkg]     Shared item i686-w64-mingw32.shared~nlopt installes .a file but no .dll
[build-pkg]     Shared item i686-w64-mingw32.shared~mman-win32 installes .a file but no .dll
[build-pkg]     Shared item i686-w64-mingw32.shared~aspell installes .a file but no .dll
[build-pkg]     Shared item x86_64-w64-mingw32.shared~libvpx installes .a file but no .dll
[build-pkg]     Shared item x86_64-w64-mingw32.shared~cblas installes .a file but no .dll
[build-pkg]     Shared item i686-w64-mingw32.shared~libvpx installes .a file but no .dll
[build-pkg]     Shared item i686-w64-mingw32.shared~cblas installes .a file but no .dll
[build-pkg]     Shared item x86_64-w64-mingw32.shared~sdl2_gfx installes .a file but no .dll
[build-pkg]     Shared item i686-w64-mingw32.shared~sdl2_gfx installes .a file but no .dll
[build-pkg]     Shared item x86_64-w64-mingw32.shared~vcdimager installes .a file but no .dll
[build-pkg]     Shared item x86_64-w64-mingw32.shared~libmng installes .a file but no .dll
[build-pkg]     Shared item i686-w64-mingw32.shared~vcdimager installes .a file but no .dll
[build-pkg]     Shared item i686-w64-mingw32.shared~libmng installes .a file but no .dll
[build-pkg]     Shared item x86_64-w64-mingw32.shared~sdl2_ttf installes .a file but no .dll
[build-pkg]     Shared item i686-w64-mingw32.shared~sdl2_ttf installes .a file but no .dll
[build-pkg]     Shared item x86_64-w64-mingw32.shared~qtservice installes .a file but no .dll
[build-pkg]     Shared item x86_64-w64-mingw32.shared~qtactiveqt installes .a file but no .dll
[build-pkg]     Shared item i686-w64-mingw32.shared~qtservice installes .a file but no .dll
[build-pkg]     Shared item i686-w64-mingw32.shared~qtactiveqt installes .a file but no .dll
```

-----------

See #968
```
$ ls *.list | wc -l
1223

$ wc -l *.list | egrep '\s1\s' | wc -l                        
10

$ wc -l *.list | egrep '\s1\s' 
       1 mxe-i686-w64-mingw32.shared-gendef.list
       1 mxe-i686-w64-mingw32.shared-wget.list
       1 mxe-i686-w64-mingw32.static-blas.list
       1 mxe-i686-w64-mingw32.static-gendef.list
       1 mxe-i686-w64-mingw32.static-wget.list
       1 mxe-x86-64-w64-mingw32.shared-gendef.list
       1 mxe-x86-64-w64-mingw32.shared-wget.list
       1 mxe-x86-64-w64-mingw32.static-blas.list
       1 mxe-x86-64-w64-mingw32.static-gendef.list
       1 mxe-x86-64-w64-mingw32.static-wget.list
```
The files listed above contain 2 lines, but last line has no EOL:
```
$ cat mxe-x86-64-w64-mingw32.shared-wget.list
usr/x86_64-w64-mingw32.shared/bin/wget.exe
usr/x86_64-w64-mingw32.shared/installed/wget$
```
It is unrelated issue.