### PR TITLE
disable wine

### DIFF
--- a/src/mxe-conf.mk
+++ b/src/mxe-conf.mk
@@ -100,4 +100,12 @@ define $(PKG)_BUILD_$(BUILD)
 
     #create readonly directory to force wine to fail
     $(INSTALL) -m444 -d "$$WINEPREFIX"
+
+    #create script "wine" in a directory which is in PATH
+    mkdir -p '$(PREFIX)/$(BUILD)/bin/'
+    (echo '#!/usr/bin/env bash'; \
+     echo 'exit 1'; \
+    ) \
+             > '$(PREFIX)/$(BUILD)/bin/wine'
+    chmod 0755 '$(PREFIX)/$(BUILD)/bin/wine'
 endef

--- a/src/mxe-conf.mk
+++ b/src/mxe-conf.mk
@@ -72,7 +72,6 @@ define $(PKG)_BUILD
      echo 'Description: OpenGL'; \
      echo 'Libs: -lopengl32';) \
      > '$(PREFIX)/$(TARGET)/lib/pkgconfig/gl.pc'
-
     (echo 'Name: glu'; \
      echo 'Version: 0'; \
      echo 'Description: OpenGL'; \

--- a/src/mxe-conf.mk
+++ b/src/mxe-conf.mk
@@ -62,9 +62,6 @@ define $(PKG)_BUILD
              > '$(PREFIX)/bin/$(TARGET)-cmake'
     chmod 0755 '$(PREFIX)/bin/$(TARGET)-cmake'
 
-    #create readonly directory to force wine to fail
-    $(INSTALL) -m444 -d "$$WINEPREFIX"
-
     # create pkg-config files for OpenGL/GLU
     $(INSTALL) -d '$(PREFIX)/$(TARGET)/lib/pkgconfig'
     (echo 'Name: gl'; \
@@ -100,4 +97,7 @@ define $(PKG)_BUILD_$(BUILD)
      > '$(1)/configure.ac'
     cd '$(1)' && autoreconf -fiv
     cd '$(1)' && ./configure
+
+    #create readonly directory to force wine to fail
+    $(INSTALL) -m444 -d "$$WINEPREFIX"
 endef


### PR DESCRIPTION
Now dlfcn-win32 can't detect wine.
From log/dlfcn-win32_i686-w64-mingw32.static:

    static: yes
    shared: no
    wine:

Previously wine was set to "yes wine".

fix #995