### PR TITLE
add Tcl/Tk

### DIFF
--- a/index.html
+++ b/index.html
@@ -2421,6 +2421,10 @@ local-pkg-list: $(LOCAL_PKG_LIST)</pre>
         <td class="website"><a href="http://developer.kde.org/~wheeler/taglib.html">TagLib</a></td>
     </tr>
     <tr>
+        <td class="package">tcl</td>
+        <td class="website"><a href="https://www.tcl.tk/">Tcl</a></td>
+    </tr>
+    <tr>
         <td class="package">tclap</td>
         <td class="website"><a href="http://tclap.sourceforge.net/">tclap</a></td>
     </tr>
@@ -2447,6 +2451,10 @@ local-pkg-list: $(LOCAL_PKG_LIST)</pre>
     <tr>
         <td class="package">tinyxml2</td>
         <td class="website"><a href="http://grinninglizard.com/tinyxml2/">tinyxml2</a></td>
+    </tr>
+    <tr>
+        <td class="package">tk</td>
+        <td class="website"><a href="https://www.tcl.tk/">Tk</a></td>
     </tr>
     <tr>
         <td class="package">tre</td>

--- a/src/tcl.mk
+++ b/src/tcl.mk
@@ -1,0 +1,28 @@
+# This file is part of MXE.
+# See index.html for further information.
+
+PKG             := tcl
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 8.6.4
+$(PKG)_CHECKSUM := 9e6ed94c981c1d0c5f5fefb8112d06c6bf4d050a7327e95e71d417c416519c8d
+$(PKG)_SUBDIR   := $(PKG)$($(PKG)_VERSION)
+$(PKG)_FILE     := $(PKG)$($(PKG)_VERSION)-src.tar.gz
+$(PKG)_URL      := $(SOURCEFORGE_MIRROR)/tcl/$($(PKG)_FILE)
+$(PKG)_DEPS     := gcc
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- 'https://www.tcl.tk/software/tcltk/download.html' | \
+    $(SED) -n 's,.*Tcl \([0-9.]*\) Sources.*,\1,p' | \
+    $(SORT) -V | \
+    tail -1
+endef
+
+# The packages aren't built.
+# They have a fully fledge configure/make environment and should therefore be their own separate packages.
+define $(PKG)_BUILD
+    cd '$(1)/win' && ./configure \
+        $(MXE_CONFIGURE_OPTS) \
+    $(if $(findstring x86_64,$(TARGET)),--enable-64bit)
+    $(MAKE) -C '$(1)/win' -j '$(JOBS)' binaries libraries doc
+    $(MAKE) -C '$(1)/win' -j 1 install-binaries install-libraries install-doc
+endef

--- a/src/tk.mk
+++ b/src/tk.mk
@@ -1,0 +1,32 @@
+# This file is part of MXE.
+# See index.html for further information.
+
+PKG             := tk
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 8.6.4
+$(PKG)_CHECKSUM := 08f99df85e5dc9c4271762163c6aabb962c8b297dc5c4c1af8bdd05fc2dd26c1
+$(PKG)_SUBDIR   := $(PKG)$($(PKG)_VERSION)
+$(PKG)_FILE     := $(PKG)$($(PKG)_VERSION)-src.tar.gz
+$(PKG)_URL      := $(SOURCEFORGE_MIRROR)/tcl/$($(PKG)_FILE)
+$(PKG)_DEPS     := gcc tcl
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- 'https://www.tcl.tk/software/tcltk/download.html' | \
+    $(SED) -n 's,.*Tk \([0-9.]*\) Sources.*,\1,p' | \
+    $(SORT) -V | \
+    tail -1
+endef
+
+# We need to unpack and configure Tcl in order for Tk to compile
+define $(PKG)_BUILD
+    cd '$(1)/..' && tar xzf $(PKG_DIR)/tcl$($(PKG)_VERSION)-src.tar.gz && \
+    cd '$(1)'/../tcl$($(PKG)_VERSION)/win && ./configure \
+    $(MXE_CONFIGURE_OPTS) \
+    $(if $(findstring x86_64,$(TARGET)),--enable-64bit) && \
+    $(MAKE) -C '$(1)'/../tcl$($(PKG)_VERSION)/win -j '$(JOBS)' binaries
+    cd '$(1)/win' && ./configure \
+        $(MXE_CONFIGURE_OPTS)
+    $(if $(findstring x86_64,$(TARGET)),--enable-64bit)
+    $(MAKE) -C '$(1)/win' -j '$(JOBS)'
+    $(MAKE) -C '$(1)/win' -j 1 install
+endef


### PR DESCRIPTION
For Tcl: I resorted to only building Tcl, not its additional packages that are again configure / make based and, I think, should be separate packages.  (Are there thoughts of introducing gentoo-like USE flags maybe?)

For Tk: Alas Tk requires Tcl to be present and compiled in order to compile.  So I built it again.  Not quite sure how to handle this better!