### PR TITLE
print Perl version to log

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -510,6 +510,7 @@ build-only-$(1)_$(3):
 	    autoconf --version 2>/dev/null | head -1
 	    automake --version 2>/dev/null | head -1
 	    python --version
+	    perl --version 2>&1 | head -3
 	    rm -rf   '$(2)'
 	    mkdir -p '$(2)'
 	    $$(if $(value $(call LOOKUP_PKG_RULE,$(1),FILE,$(3))),\


### PR DESCRIPTION
See https://github.com/mxe/mxe/issues/1108#issuecomment-169556116
See https://github.com/mxe/mxe/issues/1112

From log:
```
perl --version 2>&1 | head -3

This is perl 5, version 18, subversion 2 (v5.18.2) built for x86_64-linux-gnu-thread-multi
(with 41 registered patches, see perl -V for more detail)
```