### PR TITLE
add Coin bug fixes from Gentoo

### DIFF
--- a/src/coin-2-gcc-4.7.patch
+++ b/src/coin-2-gcc-4.7.patch
@@ -1,0 +1,16 @@
+This file is part of MXE.
+See index.html for further information.
+
+This patch was taken from Gentoo:
+https://gitweb.gentoo.org/repo/gentoo.git/tree/media-libs/coin/files/coin-3.1.3-gcc-4.7.patch?id=17d7c853393ff83e3422e48e9ad2810f23889bbf
+
+--- coin3-3.1.3.orig/include/Inventor/SbBasic.h
++++ coin3-3.1.3/include/Inventor/SbBasic.h
+@@ -24,6 +24,7 @@
+  *
+ \**************************************************************************/
+ 
++#include <Inventor/C/errors/debugerror.h>
+ #include <Inventor/C/basic.h>
+ 
+ /* ********************************************************************** */

--- a/src/coin-test.cpp
+++ b/src/coin-test.cpp
@@ -3,7 +3,7 @@
  * See index.html for further information.
  */
 
-#include <Inventor/C/errors/debugerror.h>
+#include <Inventor/SbBasic.h>
 #include <Inventor/nodes/SoCone.h>
 #include <Inventor/nodes/SoDirectionalLight.h>
 #include <Inventor/nodes/SoMaterial.h>


### PR DESCRIPTION
This adds two bugfix patches that are present in Gentoo.  The latter one is necessary, as the name indicates, to compile cleanly with a newer version of gcc.  It adds a missing include.