### PR TITLE
gcc plugin: rename gcc52 to gcc5 and update 5.2.0 --> 5.3.0

### DIFF
--- a/plugins/gcc5/gcc5-overlay.mk
+++ b/plugins/gcc5/gcc5-overlay.mk
@@ -11,15 +11,15 @@ PKG             := cloog
 $(PKG)_TARGETS  := $(MXE_TARGETS)
 
 PKG             := isl
-$(PKG)_VERSION  := 0.14
-$(PKG)_CHECKSUM := 7e3c02ff52f8540f6a85534f54158968417fd676001651c8289c705bd0228f36
+$(PKG)_VERSION  := 0.15
+$(PKG)_CHECKSUM := 8ceebbf4d9a81afa2b4449113cee4b7cb14a687d7a549a963deb5e2a41458b6b
 $(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
 $(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.bz2
 $(PKG)_URL      := http://isl.gforge.inria.fr/$($(PKG)_FILE)
 
 PKG             := gcc
-$(PKG)_VERSION  := 5.2.0
-$(PKG)_CHECKSUM := 5f835b04b5f7dd4f4d2dc96190ec1621b8d89f2dc6f638f9f8bc1b1014ba8cad
+$(PKG)_VERSION  := 5.3.0
+$(PKG)_CHECKSUM := b84f5592e9218b73dbae612b5253035a7b34a9a1f7688d2e1bfaaf7267d5c4db
 $(PKG)_SUBDIR   := gcc-$($(PKG)_VERSION)
 $(PKG)_FILE     := gcc-$($(PKG)_VERSION).tar.bz2
 $(PKG)_URL      := http://ftp.gnu.org/pub/gnu/gcc/gcc-$($(PKG)_VERSION)/$($(PKG)_FILE)


### PR DESCRIPTION
See https://github.com/mxe/mxe/issues/964#issuecomment-170358288

A single 5 series package will be easier to maintain. If anyone wants to use a specific version, they can use this as a template and maintain it locally.