### PR TITLE
add package googletest and update protobuf (fix #1269)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1418,6 +1418,10 @@ local-pkg-list: $(LOCAL_PKG_LIST)</pre>
         <td class="website"><a href="https://www.gnu.org/software/gnutls/">GnuTLS</a></td>
     </tr>
     <tr>
+        <td class="package">googletest</td>
+        <td class="website"><a href="https://github.com/google/googletest">Google Test</a></td>
+    </tr>
+    <tr>
         <td class="package">graphicsmagick</td>
         <td class="website"><a href="http://www.graphicsmagick.org/">GraphicsMagick</a></td>
     </tr>
@@ -2239,7 +2243,7 @@ local-pkg-list: $(LOCAL_PKG_LIST)</pre>
     </tr>
     <tr>
         <td class="package">protobuf</td>
-        <td class="website"><a href="http://code.google.com/p/protobuf/">protobuf</a></td>
+        <td class="website"><a href="https://github.com/google/protobuf">protobuf</a></td>
     </tr>
     <tr>
         <td class="package">pthreads</td>

--- a/src/googletest.mk
+++ b/src/googletest.mk
@@ -1,0 +1,15 @@
+# This file is part of MXE.
+# See index.html for further information.
+
+PKG             := googletest
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 1.7.0
+$(PKG)_CHECKSUM := f73a6546fdf9fce9ff93a5015e0333a8af3062a152a9ad6bcb772c96687016cc
+$(PKG)_SUBDIR   := $(PKG)-release-$($(PKG)_VERSION)
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.gz
+$(PKG)_URL      := https://github.com/google/$(PKG)/archive/release-$($(PKG)_VERSION).tar.gz
+$(PKG)_DEPS     :=
+
+define $(PKG)_UPDATE
+    $(call MXE_GET_GITHUB_TAGS, google/googletest, release-)
+endef

--- a/src/protobuf.mk
+++ b/src/protobuf.mk
@@ -3,23 +3,22 @@
 
 PKG             := protobuf
 $(PKG)_IGNORE   :=
-$(PKG)_VERSION  := 2.5.0
-$(PKG)_CHECKSUM := 13bfc5ae543cf3aa180ac2485c0bc89495e3ae711fc6fab4f8ffe90dfb4bb677
+$(PKG)_VERSION  := 2.6.1
+$(PKG)_CHECKSUM := 2667b7cda4a6bc8a09e5463adf3b5984e08d94e72338277affa8594d8b6e5cd1
 $(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
-$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.bz2
-$(PKG)_URL      := http://protobuf.googlecode.com/files/$($(PKG)_FILE)
-$(PKG)_DEPS     := gcc zlib
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.gz
+$(PKG)_URL      := https://github.com/google/$(PKG)/archive/$($(PKG)_VERSION).tar.gz
+$(PKG)_DEPS     := gcc zlib googletest
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'http://code.google.com/p/protobuf/downloads/list?sort=-uploaded' | \
-    $(SED) -n 's,.*protobuf-\([0-9][^<]*\)\.tar.*,\1,p' | \
-    grep -v 'rc' | \
-    head -1
+    $(call MXE_GET_GITHUB_TAGS, google/protobuf, v)
 endef
 
 define $(PKG)_BUILD
+    $(call PREPARE_PKG_SOURCE,googletest,$(1))
+    cd '$(1)' && mv googletest-release-$(googletest_VERSION)/ gtest
 # First step: Build for host system in order to create "protoc" binary.
-    cd '$(1)' && ./configure \
+    cd '$(1)' && ./autogen.sh && ./configure \
         --disable-shared
     $(MAKE) -C '$(1)' -j '$(JOBS)'
     cp '$(1)/src/protoc' '$(PREFIX)/bin/$(TARGET)-protoc'


### PR DESCRIPTION
Fix #1269. I have tested it for protobuf versions 2.6.1 and 3.0.0-beta-2. For version 3.0.0-beta-2 need to replace line:
```
cd '$(1)' && mv googletest-release-$(googletest_VERSION)/ gtest
```
on:
```
cd '$(1)' && mv googletest-release-$(googletest_VERSION)/ gmock
```