### PR TITLE
patch-tool-mxe: do not replace object id with 000

### DIFF
--- a/tools/patch-tool-mxe
+++ b/tools/patch-tool-mxe
@@ -101,7 +101,7 @@ function export_patch {
         --stdout \
         dist..HEAD | \
     sed 's/^From [0-9a-f]\{40\} /From 0000000000000000000000000000000000000000 /' | \
-    sed 's/^index .......\.\......../index 0000000..0000000/'
+    sed 's/^index .......\.\......../index 1111111..2222222/'
   ) > $mxedir/src/${pkg}-${patch_name}.patch && \
   echo "Generated ${mxedir}/src/${pkg}-${patch_name}.patch"
 }


### PR DESCRIPTION
Previously patch-tool-mxe produced the following diffs:

```diff
    diff --git a/CMakeLists.txt b/CMakeLists.txt
    index 0000000..0000000 100644
    --- a/CMakeLists.txt
    +++ b/CMakeLists.txt
```

patch tool refused to apply this patch:

```
    The next patch would create the file CMakeLists.txt,
    which already exists!  Assume -R? [n]
```

This commit replaces 0000000..0000000 with 1111111..2222222.