### PR TITLE
Fix cpp-netlib cmake directory.

### DIFF
--- a/src/cpp-netlib.mk
+++ b/src/cpp-netlib.mk
@@ -21,7 +21,7 @@ define $(PKG)_BUILD
    mkdir '$(1)/build'
    cd '$(1)/build' && cmake .. \
        -DCMAKE_TOOLCHAIN_FILE='$(CMAKE_TOOLCHAIN_FILE)' \
-       -DINSTALL_CMAKE_DIR='$(PREFIX)/$(TARGET)/cmake/$(PKG)' \
+       -DINSTALL_CMAKE_DIR='$(PREFIX)/$(TARGET)/cmake/cppnetlib' \
        -DCPP-NETLIB_BUILD_EXAMPLES=OFF \
        -DCPP-NETLIB_BUILD_TESTS=OFF
 


### PR DESCRIPTION
For find_package(cppnetlib) to work, the directory for the cmake files
must be called the same as the files installed into the directory.

Installing directly into the cmake directory would also be an option...