### PR TITLE
mxe-conf. set WIN32 flag is missing in toolchain conf

### DIFF
--- a/src/mxe-conf.mk
+++ b/src/mxe-conf.mk
@@ -24,6 +24,7 @@ define $(PKG)_BUILD
     touch '$(CMAKE_TOOLCHAIN_DIR)/.gitkeep'
     (echo 'set(CMAKE_SYSTEM_NAME Windows)'; \
      echo 'set(MSYS 1)'; \
+     echo 'set(WIN32 TRUE)'; \
      echo 'set(BUILD_SHARED_LIBS $(if $(BUILD_SHARED),ON,OFF))'; \
      echo 'set(LIBTYPE $(if $(BUILD_SHARED),SHARED,STATIC))'; \
      echo 'set(CMAKE_PREFIX_PATH $(PREFIX)/$(TARGET))'; \


### PR DESCRIPTION
without set(WIN32 TRUE) in the toolchain conf. some builds are failing.

currently
if(WIN32)
<cross compile won't reach here >
endif()

if(UNIX)
<shouldn't have reached here. But it does anyway in cross compiling
endif()

changing first loop to:
if(WIN32 OR CMAKE_CROSSCOMPILING)
<cross compile reaches here >
endif()
