### PR TITLE
new package: liblsmash

### DIFF
--- a/index.html
+++ b/index.html
@@ -1762,6 +1762,10 @@ local-pkg-list: $(LOCAL_PKG_LIST)</pre>
         <td class="website"><a href="http://liblqr.wikidot.com/">liblqr-1</a></td>
     </tr>
     <tr>
+        <td class="package">liblsmash</td>
+        <td class="website"><a href="https://l-smash.github.io/l-smash/">L-SMASH</a></td>
+    </tr>
+    <tr>
         <td class="package">libltdl</td>
         <td class="website"><a href="http://www.gnu.org/software/libtool/manual/html_node/Using-libltdl.html#Using-libltdl">GNU Libtool Library (libltdl)</a></td>
     </tr>

--- a/src/liblsmash-1.patch
+++ b/src/liblsmash-1.patch
@@ -1,0 +1,13 @@
+This file is part of MXE.
+See index.html for further information.
+
+--- a/configure
++++ b/configure
+@@ -198,6 +198,7 @@
+ case "$TARGET_OS" in
+     *mingw*)
+         EXT=".exe"
++        SHARED_NAME="liblsmash-$MAJVER"
+         SHARED_EXT=".dll"
+         IMPLIB="liblsmash.dll.a"
+         SO_LDFLAGS="-shared -Wl,--out-implib,$IMPLIB"

--- a/src/liblsmash.mk
+++ b/src/liblsmash.mk
@@ -10,6 +10,13 @@ $(PKG)_FILE     := $($(PKG)_SUBDIR).tar.gz
 $(PKG)_URL      := https://github.com/l-smash/l-smash/archive/v$($(PKG)_VERSION).tar.gz
 $(PKG)_DEPS     := gcc
 
+define $(PKG)_UPDATE
+    $(call MXE_GET_GITHUB_TAGS, l-smash/l-smash, v)
+endef
+
+# L-SMASH uses a custom made configure script that doesn't recognize
+# the option --host and fails on unknown options.
+# Therefor $(MXE_CONFIGURE_OPTS) can't be used here.
 define $(PKG)_BUILD
     cd '$(1)' && ./configure \
         --prefix='$(PREFIX)/$(TARGET)' \

--- a/src/liblsmash.mk
+++ b/src/liblsmash.mk
@@ -1,0 +1,20 @@
+# This file is part of MXE.
+# See index.html for further information.
+
+PKG             := liblsmash
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 2.9.1
+$(PKG)_CHECKSUM := 17f24fc8bffba753f8c628f1732fc3581b80362341274747ef6fb96af1cac45c
+$(PKG)_SUBDIR   := l-smash-$($(PKG)_VERSION)
+$(PKG)_FILE     := $($(PKG)_SUBDIR).tar.gz
+$(PKG)_URL      := https://github.com/l-smash/l-smash/archive/v$($(PKG)_VERSION).tar.gz
+$(PKG)_DEPS     := gcc
+
+define $(PKG)_BUILD
+    cd '$(1)' && ./configure \
+        --prefix='$(PREFIX)/$(TARGET)' \
+        --cross-prefix=$(TARGET)- \
+        $(if $(BUILD_SHARED), --enable-shared --disable-static)
+    $(MAKE) -C '$(1)' -j '$(JOBS)'
+    $(MAKE) -C '$(1)' -j 1 install
+endef

--- a/src/x264.mk
+++ b/src/x264.mk
@@ -8,7 +8,7 @@ $(PKG)_CHECKSUM := 80a4075ea12a81ec3b6c493e03529c5b7c1afb34c6e91d86bb078bc2ead2c
 $(PKG)_SUBDIR   := $(PKG)-snapshot-$($(PKG)_VERSION)
 $(PKG)_FILE     := $(PKG)-snapshot-$($(PKG)_VERSION).tar.bz2
 $(PKG)_URL      := http://download.videolan.org/pub/videolan/$(PKG)/snapshots/$($(PKG)_FILE)
-$(PKG)_DEPS     := gcc yasm
+$(PKG)_DEPS     := gcc yasm liblsmash
 
 define $(PKG)_UPDATE
     $(WGET) -q -O- 'http://git.videolan.org/?p=x264.git;a=shortlog' | \


### PR DESCRIPTION
L-SMASH is a library used for handling MP4 files. Example usage: if x264 was build with L-SMASH support, it's able to save its output as mp4 videos.