### PR TITLE
jsoncpp: fix build with GCC < 6.x

### DIFF
--- a/src/jsoncpp.mk
+++ b/src/jsoncpp.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://github.com/open-source-parsers/jsoncpp/archive/$($(PK
 $(PKG)_DEPS     := gcc
 
 # workaround for builds with GCC >= 6.x
-$(PKG)_CXXFLAGS := -Wno-error=conversion -Wno-error=shift-negative-value
+$(PKG)_CXXFLAGS := -Wno-error=conversion -Wno-shift-negative-value
 
 define $(PKG)_UPDATE
     $(WGET) -q -O- 'https://github.com/open-source-parsers/jsoncpp/archive/' | \


### PR DESCRIPTION
Fix after 0bc73f739d7a8f2bc4e5100da62a0d894cbc9e38.
There is no -Werror=shift-negative-value in GCC 4.9.x.