### PR TITLE
binutils: enable deterministic archives

### DIFF
--- a/src/binutils.mk
+++ b/src/binutils.mk
@@ -26,6 +26,7 @@ define $(PKG)_BUILD
         --build='$(BUILD)' \
         --prefix='$(PREFIX)' \
         --disable-multilib \
+        --enable-deterministic-archives \
         --with-gcc \
         --with-gnu-ld \
         --with-gnu-as \


### PR DESCRIPTION
Since #1206 is going to cause a full rebuild anyway.

see: https://wiki.debian.org/ReproducibleBuilds/TimestampsInStaticLibraries

