### PR TITLE
blas, lapack: remove -fdefault-integer-8 FFLAGS

### DIFF
--- a/src/blas.mk
+++ b/src/blas.mk
@@ -19,8 +19,7 @@ define $(PKG)_BUILD
         FORTRAN='$(TARGET)-gfortran' \
         RANLIB='$(TARGET)-ranlib' \
         ARCH='$(TARGET)-ar' \
-        BLASLIB='libblas.a' \
-        OPTS=$(if $(findstring x86_64,$(TARGET)),-fdefault-integer-8)
+        BLASLIB='libblas.a'
 
     $(INSTALL) -d '$(PREFIX)/$(TARGET)/lib'
     $(if $(BUILD_STATIC), \

--- a/src/lapack.mk
+++ b/src/lapack.mk
@@ -22,7 +22,6 @@ define $(PKG)_BUILD
         -DCMAKE_AR='$(PREFIX)/bin/$(TARGET)-ar' \
         -DCMAKE_RANLIB='$(PREFIX)/bin/$(TARGET)-ranlib' \
         -DLAPACKE=ON \
-        -DCMAKE_Fortran_FLAGS=$(if $(findstring x86_64,$(TARGET)),-fdefault-integer-8) \
         .
     cp '$(1)/LAPACKE/include/lapacke_mangling_with_flags.h' '$(1)/LAPACKE/include/lapacke_mangling.h'
     $(MAKE) -C '$(1)/SRC'     -j '$(JOBS)' install


### PR DESCRIPTION
* only required for octave build:
    - https://www.gnu.org/software/octave/doc/interpreter/Compiling-Octave-with-64_002dbit-Indexing.html
* closes #1247