### PR TITLE
remove Byte Order Mark (BOM) from a patch

### DIFF
--- a/src/qtwebkit-1-fixes.patch
+++ b/src/qtwebkit-1-fixes.patch
@@ -1,4 +1,4 @@
-﻿This file is part of MXE.
+This file is part of MXE.
 See index.html for further information.
 
 Taken from:


### PR DESCRIPTION
It is not needed in ASCII/UTF-8 file