### PR TITLE
pcre: enable C++

### DIFF
--- a/src/pcre.mk
+++ b/src/pcre.mk
@@ -23,7 +23,7 @@ define $(PKG)_BUILD_SHARED
         --enable-pcre16 \
         --enable-utf \
         --enable-unicode-properties \
-        --disable-cpp \
+        --enable-cpp \
         --disable-pcregrep-libz \
         --disable-pcregrep-libbz2 \
         --disable-pcretest-libreadline


### PR DESCRIPTION
Application EiskaltDC++ requires pcre with C++ support.

See https://github.com/mxe/mxe/pull/1127#issuecomment-169418284

All packages were built successfully on all 4 targets (cb8a7deb8fe5259b89ad2e5a986b477fa5808162 + this commit). Then rebased.

/cc @pavelvat 