### PR TITLE
build-pkg: do not provide empty dependency list

### DIFF
--- a/tools/build-pkg.lua
+++ b/tools/build-pkg.lua
@@ -433,8 +433,7 @@ local CONTROL = [[Package: %s
 Version: %s
 Section: devel
 Priority: optional
-Architecture: %s
-Depends: %s
+Architecture: %s%s
 Maintainer: Boris Nagaev <bnagaev@gmail.com>
 Homepage: http://mxe.cc
 Description: %s
@@ -446,7 +445,11 @@ Description: %s
 ]]
 
 local function debianControl(options)
-    local deb_deps_str = table.concat(options.deps, ', ')
+    local deb_deps_str = ''
+    if #options.deps >= 1 then
+        deb_deps_str = '\n' .. 'Depends: ' ..
+            table.concat(options.deps, ', ')
+    end
     local version = options.version .. '-' .. TODAY
     return CONTROL:format(
         options.package,


### PR DESCRIPTION
Debian packages with "Depends: " do not work:

> Reading package lists... Error!
> E: Problem parsing dependency Depends
> E: Error occurred while processing mxe-source (NewVersion2)
> E: Problem with MergeList /var/lib/apt/lists/pkg.mxe.cc_repos_apt_debian_dists_wheezy_main_binary-amd64_Packages
> E: The package lists or status file could not be parsed or opened.