### PR TITLE
add package clementine_qt4 to mxe/plugins/apps

### DIFF
--- a/plugins/apps/clementine_qt4-1-fixes.patch
+++ b/plugins/apps/clementine_qt4-1-fixes.patch
@@ -1,0 +1,78 @@
+This file is part of MXE. See LICENSE.md for licensing information.
+
+Contains ad hoc patches for cross building.
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Pavel Vatagin <pavelvat@gmail.com>
+Date: Sat, 5 Nov 2016 02:19:37 +0300
+Subject: [PATCH] fix clementine
+
+
+diff --git a/3rdparty/libprojectm/CMakeLists.txt b/3rdparty/libprojectm/CMakeLists.txt
+index 1111111..2222222 100644
+--- a/3rdparty/libprojectm/CMakeLists.txt
++++ b/3rdparty/libprojectm/CMakeLists.txt
+@@ -174,6 +174,8 @@ if(BUNDLE_PROJECTM_PRESETS)
+         COPY_ONLY
+       )
+     endforeach (preset)
++  elseif (WIN32)
++    INSTALL(FILES ${presets} DESTINATION ${CMAKE_INSTALL_PREFIX}/bin/projectm-presets)
+   else (APPLE)
+     INSTALL(FILES ${presets} DESTINATION ${CMAKE_INSTALL_PREFIX}/share/clementine/projectm-presets)
+   endif (APPLE)
+diff --git a/3rdparty/libprojectm/glew.h b/3rdparty/libprojectm/glew.h
+index 1111111..2222222 100644
+--- a/3rdparty/libprojectm/glew.h
++++ b/3rdparty/libprojectm/glew.h
+@@ -149,7 +149,7 @@ typedef unsigned short wchar_t;
+ #  endif
+ #endif
+ #if !defined(_PTRDIFF_T_DEFINED) && !defined(_PTRDIFF_T_)
+-#  ifdef _WIN64
++#  if defined(_WIN64) && !defined(__MINGW32__)
+ typedef __int64 ptrdiff_t;
+ #  else
+ typedef _W64 int ptrdiff_t;
+diff --git a/3rdparty/tinysvcmdns/CMakeLists.txt b/3rdparty/tinysvcmdns/CMakeLists.txt
+index 1111111..2222222 100644
+--- a/3rdparty/tinysvcmdns/CMakeLists.txt
++++ b/3rdparty/tinysvcmdns/CMakeLists.txt
+@@ -7,7 +7,7 @@ set(TINYSVCMDNS-SOURCES
+ )
+ 
+ find_library(PTHREAD
+-  pthreadGC2
++  pthread
+ )
+ 
+ add_library(tinysvcmdns STATIC
+diff --git a/ext/clementine-tagreader/CMakeLists.txt b/ext/clementine-tagreader/CMakeLists.txt
+index 1111111..2222222 100644
+--- a/ext/clementine-tagreader/CMakeLists.txt
++++ b/ext/clementine-tagreader/CMakeLists.txt
+@@ -27,10 +27,10 @@ add_executable(clementine-tagreader
+ 
+ target_link_libraries(clementine-tagreader
+   ${TAGLIB_LIBRARIES}
+-  ${QT_QTCORE_LIBRARY}
+-  ${QT_QTNETWORK_LIBRARY}
+   libclementine-common
+   libclementine-tagreader
++  ${QT_QTCORE_LIBRARY}
++  ${QT_QTNETWORK_LIBRARY}
+ )
+ 
+ if(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 1111111..2222222 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -1343,6 +1343,7 @@ if (WIN32)
+     tinysvcmdns
+     qtwin
+     dsound
++    ${QT_QTGUI_LIBRARY}
+   )
+ endif (WIN32)
+ 

--- a/plugins/apps/clementine_qt4.mk
+++ b/plugins/apps/clementine_qt4.mk
@@ -1,0 +1,90 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+# lconvert and lupdate are not provided by MXE for Qt4,
+# so for Debian/Ubuntu you need install packages qt4-linguist-tools
+# (this package contains lupdate and lrelease) and qt4-dev-tools
+# (this package contains lconvert):
+# apt-get install qt4-linguist-tools qt4-dev-tools
+# Or you may use lupdate, lrelease, lconvert from Qt5:
+# apt-get install qttools5-dev-tools
+
+PKG             := clementine_qt4
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 1.3.1
+$(PKG)_CHECKSUM := f885931a9ab7c88607d07b50c64fcce46fc05f13dd2c0a04188c94eff938f37c
+$(PKG)_SUBDIR   := Clementine-$($(PKG)_VERSION)
+$(PKG)_FILE     := clementine-$($(PKG)_VERSION).tar.gz
+$(PKG)_URL      := https://github.com/clementine-player/clementine/archive/$($(PKG)_VERSION).tar.gz
+$(PKG)_WEBSITE  := https://www.clementine-player.org/
+$(PKG)_OWNER    := https://github.com/pavelvat
+$(PKG)_DEPS     := gcc boost chromaprint cryptopp dlfcn-win32 fftw glew gst-libav gst-plugins-bad \
+                   gst-plugins-good gst-plugins-ugly libarchive libechonest libid3tag \
+                   libmpcdec libplist libusb1 protobuf qtsparkle_qt4 sparsehash
+
+define $(PKG)_UPDATE
+    $(call MXE_GET_GITHUB_TAGS, clementine-player/clementine)
+endef
+
+define $(PKG)_BUILD
+    cd '$(BUILD_DIR)' && $(TARGET)-cmake '$(SOURCE_DIR)' \
+        -DCMAKE_INSTALL_PREFIX=$(PREFIX)/$(TARGET)/apps/$(PKG)
+    $(MAKE) -C '$(BUILD_DIR)' -j $(JOBS)
+    $(MAKE) -C '$(BUILD_DIR)' -j 1 install
+
+    $(if $(BUILD_SHARED),
+        $(INSTALL) -d '$(PREFIX)/$(TARGET)/apps/$(PKG)/bin/gstreamer-plugins'
+        $(INSTALL) '$(PREFIX)/$(TARGET)/bin/libgstapetag.dll'            '$(PREFIX)/$(TARGET)/apps/$(PKG)/bin/gstreamer-plugins'
+        $(INSTALL) '$(PREFIX)/$(TARGET)/bin/libgstapp.dll'               '$(PREFIX)/$(TARGET)/apps/$(PKG)/bin/gstreamer-plugins'
+        $(INSTALL) '$(PREFIX)/$(TARGET)/bin/libgstasf.dll'               '$(PREFIX)/$(TARGET)/apps/$(PKG)/bin/gstreamer-plugins'
+        $(INSTALL) '$(PREFIX)/$(TARGET)/bin/libgstaudioconvert.dll'      '$(PREFIX)/$(TARGET)/apps/$(PKG)/bin/gstreamer-plugins'
+        $(INSTALL) '$(PREFIX)/$(TARGET)/bin/libgstaudiofx.dll'           '$(PREFIX)/$(TARGET)/apps/$(PKG)/bin/gstreamer-plugins'
+        $(INSTALL) '$(PREFIX)/$(TARGET)/bin/libgstaudioparsers.dll'      '$(PREFIX)/$(TARGET)/apps/$(PKG)/bin/gstreamer-plugins'
+        $(INSTALL) '$(PREFIX)/$(TARGET)/bin/libgstaudioresample.dll'     '$(PREFIX)/$(TARGET)/apps/$(PKG)/bin/gstreamer-plugins'
+        $(INSTALL) '$(PREFIX)/$(TARGET)/bin/libgstaudiotestsrc.dll'      '$(PREFIX)/$(TARGET)/apps/$(PKG)/bin/gstreamer-plugins'
+        $(INSTALL) '$(PREFIX)/$(TARGET)/bin/libgstautodetect.dll'        '$(PREFIX)/$(TARGET)/apps/$(PKG)/bin/gstreamer-plugins'
+        $(INSTALL) '$(PREFIX)/$(TARGET)/bin/libgstcdio.dll'              '$(PREFIX)/$(TARGET)/apps/$(PKG)/bin/gstreamer-plugins'
+        $(INSTALL) '$(PREFIX)/$(TARGET)/bin/libgstcoreelements.dll'      '$(PREFIX)/$(TARGET)/apps/$(PKG)/bin/gstreamer-plugins'
+        $(INSTALL) '$(PREFIX)/$(TARGET)/bin/libgstdirectsoundsink.dll'   '$(PREFIX)/$(TARGET)/apps/$(PKG)/bin/gstreamer-plugins'
+        $(INSTALL) '$(PREFIX)/$(TARGET)/bin/libgstequalizer.dll'         '$(PREFIX)/$(TARGET)/apps/$(PKG)/bin/gstreamer-plugins'
+        $(INSTALL) '$(PREFIX)/$(TARGET)/bin/libgstfaad.dll'              '$(PREFIX)/$(TARGET)/apps/$(PKG)/bin/gstreamer-plugins'
+        $(INSTALL) '$(PREFIX)/$(TARGET)/bin/libgstflac.dll'              '$(PREFIX)/$(TARGET)/apps/$(PKG)/bin/gstreamer-plugins'
+        $(INSTALL) '$(PREFIX)/$(TARGET)/bin/libgstgdp.dll'               '$(PREFIX)/$(TARGET)/apps/$(PKG)/bin/gstreamer-plugins'
+        $(INSTALL) '$(PREFIX)/$(TARGET)/bin/libgstgio.dll'               '$(PREFIX)/$(TARGET)/apps/$(PKG)/bin/gstreamer-plugins'
+        $(INSTALL) '$(PREFIX)/$(TARGET)/bin/libgsticydemux.dll'          '$(PREFIX)/$(TARGET)/apps/$(PKG)/bin/gstreamer-plugins'
+        $(INSTALL) '$(PREFIX)/$(TARGET)/bin/libgstid3demux.dll'          '$(PREFIX)/$(TARGET)/apps/$(PKG)/bin/gstreamer-plugins'
+        $(INSTALL) '$(PREFIX)/$(TARGET)/bin/libgstisomp4.dll'            '$(PREFIX)/$(TARGET)/apps/$(PKG)/bin/gstreamer-plugins'
+        $(INSTALL) '$(PREFIX)/$(TARGET)/bin/libgstlame.dll'              '$(PREFIX)/$(TARGET)/apps/$(PKG)/bin/gstreamer-plugins'
+        $(INSTALL) '$(PREFIX)/$(TARGET)/bin/libgstlibav.dll'             '$(PREFIX)/$(TARGET)/apps/$(PKG)/bin/gstreamer-plugins'
+        $(INSTALL) '$(PREFIX)/$(TARGET)/bin/libgstmad.dll'               '$(PREFIX)/$(TARGET)/apps/$(PKG)/bin/gstreamer-plugins'
+        $(INSTALL) '$(PREFIX)/$(TARGET)/bin/libgstogg.dll'               '$(PREFIX)/$(TARGET)/apps/$(PKG)/bin/gstreamer-plugins'
+        $(INSTALL) '$(PREFIX)/$(TARGET)/bin/libgstopus.dll'              '$(PREFIX)/$(TARGET)/apps/$(PKG)/bin/gstreamer-plugins'
+        $(INSTALL) '$(PREFIX)/$(TARGET)/bin/libgstplayback.dll'          '$(PREFIX)/$(TARGET)/apps/$(PKG)/bin/gstreamer-plugins'
+        $(INSTALL) '$(PREFIX)/$(TARGET)/bin/libgstreplaygain.dll'        '$(PREFIX)/$(TARGET)/apps/$(PKG)/bin/gstreamer-plugins'
+        $(INSTALL) '$(PREFIX)/$(TARGET)/bin/libgstsouphttpsrc.dll'       '$(PREFIX)/$(TARGET)/apps/$(PKG)/bin/gstreamer-plugins'
+        $(INSTALL) '$(PREFIX)/$(TARGET)/bin/libgstspectrum.dll'          '$(PREFIX)/$(TARGET)/apps/$(PKG)/bin/gstreamer-plugins'
+        $(INSTALL) '$(PREFIX)/$(TARGET)/bin/libgstspeex.dll'             '$(PREFIX)/$(TARGET)/apps/$(PKG)/bin/gstreamer-plugins'
+        $(INSTALL) '$(PREFIX)/$(TARGET)/bin/libgsttaglib.dll'            '$(PREFIX)/$(TARGET)/apps/$(PKG)/bin/gstreamer-plugins'
+        $(INSTALL) '$(PREFIX)/$(TARGET)/bin/libgsttcp.dll'               '$(PREFIX)/$(TARGET)/apps/$(PKG)/bin/gstreamer-plugins'
+        $(INSTALL) '$(PREFIX)/$(TARGET)/bin/libgsttypefindfunctions.dll' '$(PREFIX)/$(TARGET)/apps/$(PKG)/bin/gstreamer-plugins'
+        $(INSTALL) '$(PREFIX)/$(TARGET)/bin/libgstudp.dll'               '$(PREFIX)/$(TARGET)/apps/$(PKG)/bin/gstreamer-plugins'
+        $(INSTALL) '$(PREFIX)/$(TARGET)/bin/libgstvolume.dll'            '$(PREFIX)/$(TARGET)/apps/$(PKG)/bin/gstreamer-plugins'
+        $(INSTALL) '$(PREFIX)/$(TARGET)/bin/libgstvorbis.dll'            '$(PREFIX)/$(TARGET)/apps/$(PKG)/bin/gstreamer-plugins'
+        $(INSTALL) '$(PREFIX)/$(TARGET)/bin/libgstwavpack.dll'           '$(PREFIX)/$(TARGET)/apps/$(PKG)/bin/gstreamer-plugins'
+        $(INSTALL) '$(PREFIX)/$(TARGET)/bin/libgstwavparse.dll'          '$(PREFIX)/$(TARGET)/apps/$(PKG)/bin/gstreamer-plugins'
+
+        $(INSTALL) -d '$(PREFIX)/$(TARGET)/apps/$(PKG)/bin/imageformats'
+        $(INSTALL) '$(PREFIX)/$(TARGET)/qt/plugins/imageformats/qgif4.dll'  '$(PREFIX)/$(TARGET)/apps/$(PKG)/bin/imageformats'
+        $(INSTALL) '$(PREFIX)/$(TARGET)/qt/plugins/imageformats/qjpeg4.dll' '$(PREFIX)/$(TARGET)/apps/$(PKG)/bin/imageformats'
+
+        '$(TOP_DIR)/tools/copydlldeps.sh' -c \
+                                          -d '$(PREFIX)/$(TARGET)/apps/$(PKG)/bin' \
+                                          -F '$(PREFIX)/$(TARGET)/apps/$(PKG)/bin' \
+                                          -F '$(PREFIX)/$(TARGET)/apps/$(PKG)/bin/gstreamer-plugins' \
+                                          -F '$(PREFIX)/$(TARGET)/apps/$(PKG)/bin/imageformats' \
+                                          -X '$(PREFIX)/$(TARGET)/apps' \
+                                          -R '$(PREFIX)/$(TARGET)';
+    )
+endef
+
+# libechonest doesn't support static builds
+$(PKG)_BUILD_STATIC =


### PR DESCRIPTION
Problems:
1) #1269 #1273
2) (non critical) clementine-1-fixes.patch contain workaround that allow 64-bit build, but if left mouse click on menu "Tools->Vizualizations" it lead to crash:

```
-#  ifdef _WIN64
+#  if defined(_WIN64) && !defined(__MINGW32__)
typedef __int64 ptrdiff_t;
```

3) (non critical) It is not clear how to calculate the only required gstreamer plugins, currently music playback leads to crash. It can be fixed by manually copy all gstreamer plugins to subdirectory "gstreamer-plugins" and also copy all gstreamer plugins to directory with clementine.exe and re-run ./copydlldeps.sh.
4) (non critical) clementine-1-fixes.patch contain fix for detecting pthread:

```
 find_library(PTHREAD
-  pthreadGC2
+  pthread
 )
```

 because `clementine` uses pthreads  POSIX 1003.1-2001 from https://www.sourceware.org/pthreads-win32/. Maybe need to add package for Pthreads-w32 in MXE?
5) (non critical) "$(PKG)_BUILD_STATIC =" because some of `clementine` dependencies are not available for targets: `i686-w64-mingw32.static` and `x86_64-w64-mingw32.static`
