### PR TITLE
gdk-pixbuf2-devel not gdk-pixbuf-devel

### DIFF
--- a/index.html
+++ b/index.html
@@ -648,7 +648,7 @@ USE_OSGPLUGIN(&lt;plugin2&gt;)
     <!-- https://admin.fedoraproject.org/pkgdb/ -->
     <pre>yum install \
     autoconf automake bash bison bzip2 cmake flex gcc-c++ \
-    gdk-pixbuf-devel gettext git gperf intltool make sed libffi-devel \
+    gdk-pixbuf2-devel gettext git gperf intltool make sed libffi-devel \
     libtool openssl-devel p7zip patch perl pkgconfig \
     python ruby scons unzip wget xz</pre>
 


### PR DESCRIPTION
This is to provide gdk-pixbuf-csource.