### PR TITLE
mman-win32: re-enable static build after changes in ca5bba6

### DIFF
--- a/src/mman-win32.mk
+++ b/src/mman-win32.mk
@@ -15,7 +15,8 @@ $(PKG)_UPDATE = $(call MXE_GET_GITHUB_SHA, witwall/mman-win32, master) | $(SED) 
 define $(PKG)_BUILD
     mkdir '$(1).build'
     cd    '$(1).build' && '$(TARGET)-cmake' '$(1)'\
-        -DBUILD_TESTS=OFF
+        -DBUILD_TESTS=OFF \
+        $(if $(BUILD_STATIC),-DBUILD_SHARED_LIBS=OFF)
     $(MAKE) -C '$(1).build' -j '$(JOBS)'
     $(MAKE) -C '$(1).build' -j 1 install
 


### PR DESCRIPTION
The switch to using cmake in ca5bba6 also remove the ability to compile the library statically.

Also along the way (but not addressed in this PR), the renaming of mman.h to mman-win32.h done by the `mman-win32-1-include_name_change.patch` file stopped being applied albeit was kept in the repository.