### PR TITLE
agg: replace broken site antigrain.com with mirror

### DIFF
--- a/index.html
+++ b/index.html
@@ -1076,7 +1076,7 @@ local-pkg-list: $(LOCAL_PKG_LIST)</pre>
     </tr>
     <tr>
         <td class="package">agg</td>
-        <td class="website"><a href="http://www.antigrain.com/">Anti-Grain Geometry</a></td>
+        <td class="website"><a href="http://agg.sourceforge.net/">Anti-Grain Geometry</a></td>
     </tr>
     <tr>
         <td class="package">alure</td>

--- a/src/agg.mk
+++ b/src/agg.mk
@@ -7,7 +7,7 @@ $(PKG)_VERSION  := 2.5
 $(PKG)_CHECKSUM := ab1edc54cc32ba51a62ff120d501eecd55fceeedf869b9354e7e13812289911f
 $(PKG)_SUBDIR   := agg-$($(PKG)_VERSION)
 $(PKG)_FILE     := agg-$($(PKG)_VERSION).tar.gz
-$(PKG)_URL      := http://www.antigrain.com/$($(PKG)_FILE)
+$(PKG)_URL      := https://web.archive.org/web/20150811231742/http://www.antigrain.com/$($(PKG)_FILE)
 $(PKG)_DEPS     := gcc freetype sdl
 
 define $(PKG)_UPDATE


### PR DESCRIPTION
Homebrew switched to archived version of agg tarball: https://github.com/Homebrew/homebrew/commit/27b37d1ce337b02176e0b00092ab80dbe74326aa

(Unfortunately web.archive.org is banned by authorities in Russia at the moment. I hope this will change.)

agg.sourceforge.net was proposed in the agg mailing list: http://sourceforge.net/p/vector-agg/mailman/message/34712672/

fix #1077