### PR TITLE
Standardise github packages

### DIFF
--- a/src/assimp.mk
+++ b/src/assimp.mk
@@ -4,19 +4,13 @@
 PKG             := assimp
 $(PKG)_IGNORE   :=
 $(PKG)_VERSION  := 3.1.1
-$(PKG)_CHECKSUM := 3b8d16eaf6c4b26479295f4f7436388bee1e42e8c0b11f6f695b7194985eb00e
-$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
-$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).zip
-$(PKG)_URL      := http://$(SOURCEFORGE_MIRROR)/project/$(PKG)/$(PKG)-$(call SHORT_PKG_VERSION,$(PKG))/$($(PKG)_FILE)
+$(PKG)_CHECKSUM := a8164e12389277951a0bc2e68b19c04031b0152f33e2a0e74ab55b2d449c3f4e
 $(PKG)_DEPS     := gcc boost
 
-define $(PKG)_UPDATE
-    $(WGET) -q -O- "https://api.github.com/repos/assimp/assimp/releases" | \
-    grep 'tag_name' | \
-    $(SED) -n 's,.*tag_name": "v\([0-9][^>]*\)".*,\1,p' | \
-    $(SORT) -Vr | \
-    head -1
-endef
+$(PKG)_GH_REPO    := $(PKG)/$(PKG)
+$(PKG)_GH_TAG_PFX := v
+$(PKG)_GH_TAG_SHA := 1c4a8e9
+$(eval $(MXE_SETUP_GITHUB))
 
 define $(PKG)_BUILD
     mkdir '$(1)/build'

--- a/src/box2d.mk
+++ b/src/box2d.mk
@@ -4,16 +4,13 @@
 PKG             := box2d
 $(PKG)_IGNORE   :=
 $(PKG)_VERSION  := 2.3.1
-$(PKG)_CHECKSUM := 2c61505f03ef403b54cf0e510d83d6f567e37882ad79b5b2d486acbc7d5eedea
-$(PKG)_SUBDIR   := Box2D-$($(PKG)_VERSION)/Box2D
-$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.gz
-$(PKG)_URL      := https://github.com/erincatto/Box2D/archive/v$($(PKG)_VERSION).tar.gz
+$(PKG)_CHECKSUM := d323141a9bb202e37f9860568ca0769be67e4758e6bbccb4f190fdf50cc7bf4e
 $(PKG)_DEPS     := gcc
 
-define $(PKG)_UPDATE
-    $(call MXE_GET_GITHUB_TAGS, erincatto/Box2D) | \
-    $(SED) 's,^v,,g'
-endef
+$(PKG)_GH_REPO    := erincatto/Box2D
+$(PKG)_GH_TAG_PFX := v
+$(PKG)_GH_TAG_SHA := b20eb82
+$(eval $(MXE_SETUP_GITHUB))
 
 define $(PKG)_BUILD
     mkdir '$(1).build'

--- a/src/chipmunk.mk
+++ b/src/chipmunk.mk
@@ -4,17 +4,13 @@
 PKG             := chipmunk
 $(PKG)_IGNORE   :=
 $(PKG)_VERSION  := 6.2.2
-$(PKG)_CHECKSUM := c51f0e3a30770f6b940de3228bee40a871aaf7611a1b5ec546a7d2b9e1041f97
-$(PKG)_SUBDIR   := Chipmunk2D-Chipmunk-$($(PKG)_VERSION)
-$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.gz
-$(PKG)_URL      := https://github.com/slembcke/Chipmunk2D/archive/Chipmunk-$($(PKG)_VERSION).tar.gz
+$(PKG)_CHECKSUM := 961c9dd228199ed1f6e4a6260174bf31a16cc6dbb3785f513ee957437fecb200
 $(PKG)_DEPS     := gcc
 
-define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://github.com/slembcke/Chipmunk2D/releases' | \
-    $(SED) -n 's,.*/archive/Chipmunk-\([0-9][^>]*\)\.tar.*,\1,p' | \
-    head -1
-endef
+$(PKG)_GH_REPO    := slembcke/Chipmunk2D
+$(PKG)_GH_TAG_PFX := Chipmunk-
+$(PKG)_GH_TAG_SHA := 9b0d57e
+$(eval $(MXE_SETUP_GITHUB))
 
 define $(PKG)_BUILD
     mkdir '$(1)/build'

