### PR TITLE
[WIP] add libuv

### DIFF
--- a/index.html
+++ b/index.html
@@ -1910,6 +1910,10 @@ local-pkg-list: $(LOCAL_PKG_LIST)</pre>
         <td class="website"><a href="http://libusb.org/">LibUsb-1.0</a></td>
     </tr>
     <tr>
+        <td class="package">libuv</td>
+        <td class="website"><a href="http://libuv.org/">libuv</a></td>
+    </tr>
+    <tr>
         <td class="package">libvpx</td>
         <td class="website"><a href="http://code.google.com/p/webm/">vpx</a></td>
     </tr>

--- a/src/libuv-1-fixes.patch
+++ b/src/libuv-1-fixes.patch
@@ -4,24 +4,34 @@ See index.html for further information.
 Contains ad hoc patches for cross building.
 
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Boris Nagaev <bnagaev@gmail.com>
-Date: Mon, 11 Apr 2016 02:02:54 +0200
-Subject: [PATCH] set Libs in pc-file
+From: Tony Theodore <tonyt@logyst.com>
+Date: Tue, 12 Apr 2016 11:06:36 +1000
+Subject: [PATCH] set LIBS in configure.ac instead of Makefile.am
 
-They are already defined in Makefile.am, but are not passed
-(only -lpthread is passed).
 
-According to http://stackoverflow.com/a/30960268 passing LIBS from
-Makefile.am to libuv.pc is impossible, as it is not fully-expanded.
-
-diff --git a/libuv.pc.in b/libuv.pc.in
+diff --git a/Makefile.am b/Makefile.am
 index 1111111..2222222 100644
