### PR TITLE
fix qtbase on Wheezy (don't use c++1y)

### DIFF
--- a/src/qtbase.mk
+++ b/src/qtbase.mk
@@ -26,6 +26,7 @@ define $(PKG)_BUILD
         SYBASE_LIBS="-lsybdb `'$(TARGET)-pkg-config' --libs-only-l gnutls` -liconv -lws2_32" \
         ./configure \
             -opensource \
+            -c++std c++11 \
             -confirm-license \
             -xplatform win32-g++ \
             -device-option CROSS_COMPILE=${TARGET}- \


### PR DESCRIPTION
The error: `g++: error: unrecognized command line option ‘-std=c++1y’`
Full log: https://gist.github.com/147a8e697b4be73dad0218598dab2608

The problem was solved by setting C++ version to C++11 explicitly.