### PR TITLE
nonetwork: new line before the message and flush

### DIFF
--- a/tools/nonetwork.c
+++ b/tools/nonetwork.c
@@ -7,7 +7,9 @@
 #include <stdio.h>
 
 static void print_message() {
-    fprintf(stderr, "Don't use network from MXE build rules!\n");
+    fflush(stderr);
+    fprintf(stderr, "\nDon't use network from MXE build rules!\n");
+    fflush(stderr);
 }
 
 int connect(int sock, const void *addr, unsigned int len) {


### PR DESCRIPTION
`fflush(stderr)` [may be needed](http://mailman.linuxchix.org/pipermail/courses/2002-August/000691.html).

see https://github.com/mxe/mxe/pull/1270