### PR TITLE
mxe-conf: prevent touching a file in readonly dir

### DIFF
--- a/src/mxe-conf.mk
+++ b/src/mxe-conf.mk
@@ -109,7 +109,9 @@ define $(PKG)_BUILD_$(BUILD)
 
     #create readonly directory to force wine to fail
     mkdir -p "$$WINEPREFIX"
-    [ -f "$$WINEPREFIX/.gitkeep"] || touch "$$WINEPREFIX/.gitkeep"
+    [ -f "$$WINEPREFIX/.gitkeep" ] \
+        || chmod 0755 "$$WINEPREFIX" \
+        && touch "$$WINEPREFIX/.gitkeep"
     chmod 0555 "$$WINEPREFIX"
 
     #create script "wine" in a directory which is in PATH


### PR DESCRIPTION
fix #1199