### PR TITLE
box2d: update sha256

### DIFF
--- a/src/box2d.mk
+++ b/src/box2d.mk
@@ -4,7 +4,7 @@
 PKG             := box2d
 $(PKG)_IGNORE   :=
 $(PKG)_VERSION  := 2.3.1
-$(PKG)_CHECKSUM := 2c61505f03ef403b54cf0e510d83d6f567e37882ad79b5b2d486acbc7d5eedea
+$(PKG)_CHECKSUM := 75d62738b13d2836cd56647581b6e574d4005a6e077ddefa5d727d445d649752
 $(PKG)_SUBDIR   := Box2D-$($(PKG)_VERSION)/Box2D
 $(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.gz
 $(PKG)_URL      := https://github.com/erincatto/Box2D/archive/v$($(PKG)_VERSION).tar.gz


### PR DESCRIPTION
The file was changed in upstream.

File pkg/box2d-2.3.1.tar.gz
(or https://github.com/erincatto/Box2D/archive/v2.3.1.tar.gz):
Old sha256: 2c61505f03ef403b54cf0e510d83d6f567e37882ad79b5b2d486acbc7d5eedea
New sha256: 75d62738b13d2836cd56647581b6e574d4005a6e077ddefa5d727d445d649752

Changes:
$ diff -r old/ new
Only in old/Box2D-2.3.1/Contributions/Platforms: Box2D.XNA.zip
Only in old/Box2D-2.3.1/Contributions/Platforms: Tizen.zip

Files Box2D.XNA.zip and Tizen.zip are not used in build, according to logs.
Removing them them seems to be safe.

fix #1319