### PR TITLE
toolchain re-org II: build using phases with pseudo-targets

### DIFF
--- a/src/binutils.mk
+++ b/src/binutils.mk
@@ -9,7 +9,8 @@ $(PKG)_SUBDIR   := binutils-$($(PKG)_VERSION)
 $(PKG)_FILE     := binutils-$($(PKG)_VERSION).tar.bz2
 $(PKG)_URL      := http://ftp.gnu.org/pub/gnu/binutils/$($(PKG)_FILE)
 $(PKG)_URL_2    := ftp://ftp.cs.tu-berlin.de/pub/gnu/binutils/$($(PKG)_FILE)
-$(PKG)_DEPS     := pkgconf
+$(PKG)_TARGETS  := $(PHASE_1_TARGETS) $(PHASE_2_TARGETS) $(MXE_TARGETS)
+$(PKG)_DEPS     :=
 
 define $(PKG)_UPDATE
     $(WGET) -q -O- 'http://ftp.gnu.org/gnu/binutils/?C=M;O=D' | \
@@ -17,6 +18,11 @@ define $(PKG)_UPDATE
     $(SORT) -V | \
     tail -1
 endef
+
+# list of programs to symlink
+$(PKG)_PROGS := addr2line ar as c++filt dlltool dllwrap elfedit gprof \
+                ld ld.bfd nm objcopy objdump ranlib readelf size strings \
+                strip windmc windres
 
 define $(PKG)_BUILD
     cd '$(1)' && ./configure \
@@ -33,7 +39,33 @@ define $(PKG)_BUILD
     $(MAKE) -C '$(1)' -j '$(JOBS)'
     $(MAKE) -C '$(1)' -j 1 install
 
-    rm -f $(addprefix $(PREFIX)/$(TARGET)/bin/, ar as dlltool ld ld.bfd nm objcopy objdump ranlib strip)
+    rm -f $(addprefix $(PREFIX)/$(TARGET)/bin/,$($(PKG)_PROGS))
 endef
+
+# symlink previous phases
+define $(PKG)_BUILD_SYMLINK_PHASE
+    $(foreach PKG,$($(PKG)_PROGS),\
+        ln -sf '$(PREFIX)/bin/$(call GET_PHASE_$(1)_TARGET,$(TARGET))-$(PKG)' \
+               '$(PREFIX)/bin/$(TARGET)-$(PKG)';)
+endef
+
+# ld wrapper for packages that call ld directly
+define $(PKG)_BUILD_LD_WRAPPER
+    rm '$(PREFIX)/bin/$(TARGET)-ld'
+    (echo '#!/bin/sh'; \
+     echo 'exec "$(PREFIX)/bin/$(call GET_PHASE_1_TARGET,$(TARGET))-ld" "$$@" \
+                    -L$(PREFIX)/$(call GET_PHASE_2_TARGET,$(TARGET))/lib \
+                    -L$(PREFIX)/$(TARGET)/lib' \
+    ) > '$(PREFIX)/bin/$(TARGET)-ld'
+    chmod 0755 '$(PREFIX)/bin/$(TARGET)-ld'
+endef
+
+$(foreach TARGET,$(PHASE_2_TARGETS), \
+    $(eval $(PKG)_BUILD_$(TARGET) := $$(call $(PKG)_BUILD_SYMLINK_PHASE,1)) \
+    $(eval $(PKG)_FILE_$(TARGET)  :=))
+$(foreach TARGET,$(MXE_TARGETS), \
+    $(eval $(PKG)_BUILD_$(TARGET) := $$(call $(PKG)_BUILD_SYMLINK_PHASE,2) \
+                                     $$($(PKG)_BUILD_LD_WRAPPER)) \
+    $(eval $(PKG)_FILE_$(TARGET)  :=))
 
 $(PKG)_BUILD_$(BUILD) :=

--- a/src/mingw-w64.mk
+++ b/src/mingw-w64.mk
@@ -8,6 +8,7 @@ $(PKG)_CHECKSUM := 89356a0aa8cf9f8b9dc8d92bc8dd01a131d4750c3acb30c6350a406316c42
 $(PKG)_SUBDIR   := $(PKG)-v$($(PKG)_VERSION)
 $(PKG)_FILE     := $(PKG)-v$($(PKG)_VERSION).tar.bz2
 $(PKG)_URL      := http://$(SOURCEFORGE_MIRROR)/project/$(PKG)/$(PKG)/$(PKG)-release/$($(PKG)_FILE)
