### PR TITLE
build-pkg: build empty dependencies of non-empty

### DIFF
--- a/tools/build-pkg.lua
+++ b/tools/build-pkg.lua
@@ -622,21 +622,40 @@ local function buildPackages(items, item2deps)
 end
 
 local function makeDebs(items, item2deps, item2ver, item2files)
+    -- start from building non-empty packages
+    local to_build = {}
     for _, item in ipairs(items) do
-        local deps = assert(item2deps[item], item)
-        local ver = assert(item2ver[item], item)
         local files = assert(item2files[item], item)
         if not isEmpty(item, files) then
+            table.insert(to_build, item)
+        end
+    end
+    local built = {}
+    repeat
+        local missing_deps_set = {}
+        for _, item in ipairs(to_build) do
+            local deps = assert(item2deps[item], item)
+            local ver = assert(item2ver[item], item)
+            local files = assert(item2files[item], item)
             for _, dep in ipairs(deps) do
-                local dep_files = assert(item2files[dep], dep)
+                local dep_files = item2files[dep]
                 if isEmpty(dep, dep_files) then
-                    log('Non-empty item %s depends on ' ..
+                    log('Item %s depends on ' ..
                         'empty item %s', item, dep)
+                    missing_deps_set[dep] = true
                 end
             end
             makeDeb(item, files, deps, ver)
+            built[item] = true
         end
-    end
+        -- empty packages built to satisfy non-empty
+        to_build = {}
+        for item in pairs(missing_deps_set) do
+            if not built[item] then
+                table.insert(to_build, item)
+            end
+        end
+    until #to_build == 0
 end
 
 local function getMxeVersion()


### PR DESCRIPTION
Otherwise empty dependency produces no `.deb` file preventing non-empty package from being installed.

Example: non-empty package `gcc` depends on empty package `mingw-w64`.