### PR TITLE
add package libsoup

### DIFF
--- a/index.html
+++ b/index.html
@@ -1878,6 +1878,10 @@ local-pkg-list: $(LOCAL_PKG_LIST)</pre>
         <td class="website"><a href="https://download.libsodium.org/doc/">libsodium</a></td>
     </tr>
     <tr>
+        <td class="package">libsoup</td>
+        <td class="website"><a href="https://github.com/GNOME/libsoup">libsoup</a></td>
+    </tr>
+    <tr>
         <td class="package">libssh2</td>
         <td class="website"><a href="http://www.libssh2.org">libssh2</a></td>
     </tr>

--- a/src/gst-plugins-good.mk
+++ b/src/gst-plugins-good.mk
@@ -9,7 +9,7 @@ $(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
 $(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.xz
 $(PKG)_URL      := http://gstreamer.freedesktop.org/src/$(PKG)/$($(PKG)_FILE)
 $(PKG)_DEPS     := gcc cairo flac glib gst-plugins-base gstreamer jpeg \
-                   liboil libpng libshout libxml2 speex taglib wavpack
+                   liboil libpng libshout libsoup libxml2 speex taglib wavpack
 
 $(PKG)_UPDATE = $(subst gstreamer/refs,gst-plugins-good/refs,$(gstreamer_UPDATE))
 

--- a/src/libsoup-1-fixes.patch
+++ b/src/libsoup-1-fixes.patch
@@ -1,0 +1,57 @@
+This file is part of MXE.
+See index.html for further information.
+
+diff -Naur libsoup-2.54.0.1.orig/autogen.sh libsoup-2.54.0.1/autogen.sh
+--- libsoup-2.54.0.1.orig/autogen.sh	2016-03-23 15:19:17.000000000 +0300
++++ libsoup-2.54.0.1/autogen.sh	2016-04-09 18:29:05.799748895 +0300
+@@ -19,13 +19,6 @@
+         exit 1
+ fi
+ 
+-GTKDOCIZE=`which gtkdocize`
+-if test -z $GTKDOCIZE; then
+-        echo "*** No GTK-Doc found, please install it ***"
+-        exit 1
+-fi
+-
+-gtkdocize || exit $?
+ intltoolize --automake --copy
+ autoreconf --force --install --verbose
+ 
+diff -Naur libsoup-2.54.0.1.orig/docs/reference/Makefile.am libsoup-2.54.0.1/docs/reference/Makefile.am
+--- libsoup-2.54.0.1.orig/docs/reference/Makefile.am	2016-03-23 15:19:17.000000000 +0300
++++ libsoup-2.54.0.1/docs/reference/Makefile.am	2016-04-09 18:30:33.644569273 +0300
+@@ -77,7 +77,6 @@
+ 	$(GLIB_LIBS)
+ 
+ # include common portion ...
+-include $(top_srcdir)/gtk-doc.make
+ 
+ # kludges
+ $(srcdir)/tmpl/*.sgml:
+diff -Naur libsoup-2.54.0.1.orig/Makefile.am libsoup-2.54.0.1/Makefile.am
+--- libsoup-2.54.0.1.orig/Makefile.am	2016-03-23 15:19:17.000000000 +0300
++++ libsoup-2.54.0.1/Makefile.am	2016-04-09 22:41:40.604386782 +0300
+@@ -1,7 +1,7 @@
+ ## Process this file with automake to produce Makefile.in
+ ACLOCAL_AMFLAGS = -I m4 ${ACLOCAL_FLAGS}
+ 
+-SUBDIRS = libsoup po tests examples docs build/win32
++SUBDIRS = libsoup tests docs build/win32
+ 
+ EXTRA_DIST =				\
+ 	data/effective_tld_names.dat	\
+diff -Naur libsoup-2.54.0.1.orig/tests/test-utils.c libsoup-2.54.0.1/tests/test-utils.c
+--- libsoup-2.54.0.1.orig/tests/test-utils.c	2016-03-23 15:19:17.000000000 +0300
++++ libsoup-2.54.0.1/tests/test-utils.c	2016-04-09 18:31:51.741646290 +0300
+@@ -215,10 +215,6 @@
+ 		return;
+ 	apache_running = FALSE;
+ 
+-	if (pid) {
+-		while (kill (pid, 0) == 0)
+-			g_usleep (100);
+-	}
+ }
+ 
+ #endif /* HAVE_APACHE */

--- a/src/libsoup-test.c
+++ b/src/libsoup-test.c
@@ -1,0 +1,17 @@
+/*
+ * This file is part of MXE.
+ * See index.html for further information.
+ */
+
+#include <libsoup/soup.h>
+
+int main()
+{
+    SoupServer *server;
+    GError *error;
+
+    server = soup_server_new (SOUP_SERVER_SERVER_HEADER, "simple-httpd ", SOUP_SERVER_TLS_CERTIFICATE, NULL, NULL);
+    soup_server_listen_all (server, 1234, SOUP_SERVER_LISTEN_HTTPS, &error);
+
+    return 0;
+}

--- a/src/libsoup.mk
+++ b/src/libsoup.mk
@@ -16,7 +16,10 @@ define $(PKG)_UPDATE
 endef
 
 define $(PKG)_BUILD
-    cd '$(1)' && NOCONFIGURE=1 ./autogen.sh
+    cd '$(1)' && \
+        NOCONFIGURE=1 \
+        ACLOCAL_FLAGS=-I'$(PREFIX)/$(TARGET)/share/aclocal' \
+        ./autogen.sh
     cd '$(1)' && ./configure \
         $(MXE_CONFIGURE_OPTS) \
         --disable-vala

--- a/src/libsoup.mk
+++ b/src/libsoup.mk
@@ -1,0 +1,30 @@
+# This file is part of MXE.
+# See index.html for further information.
+
+PKG             := libsoup
+$(PKG)_IGNORE   := libsoup-pre%
+$(PKG)_VERSION  := 2.54.0.1
+$(PKG)_APIVER   := 2.4
+$(PKG)_CHECKSUM := b466c68e6575ca5ed170da60cc316c562a96db5dba5345a6043f740201afa8f4
+$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.gz
+$(PKG)_URL      := https://github.com/GNOME/$(PKG)/archive/$($(PKG)_VERSION).tar.gz
+$(PKG)_DEPS     := gcc glib libxml2 sqlite
+
+define $(PKG)_UPDATE
+    $(call MXE_GET_GITHUB_TAGS, GNOME/libsoup)
+endef
+
+define $(PKG)_BUILD
+    cd '$(1)' && NOCONFIGURE=1 ./autogen.sh
+    cd '$(1)' && ./configure \
+        $(MXE_CONFIGURE_OPTS) \
+        --disable-vala
+    $(MAKE) -C '$(1)' -j '$(JOBS)'
+    $(MAKE) -C '$(1)' -j 1 install
+
+    $(TARGET)-gcc \
+        -W -Wall -Werror -ansi \
+        '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-$(PKG).exe' \
+        `$(TARGET)-pkg-config $(PKG)-$($(PKG)_APIVER) --cflags --libs`
+endef


### PR DESCRIPTION
```libsoup``` required for ```clementine``` to play internet radio stations. 
After this need build again the package ```gst-plugins-good```, then there will be ```$(PREFIX)/$(TARGET)/bin/libgstsouphttpsrc.dll``` which need to add to gstreamer-plugins directory for clementine https://github.com/mxe/mxe/pull/1277.

```libsoup-1-fixes.patch``` contain workaround for disable build docs, because by default for correct work ./autogen.sh required install Debian package: ```apt install gtk-doc-tools```, but ```gtk-doc-tools``` not listed in http://mxe.cc/#requirements-debian