### PR TITLE
build-pkg: fix .deb installation

### DIFF
--- a/tools/build-pkg.lua
+++ b/tools/build-pkg.lua
@@ -692,11 +692,15 @@ local function makeMxeRequirementsPackage(release)
         -- Jessie+
         table.insert(deps, 'libtool-bin')
     end
-    local files = {}
+    local dummy_name = 'mxe-requirements.dummy.' .. release
+    local dummy = io.open(dummy_name, 'w')
+    dummy:close()
+    local files = {dummy_name}
     local d1 = "MXE requirements package"
     local d2 = MXE_REQUIREMENTS_DESCRIPTION2
     local dst = release
     makePackage(name, files, deps, ver, d1, d2, dst)
+    os.remove(dummy_name)
 end
 
 local MXE_SOURCE_DESCRIPTION2 =


### PR DESCRIPTION
The installation failed with the following note:

> Noting disappearance of mxe-requirements,
> which has been completely replaced.

Add an empty file `mxe-requirements.dummy.$release` to prevent this.