### PR TITLE
Allow qtserialport_qt4 to be compiled statically

### DIFF
--- a/src/qtserialport_qt4-1-static.patch
+++ b/src/qtserialport_qt4-1-static.patch
@@ -1,0 +1,10 @@
+diff --git a/src/serialport/qt4support/serialport.prf b/src/serialport/qt4support/serialport.prf
+index b1d65e1..d20d47a 100644
+--- a/src/serialport/qt4support/serialport.prf
++++ b/src/serialport/qt4support/serialport.prf
+@@ -25,3 +25,5 @@ mac {
+        LIBS += -lQtSerialPort$${QT_LIBINFIX}
+    }
+ }
++
++static:DEFINES += QT_STATIC

--- a/src/qtserialport_qt4.mk
+++ b/src/qtserialport_qt4.mk
@@ -15,6 +15,12 @@ $(PKG)_DEPS     := gcc qt
 
 $(PKG)_UPDATE   := $(call MXE_GET_GITHUB_SHA, $($(PKG)_GH_USER)/$($(PKG)_GH_REPO), $($(PKG)_GH_TREE))
 
+define $(PKG)_BUILD
+    cd '$(1)' && '$(PREFIX)/$(TARGET)/qt/bin/qmake'
+    $(MAKE) -C '$(1)' -j '$(JOBS)'
+    $(MAKE) -C '$(1)' -j 1 install
+endef
+
 define $(PKG)_BUILD_SHARED
     cd '$(1)' && '$(PREFIX)/$(TARGET)/qt/bin/qmake'
     $(MAKE) -C '$(1)' -j '$(JOBS)'

--- a/src/qtserialport_qt4.mk
+++ b/src/qtserialport_qt4.mk
@@ -19,4 +19,6 @@ define $(PKG)_BUILD
     cd '$(1)' && '$(PREFIX)/$(TARGET)/qt/bin/qmake'
     $(MAKE) -C '$(1)' -j '$(JOBS)'
     $(MAKE) -C '$(1)' -j 1 install
+    # install one of the test programs
+    cp -f '$(1)/examples/serialport/cenumerator/debug/cenumerator.exe' '$(PREFIX)/$(TARGET)/bin/test-qtserialport_qt4.exe'
 endef

--- a/src/qtserialport_qt4.mk
+++ b/src/qtserialport_qt4.mk
@@ -20,5 +20,5 @@ define $(PKG)_BUILD
     $(MAKE) -C '$(1)' -j '$(JOBS)'
     $(MAKE) -C '$(1)' -j 1 install
     # install one of the test programs
-    cp -f '$(1)/examples/serialport/cenumerator/debug/cenumerator.exe' '$(PREFIX)/$(TARGET)/bin/test-qtserialport_qt4.exe'
+    cp -f '$(1)/examples/serialport/cenumerator/release/cenumerator.exe' '$(PREFIX)/$(TARGET)/bin/test-qtserialport_qt4.exe'
 endef

--- a/src/qtserialport_qt4.mk
+++ b/src/qtserialport_qt4.mk
@@ -20,9 +20,3 @@ define $(PKG)_BUILD
     $(MAKE) -C '$(1)' -j '$(JOBS)'
     $(MAKE) -C '$(1)' -j 1 install
 endef
-
-define $(PKG)_BUILD_SHARED
-    cd '$(1)' && '$(PREFIX)/$(TARGET)/qt/bin/qmake'
-    $(MAKE) -C '$(1)' -j '$(JOBS)'
-    $(MAKE) -C '$(1)' -j 1 install
-endef


### PR DESCRIPTION
The QtSerialPort library expects QT_STATIC to be defined when it is being compiled as a static library.  If is not defined then the Q_SERIALPORT_EXPORT macro will be set to one of Q_DECL_IMPORT/Q_DECL_EXPORT, resulting in linking errors when the test cases are built under Windows.

The following changeset introduced support for the QT_STATIC macro into QT:

https://gitlab.com/pteam/pteam-qtbase/commit/96166fa56abb52157387c4911efbd4e5e6beee93

This change is not included in QT 4.8.7 (appears to be 5.x only) and therefore QT_STATIC is not defined when QtSerialPort is compiled against 4.x QT versions.

The workaround used here is for the QSerialPort build system to defined QT_STATIC when it is being compiled statically.