### PR TITLE
fix dependencies of build-matrix.html

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -701,7 +701,7 @@ cleanup-deps-style:
 	     || echo '*** Multi-line deps are mangled ***' && comm -3 tmp-$@-pre tmp-$@-post
 	@rm -f $(TOP_DIR)/tmp-$@-*
 
-build-matrix.html: $(foreach PKG,$(PKGS), $(TOP_DIR)/src/$(PKG).mk)
+build-matrix.html: $(foreach 1,$(PKGS),$(PKG_MAKEFILES))
 	@echo '<!DOCTYPE html>'                  > $@
 	@echo '<html>'                          >> $@
 	@echo '<head>'                          >> $@


### PR DESCRIPTION
Dependencies of build-matrix.html were written without regarding plugins. It resulted in the following error on Debian Wheezy (which uses plugin "plugins/native/wheezy/"):

```
$ make build-matrix.html
make: *** No rule to make target `src/autoconf.mk',
needed by `build-matrix.html'.  Stop.
```

The following targets also need updating:
  * cleanup-style
  * cleanup-deps-style
  * versions.json