### PR TITLE
Fix MySQL and PostgreSQL posix build

### DIFF
--- a/src/libmysqlclient-2-posix-fixes.patch
+++ b/src/libmysqlclient-2-posix-fixes.patch
@@ -1,0 +1,86 @@
+This file is part of MXE.
+See index.html for further information.
+
+Contains ad hoc patches for cross building.
+
+From 6721189cf5ceeb34f47cc228d9a5d8a9cf9dfdb8 Mon Sep 17 00:00:00 2001
+From: MXE
+Date: Fri, 13 Nov 2015 10:22:12 -0500
+Subject: [PATCH] For Windows, check if POSIX thread model or win32 thread
+ model is being used.
+
+
+diff --git a/configure.cmake b/configure.cmake
+index a4f5e8f..8e623b8 100644
+--- a/configure.cmake
++++ b/configure.cmake
+@@ -389,6 +389,7 @@ CHECK_INCLUDE_FILES (fnmatch.h HAVE_FNMATCH_H)
+ CHECK_INCLUDE_FILES (sys/un.h HAVE_SYS_UN_H)
+ CHECK_INCLUDE_FILES (vis.h HAVE_VIS_H) # Used by libedit
+ CHECK_INCLUDE_FILES (sasl/sasl.h HAVE_SASL_SASL_H) # Used by memcached
++CHECK_INCLUDE_FILES (pthread.h HAVE_PTHREAD_H)
+ 
+ # For libevent
+ CHECK_INCLUDE_FILES(sys/devpoll.h HAVE_DEVPOLL)
+diff --git a/include/my_pthread.h b/include/my_pthread.h
+index 0a58cc0..abcffe8 100644
+--- a/include/my_pthread.h
++++ b/include/my_pthread.h
+@@ -20,7 +20,7 @@
+ 
+ #include "my_global.h"                          /* myf */
+ 
+-#if !defined(_WIN32)
++#if !(defined(_WIN32) && !defined(USING_PTHREADS))
+ #include <pthread.h>
+ #endif
+ 
+@@ -35,7 +35,7 @@ extern "C" {
+ #define EXTERNC
+ #endif /* __cplusplus */ 
+ 
+-#if defined(_WIN32)
++#if defined(_WIN32) && !defined(__WINPTHREADS_VERSION)
+ typedef DWORD		 pthread_t;
+ #define pthread_self() GetCurrentThreadId()
+ #define pthread_handler_t EXTERNC void * __cdecl
+@@ -51,7 +51,7 @@ typedef DWORD		 pthread_t;
+ #include "thr_cond.h"
+ #include "thr_rwlock.h"
+ 
+-#if defined(_WIN32)
++#if defined(_WIN32) && !defined(__WINPTHREADS_VERSION)
+ /*
+   Existing mysql_thread_create() or pthread_create() does not work well
+   in windows platform when threads are joined because
+diff --git a/mysys/CMakeLists.txt b/mysys/CMakeLists.txt
+index e8e4972..322267c 100644
+--- a/mysys/CMakeLists.txt
++++ b/mysys/CMakeLists.txt
+@@ -78,6 +78,10 @@ IF(CMAKE_USE_PTHREADS_INIT AND CMAKE_C_FLAGS MATCHES "-fsanitize=")
+   TARGET_LINK_LIBRARIES(mysys pthread)
+ ENDIF()
+ 
++IF(HAVE_PTHREAD_H)
++  ADD_DEFINITIONS(-DUSING_PTHREADS)
++ENDIF()
++
+ IF(WITH_UNIT_TESTS)
+ 
+ ADD_EXECUTABLE(thr_lock thr_lock.c)
+diff --git a/mysys/my_winthread.c b/mysys/my_winthread.c
+index 7924fe4..b364030 100644
+--- a/mysys/my_winthread.c
++++ b/mysys/my_winthread.c
+@@ -16,7 +16,7 @@
+ /*****************************************************************************
+ ** Simulation of posix threads calls for Windows
+ *****************************************************************************/
+-#if defined (_WIN32)
++#if defined (_WIN32) && !defined (USING_PTHREADS)
+ #include "mysys_priv.h"
+ #include <process.h>
+ #include <signal.h>
+-- 
+2.5.0
+

--- a/src/postgresql-4-posix-threads.patch
+++ b/src/postgresql-4-posix-threads.patch
@@ -1,0 +1,68 @@
+This file is part of MXE.
+See index.html for further information.
+
+Contains ad hoc patches for cross building.
+
+From de18dd0d72cd44a132bd6e7852f461998aef3e5d Mon Sep 17 00:00:00 2001
+From: MXE
+Date: Fri, 13 Nov 2015 18:15:26 -0500
+Subject: [PATCH] Windows POSIX threads build fixes.
+
+
+diff --git a/configure.in b/configure.in
+index 2f8bb3d..ed582e0 100644
+--- a/configure.in
++++ b/configure.in
+@@ -1455,7 +1455,10 @@ fi
+ # libraries, and whether the normal C function names are thread-safe.
+ # See the comment at the top of src/port/thread.c for more information.
+ # WIN32 doesn't need the pthread tests;  it always uses threads
+-if test "$enable_thread_safety" = yes -a "$PORTNAME" != "win32"; then
++if test "$enable_thread_safety" = yes; then
++if test "$PORTNAME" = "win32"; then
++AC_CHECK_HEADER(pthread.h, [AC_SUBST(USING_WINDOWS_POSIX,yes)], [AC_SUBST(USING_WINDOWS_POSIX,no)])
++else
+ ACX_PTHREAD	# set thread flags
+ 
+ # Some platforms use these, so just define them.  They can't hurt if they
+@@ -1492,6 +1495,7 @@ PGAC_FUNC_STRERROR_R_INT
+ CFLAGS="$_CFLAGS"
+ LIBS="$_LIBS"
+ 
++fi
+ else
+ # do not use values from template file
+ PTHREAD_CFLAGS=
+diff --git a/src/Makefile.global.in b/src/Makefile.global.in
+index b10ce30..060457d 100644
+--- a/src/Makefile.global.in
++++ b/src/Makefile.global.in
+@@ -366,6 +366,9 @@ WIN32_STACK_RLIMIT=4194304
+ # Set if we have a working win32 crashdump header
+ have_win32_dbghelp = @have_win32_dbghelp@
+ 
++# Set if the win32 GCC is using the posix thread model
++USING_WINDOWS_POSIX = @USING_WINDOWS_POSIX@
++
+ # Pull in platform-specific magic
+ include $(top_builddir)/src/Makefile.port
+ 
+diff --git a/src/interfaces/libpq/Makefile b/src/interfaces/libpq/Makefile
+index b71b0c7..5d44f7a 100644
+--- a/src/interfaces/libpq/Makefile
++++ b/src/interfaces/libpq/Makefile
+@@ -55,9 +55,11 @@ libpqrc.o: libpq.rc
+ 	$(WINDRES) -i $< -o $@
+ 
+ ifeq ($(enable_thread_safety), yes)
++ifneq ($(USING_WINDOWS_POSIX), yes)
+ OBJS += pthread-win32.o
+ endif
+ endif
++endif
+ 
+ 
+ # Add libraries that libpq depends (or might depend) on into the
+-- 
+2.5.0
+


### PR DESCRIPTION
Both of these applications assume pthreads isn't available on Windows and redefine those functions, resulting in duplicate definitions.