+$(PKG)_TARGETS  := $(PHASE_1_TARGETS)
 $(PKG)_DEPS     :=
 
 define $(PKG)_UPDATE

--- a/src/mxe-conf.mk
+++ b/src/mxe-conf.mk
@@ -4,11 +4,16 @@
 PKG            := mxe-conf
 $(PKG)_VERSION := 1
 $(PKG)_UPDATE  := echo 1
-$(PKG)_TARGETS := $(BUILD) $(MXE_TARGETS)
+$(PKG)_TARGETS := $(BUILD) $(MXE_TARGETS) $(PHASE_1_TARGETS) $(PHASE_2_TARGETS)
 
 define $(PKG)_BUILD
-    # install target-specific autotools config file
+    # create basic directory layout
+    $(INSTALL) -d '$(PREFIX)/$(TARGET)/bin'
+    $(INSTALL) -d '$(PREFIX)/$(TARGET)/include'
+    $(INSTALL) -d '$(PREFIX)/$(TARGET)/lib'
     $(INSTALL) -d '$(PREFIX)/$(TARGET)/share'
+
+    # install target-specific autotools config file
     # setting ac_cv_build bypasses the config.guess check in every package
     echo "ac_cv_build=$(BUILD)" > '$(PREFIX)/$(TARGET)/share/config.site'
 
@@ -21,7 +26,7 @@ define $(PKG)_BUILD
      echo 'set(BUILD_SHARED_LIBS $(if $(BUILD_SHARED),ON,OFF))'; \
      echo 'set(LIBTYPE $(if $(BUILD_SHARED),SHARED,STATIC))'; \
      echo 'set(CMAKE_PREFIX_PATH $(PREFIX)/$(TARGET))'; \
-     echo 'set(CMAKE_FIND_ROOT_PATH $(PREFIX)/$(TARGET))'; \
+     echo 'set(CMAKE_FIND_ROOT_PATH $(PREFIX)/$(TARGET) $(PREFIX)/$(call GET_PHASE_2_TARGET,$(TARGET)))'; \
      echo 'set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)'; \
      echo 'set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)'; \
      echo 'set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)'; \
@@ -109,3 +114,10 @@ define $(PKG)_BUILD_$(BUILD)
              > '$(PREFIX)/$(BUILD)/bin/wine'
     chmod 0755 '$(PREFIX)/$(BUILD)/bin/wine'
 endef
+
+# define empty rules for phases
+$(foreach TARGET,$(PHASE_1_TARGETS) $(PHASE_2_TARGETS), \
+    $(eval $(PKG)_BUILD_$(TARGET) := ))
+# use common rule for cross targets
+$(foreach TARGET,$(filter-out $(BUILD),$(MXE_TARGETS)), \
+    $(eval $(PKG)_BUILD_$(TARGET) = $$($$(PKG)_BUILD)))

--- a/src/pkgconf.mk
+++ b/src/pkgconf.mk
@@ -8,7 +8,7 @@ $(PKG)_CHECKSUM := 91b2e5d7ce06583d5920c373b61d7d6554cd085cbd61ed176c7ff7ff30325
 $(PKG)_SUBDIR   := $(PKG)-$(PKG)-$($(PKG)_VERSION)
 $(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.gz
 $(PKG)_URL      := http://github.com/$(PKG)/$(PKG)/tarball/$($(PKG)_VERSION)/$($(PKG)_FILE)
-$(PKG)_TARGETS  := $(BUILD) $(MXE_TARGETS)
+$(PKG)_TARGETS  := $(BUILD) $(MXE_TARGETS) $(PHASE_2_TARGETS)
 $(PKG)_DEPS     :=
 
 $(PKG)_UPDATE    = $(call MXE_GET_GITHUB_SHA, pkgconf/pkgconf, master)


### PR DESCRIPTION
Following on from #961, there's are very hard trade-off between minimising build duplication and complexity of build rules. GCC has it's own internal phases that could be split out further, but then we need to know "way" too much about the build system and even on modern (SSD) hardware, unpacking the tarball multiple times would outweigh any build-time benefits.

This is somewhere in between:
* determine generic build phases from user-specified targets
    - phase 1 uses the plain triplet for generic packages e.g. binutils
    - phase 2 uses triplet.threads.exceptions convention for gcc variations
* setup phase dependencies
* enable exception handling variants and default fallback
* build symlinks or wrappers to previous phases

I'm not really happy with it yet (other than building all packages on all current targets ), the build rules are somewhat ugly and will seem complicated in six months. It's worth pursuing though as it will give us the ability to enable global customisation of CFLAGS/debug/strip etc. without having to understand and modify every package.