### PR TITLE
openthreads: build in  src/OpenThreads

### DIFF
--- a/src/openthreads.mk
+++ b/src/openthreads.mk
@@ -25,5 +25,5 @@ define $(PKG)_BUILD
         -D_OPENTHREADS_ATOMIC_USE_WIN32_INTERLOCKED=1 \
         '$(1)'
 
-    $(MAKE) -C '$(1).build' -j '$(JOBS)' install VERBOSE=1
+    $(MAKE) -C '$(1).build/src/OpenThreads' -j '$(JOBS)' install VERBOSE=1
 endef


### PR DESCRIPTION
openthreads should not do rebuild of osg. it should only build src/OpenThreads