### PR TITLE
proj4: libproj-0.dll is checked by GDAL if the platform is windows

### DIFF
--- a/src/proj-1-fixes.patch
+++ b/src/proj-1-fixes.patch
@@ -1,0 +1,12 @@
+diff -bruN proj-4.9.1.original/src/Makefile.in proj-4.9.1/src/Makefile.in
+--- proj-4.9.1.original/src/Makefile.in	2016-04-05 10:59:38.834624359 +0200
++++ proj-4.9.1/src/Makefile.in	2016-04-05 11:00:11.073813213 +0200
+@@ -400,7 +400,7 @@
+ multistresstest_LDADD = libproj.la -lpthread
+ test228_LDADD = libproj.la -lpthread
+ lib_LTLIBRARIES = libproj.la
+-libproj_la_LDFLAGS = -no-undefined -version-info 9:0:0
++libproj_la_LDFLAGS = -no-undefined -version-info 0:0:0
+ libproj_la_SOURCES = \
+ 	pj_list.h \
+ 	PJ_aeqd.c PJ_gnom.c PJ_laea.c PJ_mod_ster.c \


### PR DESCRIPTION
For mingw, proj4 creates libproj-9.dll and GDAL library consider
this as missing dll. GDAL has a workaround to use PROJSO env
variable that allows to set proj-9.dll. But it is better if
proj library could simply output the dll with the other name

https://trac.osgeo.org/gdal/browser/branches/2.1/gdal/ogr/ogrct.cpp#L86