### PR TITLE
patch-tool-mxe: always output text diffs

### DIFF
--- a/tools/patch-tool-mxe
+++ b/tools/patch-tool-mxe
@@ -99,6 +99,7 @@ function export_patch {
         -p \
         --no-signature \
         --stdout \
+        --text \
         dist..HEAD | \
     sed 's/^From [0-9a-f]\{40\} /From 0000000000000000000000000000000000000000 /' | \
     sed 's/^index .......\.\......../index 1111111..2222222/'


### PR DESCRIPTION
Otherwise it provides binary diff for jack/waf file, which is a mix of Python and tar.