### PR TITLE
build-pkg: build a package second time in tree with all packages

### DIFF
--- a/tools/build-pkg.lua
+++ b/tools/build-pkg.lua
@@ -430,7 +430,7 @@ local function gitCheckout(new_branch, deps, item2index, pass_of_deps)
 end
 
 local function gitAdd()
-    os.execute(GIT .. 'add .')
+    os.execute(GIT .. 'add --all .')
 end
 
 -- return two lists of filepaths under ./usr/
@@ -442,6 +442,7 @@ local function gitStatus()
     local git_st = io.popen(GIT .. 'status --porcelain', 'r')
     for line in git_st:lines() do
         local status, file = line:match('(..) (.*)')
+        assert(status:sub(2, 2) == ' ')
         status = trim(status)
         if file:sub(1, 1) == '"' then
             -- filename with a space is quoted by git

--- a/tools/build-pkg.lua
+++ b/tools/build-pkg.lua
@@ -602,13 +602,15 @@ local function prepareTree(pass, item, item2deps, prev_files, item2index)
             item2index,
             'first'
         )
-        -- Remove files of item from previous build.
-        for _, file in ipairs(prev_files) do
-            os.remove(file)
-        end
         removeEmptyDirs()
-        gitAdd()
-        gitCommit(("Remove %s to rebuild it"):format(item, pass))
+        if prev_files then
+            -- Remove files of item from previous build.
+            for _, file in ipairs(prev_files) do
+                os.remove(file)
+            end
+            gitAdd()
+            gitCommit(("Remove %s to rebuild it"):format(item, pass))
+        end
     else
         error("Unknown pass: " .. pass)
     end

--- a/tools/build-pkg.lua
+++ b/tools/build-pkg.lua
@@ -572,8 +572,8 @@ local function buildItem(item, item2deps, file2item, item2index, pass)
         if not isInArray(creator_item, item2deps[item]) then
             table.insert(item2deps[item], creator_item)
         end
-        log('Item %s changes %s, created by %s',
-            item, file, creator_item)
+        log('Item %s (pass %s) changes %s, created by %s',
+            item, pass, file, creator_item)
     end
     checkFileList(concatArrays(new_files, changed_files), item)
     removeEmptyDirs(item)

--- a/tools/build-pkg.lua
+++ b/tools/build-pkg.lua
@@ -19,6 +19,9 @@ To prevent build-pkg from creating deb packages,
 set environment variable MXE_NO_DEBS to 1
 In this case fakeroot and dpkg-deb are not needed.
 
+To switch off the second pass, set MXE_NO_SECOND_PASS to 1.
+See https://github.com/mxe/mxe/issues/1111
+
 To limit number of packages being built to x,
 set environment variable MXE_MAX_ITEMS to x,
 
@@ -32,6 +35,7 @@ How to remove them: http://stackoverflow.com/a/4262545
 
 local max_items = tonumber(os.getenv('MXE_MAX_ITEMS'))
 local no_debs = os.getenv('MXE_NO_DEBS')
+local no_second_pass = os.getenv('MXE_NO_SECOND_PASS')
 
 local TODAY = os.date("%Y%m%d")
 
@@ -1024,10 +1028,11 @@ local function main()
         makeMxeRequirementsPackage('jessie')
     end
     makeMxeSourcePackage()
-    -- second pass
-    buildPackages(
-        build_list, item2deps, 'second', item2files
-    )
+    if not no_second_pass then
+        buildPackages(
+            build_list, item2deps, 'second', item2files
+        )
+    end
     if #unbroken < #build_list then
         local code = 1
         local close = true

--- a/tools/build-pkg.lua
+++ b/tools/build-pkg.lua
@@ -531,13 +531,16 @@ end
 
 local function removeEmptyDirs(item)
     -- removing an empty dir can reveal another one (parent)
+    -- don't pass item to mute the log message
     local go_on = true
     while go_on do
         go_on = false
         local f = io.popen('find usr/* -empty -type d', 'r')
         for dir in f:lines() do
-            log("Remove empty directory %s created by %s",
-                dir, item)
+            if item then
+                log("Remove empty directory %s created by %s",
+                    dir, item)
+            end
             os.remove(dir)
             go_on = true
         end

--- a/tools/build-pkg.lua
+++ b/tools/build-pkg.lua
@@ -178,6 +178,10 @@ local function fileExists(name)
     end
 end
 
+local function isSymlink(name)
+    return shell(("ls -l %q"):format(name)):sub(1, 1) == "l"
+end
+
 local function writeFile(filename, data)
     local file = io.open(filename, 'w')
     file:write(data)
@@ -450,7 +454,13 @@ local function gitStatus()
         end
         file = 'usr/' .. file
         if not fileExists(file) then
-            log('Missing file: %q', file)
+            if status == 'D' then
+                log('Removed file: %q', file)
+            elseif isSymlink(file) then
+                log('Broken symlink: %q', file)
+            else
+                log('Missing file: %q', file)
+            end
         elseif not isBlacklisted(file) then
             if status == 'A' then
                 table.insert(new_files, file)

--- a/tools/build-pkg.lua
+++ b/tools/build-pkg.lua
@@ -548,6 +548,18 @@ local function removeEmptyDirs(item)
     end
 end
 
+local function isBuilt(item, files)
+    local target, pkg = parseItem(item)
+    local INSTALLED = 'usr/%s/installed/%s'
+    local installed = INSTALLED:format(target, pkg)
+    for _, file in ipairs(files) do
+        if file == installed then
+            return true
+        end
+    end
+    return false
+end
+
 -- builds package, returns list of new files
 local function buildItem(item, item2deps, file2item, item2index, pass)
     gitCheckout(
@@ -690,18 +702,6 @@ local function makeDeb(item, files, deps, ver)
         table.insert(deb_deps, nameToDebian(dep))
     end
     makePackage(deb_pkg, files, deb_deps, ver, d1, d2)
-end
-
-local function isBuilt(item, files)
-    local target, pkg = parseItem(item)
-    local INSTALLED = 'usr/%s/installed/%s'
-    local installed = INSTALLED:format(target, pkg)
-    for _, file in ipairs(files) do
-        if file == installed then
-            return true
-        end
-    end
-    return false
 end
 
 local function findForeignInstalls(item, files)


### PR DESCRIPTION
This pull request implements second and third passes of #1111. In original proposal, the second pass builds a package in a tree with all packages except itself and its followers and the third pass rebuilds a package in a tree with all packages built. The third pass seems to be more strict than second, so it was implemented here.

Build log: https://gist.github.com/starius/a165cbb474f4d9c1dd7e
(It is based on commit 62467d9d4dbb69aa632ae684b4a5a3f4c3b4a1ff.)

Package `fontconfig` breaks on the seconds pass.