### PR TITLE
aubio: unify patch and fix it for patch-tool-mxe

### DIFF
--- a/src/aubio-1-fixes.patch
+++ b/src/aubio-1-fixes.patch
@@ -1,12 +1,16 @@
-From a34301d5fcdb6187dceb508bab341727ec57d0b4 Mon Sep 17 00:00:00 2001
+This file is part of MXE.
+See index.html for further information.
+
+Contains ad hoc patches for cross building.
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Timothy Gu <timothygu99@gmail.com>
 Date: Fri, 14 Nov 2014 16:37:52 -0500
-Subject: [PATCH 1/4] Add options for enabling shared and/or static libraries
+Subject: [PATCH] Add options for enabling shared and/or static libraries
 
-Signed-off-by: Timothy Gu <timothygu99@gmail.com>
 
 diff --git a/src/wscript_build b/src/wscript_build
-index 94b2062..1a72e4a 100644
+index 1111111..2222222 100644
 --- a/src/wscript_build
 +++ b/src/wscript_build
 @@ -18,13 +18,11 @@ ctx(features = 'c',
@@ -29,39 +33,34 @@ index 94b2062..1a72e4a 100644
  for target in build_features:
      ctx(features = 'c ' + target,
 diff --git a/wscript b/wscript
-index 83ad7b8..7013f12 100644
+index 1111111..2222222 100644
 --- a/wscript
 +++ b/wscript
-@@ -73,6 +73,13 @@ def options(ctx):
+@@ -72,6 +72,12 @@ def options(ctx):
+     add_option_enable_disable(ctx, 'double', default = False,
              help_str = 'compile in double precision mode',
              help_disable_str = 'compile in single precision mode (default)')
- 
 +    add_option_enable_disable(ctx, 'shared', default = True,
 +            help_str = 'compile shared libraries (defaut)',
 +            help_disable_str = 'do not compile shared library')
 +    add_option_enable_disable(ctx, 'static', default = True,
 +            help_str = 'compile static libraries (default)',
 +            help_disable_str = 'do not compile static library')
-+
-     ctx.add_option('--with-target-platform', type='string',
-             help='set target platform for cross-compilation', dest='target_platform')
- 
--- 
-1.9.1
+     add_option_enable_disable(ctx, 'fat', default = False,
+             help_str = 'build fat binaries (darwin only)',
+             help_disable_str = 'do not build fat binaries (default)')
 
-
-From e133535438a965b3f6f7f0cac5cb5c062c07829f Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Timothy Gu <timothygu99@gmail.com>
 Date: Fri, 14 Nov 2014 16:39:51 -0500
-Subject: [PATCH 2/4] fftw3 support requires -pthread
+Subject: [PATCH] fftw3 support requires -pthread
 
-Signed-off-by: Timothy Gu <timothygu99@gmail.com>
 
 diff --git a/wscript b/wscript
-index 7013f12..052fb27 100644
+index 1111111..2222222 100644
 --- a/wscript
 +++ b/wscript
-@@ -197,8 +197,10 @@ def configure(ctx):
+@@ -200,8 +200,10 @@ def configure(ctx):
      # fftw not enabled, use vDSP or ooura
      if 'HAVE_FFTW3F' in ctx.env.define_key:
          ctx.msg('Checking for FFT implementation', 'fftw3f')
@@ -72,19 +71,15 @@ index 7013f12..052fb27 100644
      elif 'HAVE_ACCELERATE' in ctx.env.define_key:
          ctx.msg('Checking for FFT implementation', 'vDSP')
      else:
--- 
-1.9.1
 
-
-From 16fda40e02065b670b63e193a453357051ca9c33 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Timothy Gu <timothygu99@gmail.com>
 Date: Fri, 14 Nov 2014 16:40:53 -0500
-Subject: [PATCH 3/4] Add static deps to pkgconfig file
+Subject: [PATCH] Add static deps to pkgconfig file
 
-Signed-off-by: Timothy Gu <timothygu99@gmail.com>
 
 diff --git a/aubio.pc.in b/aubio.pc.in
-index 301a1b5..0cd2281 100644
+index 1111111..2222222 100644
 --- a/aubio.pc.in
 +++ b/aubio.pc.in
 @@ -6,5 +6,7 @@ includedir=@includedir@
@@ -96,10 +91,10 @@ index 301a1b5..0cd2281 100644
 +Libs.private: @PCLIBS@
  Cflags: -I${includedir} 
 diff --git a/wscript b/wscript
-index 052fb27..424bcf8 100644
+index 1111111..2222222 100644
 --- a/wscript
 +++ b/wscript
-@@ -176,6 +176,8 @@ def configure(ctx):
+@@ -179,6 +179,8 @@ def configure(ctx):
      if (ctx.options.enable_complex == True):
          ctx.check(header_name='complex.h')
  
@@ -108,7 +103,7 @@ index 052fb27..424bcf8 100644
      # check for fftw3
      if (ctx.options.enable_fftw3 != False or ctx.options.enable_fftw3f != False):
          # one of fftwf or fftw3f
-@@ -197,9 +199,13 @@ def configure(ctx):
+@@ -200,9 +202,13 @@ def configure(ctx):
      # fftw not enabled, use vDSP or ooura
      if 'HAVE_FFTW3F' in ctx.env.define_key:
          ctx.msg('Checking for FFT implementation', 'fftw3f')
@@ -122,7 +117,7 @@ index 052fb27..424bcf8 100644
          ctx.env.LINKFLAGS += ['-pthread']
      elif 'HAVE_ACCELERATE' in ctx.env.define_key:
          ctx.msg('Checking for FFT implementation', 'vDSP')
-@@ -210,16 +216,22 @@ def configure(ctx):
+@@ -213,16 +219,22 @@ def configure(ctx):
      if (ctx.options.enable_sndfile != False):
          ctx.check_cfg(package = 'sndfile', atleast_version = '1.0.4',
                  args = '--cflags --libs', mandatory = False)
@@ -145,7 +140,7 @@ index 052fb27..424bcf8 100644
  
      # check for libav
      if (ctx.options.enable_avcodec != False):
-@@ -235,9 +247,13 @@ def configure(ctx):
+@@ -238,9 +250,13 @@ def configure(ctx):
                  for i in ['AVCODEC', 'AVFORMAT', 'AVUTIL', 'AVRESAMPLE'] ):
              ctx.define('HAVE_LIBAV', 1)
              ctx.msg('Checking for all libav libraries', 'yes')
@@ -159,22 +154,18 @@ index 052fb27..424bcf8 100644
      ctx.define('HAVE_WAVREAD', 1)
      ctx.define('HAVE_WAVWRITE', 1)
  
--- 
-1.9.1
 
-
-From 407863716f05ffca5b2241d7dcedb3d1c1ae87ad Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Timothy Gu <timothygu99@gmail.com>
 Date: Fri, 14 Nov 2014 16:45:04 -0500
-Subject: [PATCH 4/4] [MXE] disable tests and examples
+Subject: [PATCH] disable tests and examples
 
-Signed-off-by: Timothy Gu <timothygu99@gmail.com>
 
 diff --git a/wscript b/wscript
-index 424bcf8..7f135b5 100644
+index 1111111..2222222 100644
 --- a/wscript
 +++ b/wscript
-@@ -290,9 +290,9 @@ def build(bld):
+@@ -293,9 +293,9 @@ def build(bld):
      bld.recurse('src')
      if bld.env['DEST_OS'] not in ['ios', 'iosimulator']:
          pass
@@ -187,6 +178,3 @@ index 424bcf8..7f135b5 100644
  
      bld( source = 'aubio.pc.in' )
  
--- 
-1.9.1
-


### PR DESCRIPTION
Additional changes:

  * fix patch "Add options for enabling shared and/or static libraries"
  * remove Signed-off-by

Moved from https://github.com/mxe/mxe/pull/1124