### PR TITLE
#782 fix, wrong checksum calculation command for OSX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -193,7 +193,7 @@ define PREPARE_PKG_SOURCE
 endef
 
 PKG_CHECKSUM = \
-    openssl sha256 '$(PKG_DIR)/$($(1)_FILE)' 2>/dev/null | $(SED) -n 's,^.*\([0-9a-f]\{64\}\)$$,\1,p'
+    openssl dgst -sha256 '$(PKG_DIR)/$($(1)_FILE)' 2>/dev/null | $(SED) -n 's,^.*\([0-9a-f]\{64\}\)$$,\1,p'
 
 CHECK_PKG_ARCHIVE = \
     [ '$($(1)_CHECKSUM)' == "`$$(call PKG_CHECKSUM,$(1))`" ]


### PR DESCRIPTION
Fix for issue which has been described in https://github.com/mxe/mxe/issues/782#issuecomment-164198871