### PR TITLE
add unpacker for .deb files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,7 +168,8 @@ UNPACK_ARCHIVE = \
     $(if $(filter %.tar.xz,  $(1)),xz -dc '$(1)' | tar xf -, \
     $(if $(filter %.7z,      $(1)),7za x '$(1)', \
     $(if $(filter %.zip,     $(1)),unzip -q '$(1)', \
-    $(error Unknown archive format: $(1)))))))))))
+    $(if $(filter %.deb,     $(1)),ar x '$(1)' && tar xf data.tar*, \
+    $(error Unknown archive format: $(1))))))))))))
 
 UNPACK_PKG_ARCHIVE = \
     $(call UNPACK_ARCHIVE,$(PKG_DIR)/$($(1)_FILE))


### PR DESCRIPTION
It is needed for #976, to unpack Debian package with GeoIP.dat downloaded from https://packages.debian.org/jessie/all/geoip-database/download

`tar xf` instead of `tar xzf` / `xz -dc '$(1)' | tar xf -` because Debian package can contain `data.tar.gz` or `data.tar.xz`. Probably this code can be rewritten better.