### PR TITLE
Makefile: error on paths with dollar signs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -230,6 +230,11 @@ ifneq ($(words $(PWD)),1)
     $(error GNU Make chokes on paths with spaces)
 endif
 
+# dollar signs also cause troubles
+ifneq (,$(findstring $$,$(PWD)))
+    $(error GNU Make chokes on paths with dollar signs)
+endif
+
 ifeq ($(IGNORE_SETTINGS),yes)
     $(info [ignore settings.mk])
 else ifeq ($(wildcard $(PWD)/settings.mk),$(PWD)/settings.mk)


### PR DESCRIPTION
see #1085. 

Dollars signs are okay in some places, but they don't play well with `eval` or variable targets.