### PR TITLE
Update SFML to the version 2.3.2

### DIFF
--- a/src/sfml.mk
+++ b/src/sfml.mk
@@ -3,8 +3,8 @@
 
 PKG             := sfml
 $(PKG)_IGNORE   :=
-$(PKG)_VERSION  := 2.3.1
-$(PKG)_CHECKSUM := 5c610bd5db3ecd9984f58b038f2eebc1b8856773d50c58cd55b4daf0fe94e120
+$(PKG)_VERSION  := 2.3.2
+$(PKG)_CHECKSUM := 03fe79943c48222037f1126a581b12c95a4dd53168881907964695c5ec3dc395
 $(PKG)_SUBDIR   := SFML-$($(PKG)_VERSION)
 $(PKG)_FILE     := SFML-$($(PKG)_VERSION)-sources.zip
 $(PKG)_URL      := http://sfml-dev.org/download/sfml/$($(PKG)_VERSION)/$($(PKG)_FILE)


### PR DESCRIPTION
There is available a new version already: http://www.sfml-dev.org/download/sfml/2.3.2/


It builds correctly:

 ```
> file ./usr/i686-w64-mingw32.static/bin/test-sfml.exe 
./usr/i686-w64-mingw32.static/bin/test-sfml.exe: PE32 executable (console) Intel 80386, for MS Windows
 ```
I have tried also executing binary file with wine - it worked out correctly unveiling a red eclipse.