---- a/libuv.pc.in
-+++ b/libuv.pc.in
-@@ -7,5 +7,5 @@ Name: @PACKAGE_NAME@
- Version: @PACKAGE_VERSION@
- Description: multi-platform support library with a focus on asynchronous I/O.
- 
--Libs: -L${libdir} -luv @LIBS@
-+Libs: -L${libdir} -luv -lpthread -lws2_32 -lpsapi -liphlpapi -lshell32 -luserenv
- Cflags: -I${includedir}
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -45,7 +45,6 @@ include_HEADERS += include/uv-win.h include/tree.h
+ AM_CPPFLAGS += -I$(top_srcdir)/src/win \
+                -DWIN32_LEAN_AND_MEAN \
+                -D_WIN32_WINNT=0x0600
+-LIBS += -lws2_32 -lpsapi -liphlpapi -lshell32 -luserenv
+ libuv_la_SOURCES += src/win/async.c \
+                     src/win/atomicops-inl.h \
+                     src/win/core.c \
+diff --git a/configure.ac b/configure.ac
+index 1111111..2222222 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -58,6 +58,9 @@ AM_CONDITIONAL([NETBSD],   [AS_CASE([$host_os],[netbsd*],       [true], [false])
+ AM_CONDITIONAL([OPENBSD],  [AS_CASE([$host_os],[openbsd*],      [true], [false])])
+ AM_CONDITIONAL([SUNOS],    [AS_CASE([$host_os],[solaris*],      [true], [false])])
+ AM_CONDITIONAL([WINNT],    [AS_CASE([$host_os],[mingw*],        [true], [false])])
++AS_CASE([$host_os],[mingw*], [
++    LIBS="$LIBS -lws2_32 -lpsapi -liphlpapi -lshell32 -luserenv"
++])
+ AC_CHECK_HEADERS([sys/ahafs_evProds.h])
+ AC_CHECK_PROG(PKG_CONFIG, pkg-config, yes)
+ AM_CONDITIONAL([HAVE_PKG_CONFIG], [test "x$PKG_CONFIG" != "x"])

--- a/src/libuv-1-fixes.patch
+++ b/src/libuv-1-fixes.patch
@@ -1,0 +1,27 @@
+This file is part of MXE.
+See index.html for further information.
+
+Contains ad hoc patches for cross building.
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Boris Nagaev <bnagaev@gmail.com>
+Date: Mon, 11 Apr 2016 02:02:54 +0200
+Subject: [PATCH] set Libs in pc-file
+
+They are already defined in Makefile.am, but are not passed
+(only -lpthread is passed).
+
+According to http://stackoverflow.com/a/30960268 passing LIBS from
+Makefile.am to libuv.pc is impossible, as it is not fully-expanded.
+
+diff --git a/libuv.pc.in b/libuv.pc.in
+index 1111111..2222222 100644
+--- a/libuv.pc.in
++++ b/libuv.pc.in
+@@ -7,5 +7,5 @@ Name: @PACKAGE_NAME@
+ Version: @PACKAGE_VERSION@
+ Description: multi-platform support library with a focus on asynchronous I/O.
+ 
+-Libs: -L${libdir} -luv @LIBS@
++Libs: -L${libdir} -luv -lpthread -lws2_32 -lpsapi -liphlpapi -lshell32 -luserenv
+ Cflags: -I${includedir}

--- a/src/libuv-test.c
+++ b/src/libuv-test.c
@@ -1,0 +1,15 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <uv.h>
+
+int main() {
+    uv_loop_t *loop = malloc(sizeof(uv_loop_t));
+    uv_loop_init(loop);
+
+    printf("Now quitting.\n");
+    uv_run(loop, UV_RUN_DEFAULT);
+
+    uv_loop_close(loop);
+    free(loop);
+    return 0;
+}

--- a/src/libuv.mk
+++ b/src/libuv.mk
@@ -1,0 +1,28 @@
+# This file is part of MXE.
+# See index.html for further information.
+
+PKG             := libuv
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 1.8.0
+$(PKG)_CHECKSUM := 6511f734da4fe082dacf85967606d600b7bce557bb9b2f0d2539193535323125
+$(PKG)_SUBDIR   := $(PKG)-v$($(PKG)_VERSION)
+$(PKG)_FILE     := $(PKG)-v$($(PKG)_VERSION).tar.gz
+$(PKG)_URL      := http://dist.libuv.org/dist/v$($(PKG)_VERSION)/$($(PKG)_FILE)
+$(PKG)_DEPS     := gcc
+
+define $(PKG)_UPDATE
+    $(call MXE_GET_GITHUB_TAGS, libuv/libuv, v)
+endef
+
+define $(PKG)_BUILD
+    cd '$(1)' && sh autogen.sh
+    cd '$(1)' && ./configure \
+        $(MXE_CONFIGURE_OPTS)
+    $(MAKE) -C '$(1)' -j '$(JOBS)'
+    $(MAKE) -C '$(1)' -j 1 install
+
+    '$(TARGET)-gcc' \
+        -W -Wall -Werror -pedantic \
+        '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-$(PKG).exe' \
+        `'$(TARGET)-pkg-config' $(PKG) --libs`
+endef


### PR DESCRIPTION
Test binary works on Windows.

TODO: patch `libuv-1-fixes.patch` just copies dependencies from Makefile.am.
`LIBS` variable (in upstream version) becomes equal to `-lpthreads`.

From generated `Makefile.am`:
```make
am__append_4 = -lws2_32 -lpsapi -liphlpapi -lshell32 -luserenv
...
LIBS = -lpthread  $(am__append_4)
```

From `configure.ac`:
```ac
 AS_IF([test "x$PKG_CONFIG" != "x"], [
    AC_CONFIG_FILES([libuv.pc])
])
AC_CONFIG_FILES([Makefile])
```

Therefore, `Makefile` is generated after `libuv.pc`. Variables from `Makefile` don't affect `config.status` and `libuv.pc`.

The following work:
```
$ LIBS="-lpthread -lws2_32 -lpsapi -liphlpapi -lshell32 -luserenv" ./config.status --recheck
$ ./config.status libuv.pc
```
But how to extract that `LIBS` variable from `Makefile`?