### PR TITLE
Coin3D: do not disable features by default

### DIFF
--- a/src/coin.mk
+++ b/src/coin.mk
@@ -23,12 +23,6 @@ define $(PKG)_BUILD
         --disable-debug \
         --disable-symbols \
         --enable-compact \
-        --without-openal \
-        --without-fontconfig \
-        --without-spidermonkey \
-        --without-freetype \
-        --without-zlib \
-        --without-bzip2 \
         --without-x \
         COIN_STATIC=$(if $(BUILD_STATIC),true,false)
 


### PR DESCRIPTION
Per https://github.com/mxe/mxe/pull/966#issuecomment-157644451, I have removed the disabling of features.  I tested it with a clean MXE installation that only had gcc installed.