### PR TITLE
fix nsis

### DIFF
--- a/src/nsis.mk
+++ b/src/nsis.mk
@@ -26,7 +26,7 @@ define $(PKG)_BUILD
         `[ -d /usr/local/lib ]     && echo APPEND_LIBPATH=/usr/local/lib` \
         $(if $(findstring x86_64-w64-mingw32,$(TARGET)),\
             SKIPPLUGINS='System') \
-        SKIPUTILS='MakeLangId,Makensisw,NSIS Menu,UIs,zip2exe' \
+        SKIPUTILS='MakeLangId,Makensisw,NSIS Menu,zip2exe' \
         NSIS_MAX_STRLEN=8192 \
         install
     $(INSTALL) -m755 '$(PREFIX)/$(TARGET)/bin/makensis' '$(PREFIX)/bin/$(TARGET)-makensis'


### PR DESCRIPTION
```UIs``` is needed.

```$(TARGET)-makensis EiskaltDC++.nsi```:
```
...
SetCompressor: /SOLID lzma
!insertmacro: MUI_PAGE_WELCOME
Error: Can't open "/home/pavel/builds/mxe/usr/x86_64-w64-mingw32.static/share/nsis\Contrib\UIs\modern.exe"!
Error in macro MUI_INTERFACE on macroline 54
Error in macro MUI_PAGE_INIT on macroline 3
Error in macro MUI_PAGE_WELCOME on macroline 5
...
```

For Debian package ```nsis```:
```
ls /usr/share/nsis/Contrib
Graphics  Language files  Modern UI  Modern UI 2  UIs

ls /usr/share/nsis/Contrib/UIs/
default.exe  modern.exe  modern_headerbmp.exe  modern_headerbmpr.exe  modern_nodesc.exe  modern_smalldesc.exe  sdbarker_tiny.exe
```