--- a/src/dlfcn-win32.mk
+++ b/src/dlfcn-win32.mk
@@ -4,17 +4,13 @@
 PKG             := dlfcn-win32
 $(PKG)_IGNORE   :=
 $(PKG)_VERSION  := 1.0.0
-$(PKG)_CHECKSUM := 36f2e7ef1f1ba04f6ce682a71937eaddd3d6994f09e29df2c7578ec524e47450
-$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
-$(PKG)_FILE     := $($(PKG)_SUBDIR).tar.gz
-$(PKG)_URL      := https://github.com/$(PKG)/$(PKG)/archive/v$($(PKG)_VERSION).tar.gz
+$(PKG)_CHECKSUM := a0077c1b2da06d6ffa665cf4b315b40d8633054fd8738c68309ff800e0c95ee3
 $(PKG)_DEPS     := gcc
 
-define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://github.com/dlfcn-win32/dlfcn-win32/releases' | \
-    $(SED) -n 's,.*<a href="/dlfcn-win32/dlfcn-win32/archive/v\([0-9][^>]*\)\.tar.*,\1,p' | \
-    head -1
-endef
+$(PKG)_GH_REPO    := $(PKG)/$(PKG)
+$(PKG)_GH_TAG_PFX := v
+$(PKG)_GH_TAG_SHA := cf56306
+$(eval $(MXE_SETUP_GITHUB))
 
 define $(PKG)_BUILD
     cd '$(1)' && ./configure \

--- a/src/jsoncpp.mk
+++ b/src/jsoncpp.mk
@@ -4,18 +4,13 @@
 PKG             := jsoncpp
 $(PKG)_IGNORE   :=
 $(PKG)_VERSION  := 1.6.5
-$(PKG)_CHECKSUM := a2b121eaff56ec88cfd034d17685821a908d0d87bc319329b04f91a6552c1ac2
-$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
-$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.gz
-$(PKG)_URL      := https://github.com/open-source-parsers/jsoncpp/archive/$($(PKG)_VERSION).tar.gz
+$(PKG)_CHECKSUM := ce0f245885fef62f2cbcbfbfe8a1267dc289b9c2d48fdbb90775c33d71fdc750
 $(PKG)_DEPS     := gcc
 
-define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://github.com/open-source-parsers/jsoncpp/archive/' | \
-    $(SED) -n 's,.*/\([0-9][^"]*\)/"\.tar.*,\1,p' | \
-    sort | uniq | \
-    head -1
-endef
+$(PKG)_GH_REPO    := open-source-parsers/$(PKG)
+$(PKG)_GH_TAG_PFX :=
+$(PKG)_GH_TAG_SHA := d84702c
+$(eval $(MXE_SETUP_GITHUB))
 
 define $(PKG)_BUILD
     mkdir '$(1)/build'

--- a/src/librtmp.mk
+++ b/src/librtmp.mk
@@ -5,12 +5,11 @@ PKG             := librtmp
 $(PKG)_IGNORE   :=
 $(PKG)_VERSION  := a1900c3
 $(PKG)_CHECKSUM := fa4edd83cb6ed19d97f89a6d83aef6231c1bd8079aea5d33c083f827459a9ab2
-$(PKG)_SUBDIR   := mirror-rtmpdump-$($(PKG)_VERSION)
-$(PKG)_FILE     := rtmpdump-$($(PKG)_VERSION).tar.gz
-$(PKG)_URL      := https://github.com/mirror/rtmpdump/tarball/$($(PKG)_VERSION)/$($(PKG)_FILE)
 $(PKG)_DEPS     := gcc gnutls
 
-$(PKG)_UPDATE = $(call MXE_GET_GITHUB_SHA, mirror/rtmpdump, master)
+$(PKG)_GH_REPO   := mirror/rtmpdump
+$(PKG)_GH_BRANCH := master
+$(eval $(MXE_SETUP_GITHUB))
 
 define $(PKG)_BUILD
     $(MAKE) -C '$(1)' \

