### PR TITLE
Use my fork of libgnurx

### DIFF
--- a/src/libgnurx.mk
+++ b/src/libgnurx.mk
@@ -3,20 +3,18 @@
 
 PKG             := libgnurx
 $(PKG)_IGNORE   :=
-$(PKG)_VERSION  := 2.5.1
-$(PKG)_CHECKSUM := 7147b7f806ec3d007843b38e19f42a5b7c65894a57ffc297a76b0dcd5f675d76
+$(PKG)_VERSION  := 2.6.1
+$(PKG)_CHECKSUM := ee6edc110c6b63d0469f4f05ef187564b310cc8a88b6566310a4aebd48b612c7
 $(PKG)_SUBDIR   := mingw-libgnurx-$($(PKG)_VERSION)
 $(PKG)_FILE     := mingw-libgnurx-$($(PKG)_VERSION)-src.tar.gz
-$(PKG)_URL      := http://$(SOURCEFORGE_MIRROR)/project/mingw/Other/UserContributed/regex/mingw-regex-$($(PKG)_VERSION)/$($(PKG)_FILE)
+$(PKG)_URL      := https://github.com/TimothyGu/libgnurx/releases/download/libgnurx-$($(PKG)_VERSION)/$($(PKG)_FILE)
 $(PKG)_DEPS     := gcc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'http://sourceforge.net/projects/mingw/files/Other/UserContributed/regex/' | \
-    grep 'mingw-regex-' | \
-    $(SED) -n 's,.*mingw-regex-\([0-9\.]*\).*,\1,p' | \
-    $(SORT) | \
-    uniq | \
-    tail -1
+    $(WGET) -q -O- 'https://api.github.com/repos/TimothyGu/libgnurx/git/refs/tags/' \
+    | $(SED) -n 's#.*"ref": "refs/tags/libgnurx-\([^"]*\).*#\1#p' \
+    | $(SORT) -V \
+    | tail -1
 endef
 
 define $(PKG)_BUILD


### PR DESCRIPTION
The original libgnurx is based off glibc 2.5, which has multiple known vulnerabilities, including but not limited to:

- CVE-2013-0242: Buffer overflow in the extend_buffers function in the
  regular expression matcher (posix/regexec.c) in glibc, possibly 2.17
  and earlier, allows context-dependent attackers to cause a denial of
  service (memory corruption and crash) via crafted multibyte
  characters.