### PR TITLE
tor: fix linking errors if mman-win32 is installed

### DIFF
--- a/plugins/apps/tor-1-fixes.patch
+++ b/plugins/apps/tor-1-fixes.patch
@@ -1,0 +1,50 @@
+This file is part of MXE.
+See index.html for further information.
+
+Contains ad hoc patches for cross building.
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Boris Nagaev <bnagaev@gmail.com>
+Date: Sun, 21 Feb 2016 22:51:30 +0300
+Subject: [PATCH] do not use mman-win32
+
+tor can be compiled without mman-win32, because it has own
+implementation of mmap using Windows API. But if mman-win32
+is installed, tor tries to use it resulting in linking errors.
+(In MXE mman-win32 installs DLLs even for static targets!)
+
+diff --git a/src/common/compat.c b/src/common/compat.c
+index 1111111..2222222 100644
+--- a/src/common/compat.c
++++ b/src/common/compat.c
+@@ -101,7 +101,7 @@
+ #ifdef HAVE_SYS_UTIME_H
+ #include <sys/utime.h>
+ #endif
+-#ifdef HAVE_SYS_MMAN_H
++#if 0
+ #include <sys/mman.h>
+ #endif
+ #ifdef HAVE_SYS_SYSLIMITS_H
+@@ -191,7 +191,7 @@ tor_rename(const char *path_old, const char *path_new)
+                 sandbox_intern_string(path_new));
+ }
+ 
+-#if defined(HAVE_SYS_MMAN_H) || defined(RUNNING_DOXYGEN)
++#if 0
+ /** Try to create a memory mapping for <b>filename</b> and return it.  On
+  * failure, return NULL.  Sets errno properly, using ERANGE to mean
+  * "empty file". */
+diff --git a/src/common/compat.h b/src/common/compat.h
+index 1111111..2222222 100644
+--- a/src/common/compat.h
++++ b/src/common/compat.h
+@@ -285,7 +285,7 @@ typedef struct tor_mmap_t {
+   size_t size; /**< Size of the file. */
+ 
+   /* None of the fields below should be accessed from outside compat.c */
+-#ifdef HAVE_SYS_MMAN_H
++#if 0
+   size_t mapping_size; /**< Size of the actual mapping. (This is this file
+                         * size, rounded up to the nearest page.) */
+ #elif defined _WIN32


### PR DESCRIPTION
Tor can be compiled without `mman-win32`, because it has own implementation of `mmap` using Windows API. But if `mman-win32` is installed, Tor tries to use it resulting in linking errors. (In MXE mman-win32 installs DLLs even for static targets!)

This is another case of [undeclared optional dependency](https://github.com/mxe/mxe/issues/1111) resulting in build failure.

See also https://trac.torproject.org/projects/tor/ticket/18360