--- a/src/muparser.mk
+++ b/src/muparser.mk
@@ -4,15 +4,13 @@
 PKG             := muparser
 $(PKG)_IGNORE   :=
 $(PKG)_VERSION  := 2.2.5
-$(PKG)_CHECKSUM := 0666ef55da72c3e356ca85b6a0084d56b05dd740c3c21d26d372085aa2c6e708
-$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
-$(PKG)_FILE     := $($(PKG)_SUBDIR).tar.gz
-$(PKG)_URL      := https://github.com/beltoforion/$(PKG)/archive/v$($(PKG)_VERSION).tar.gz
+$(PKG)_CHECKSUM := 3a7e1c94865abd11c8ade7824241eb9eacfc252f4d4214723a5f06d19563f5e0
 $(PKG)_DEPS     := gcc
 
-define $(PKG)_UPDATE
-    $(call MXE_GET_GITHUB_TAGS, beltoforion/muparser, v)
-endef
+$(PKG)_GH_REPO    := beltoforion/muparser
+$(PKG)_GH_TAG_PFX := v
+$(PKG)_GH_TAG_SHA := 57e7e28
+$(eval $(MXE_SETUP_GITHUB))
 
 define $(PKG)_BUILD
     cd '$(1)' && ./configure \

--- a/src/pire.mk
+++ b/src/pire.mk
@@ -4,15 +4,13 @@
 PKG             := pire
 $(PKG)_IGNORE   :=
 $(PKG)_VERSION  := 0.0.5
-$(PKG)_CHECKSUM := 85a9bd66fff568554826e4aff9b188ed6124e3ea0530cc561723b36aea2a58e3
-$(PKG)_SUBDIR   := pire-release-$($(PKG)_VERSION)
-$(PKG)_FILE     := pire-$($(PKG)_VERSION).tar.gz
-$(PKG)_URL      := https://github.com/yandex/pire/archive/release-$($(PKG)_VERSION).tar.gz
+$(PKG)_CHECKSUM := 8cfe1c97e54539c5751dcbcddc3b15610cf43fd8458ed821450cac7b2ad6b2f9
 $(PKG)_DEPS     := gcc
 
-define $(PKG)_UPDATE
-    $(call MXE_GET_GITHUB_TAGS, yandex/pire, release-)
-endef
+$(PKG)_GH_REPO    := yandex/pire
+$(PKG)_GH_TAG_PFX := release-
+$(PKG)_GH_TAG_SHA := 012bedf
+$(eval $(MXE_SETUP_GITHUB))
 
 define $(PKG)_BUILD
     cd '$(1)' && autoreconf -fi

--- a/src/vmime.mk
+++ b/src/vmime.mk
@@ -5,12 +5,11 @@ PKG             := vmime
 $(PKG)_IGNORE   :=
 $(PKG)_VERSION  := 7e36a74
 $(PKG)_CHECKSUM := 4b73f0f30e37f9134fb5157aca3576ca29036262d379aaffcce3a443a2f271ee
-$(PKG)_SUBDIR   := kisli-vmime-$($(PKG)_VERSION)
-$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.gz
-$(PKG)_URL      := https://github.com/kisli/vmime/tarball/$($(PKG)_VERSION)/$($(PKG)_FILE)
 $(PKG)_DEPS     := gcc gnutls libgsasl pthreads zlib
 
-$(PKG)_UPDATE    = $(call MXE_GET_GITHUB_SHA, kisli/vmime, master) | $(SED) 's/^\(.......\).*/\1/;'
+$(PKG)_GH_REPO   := kisli/vmime
+$(PKG)_GH_BRANCH := master
+$(eval $(MXE_SETUP_GITHUB))
 
 define $(PKG)_BUILD
     # The following hint is probably needed for ICU:


### PR DESCRIPTION
Following on from #998, a first pass at standardising the handling of github packages. I had to use the `sha` for downloads as tag/file naming conventions vary too much.

Thoughts?