### PR TITLE
glm: add rules to download/build version 0.9.7.4

### DIFF
--- a/index.html
+++ b/index.html
@@ -1418,6 +1418,10 @@ local-pkg-list: $(LOCAL_PKG_LIST)</pre>
         <td class="website"><a href="http://www.gtkmm.org/">GLibmm</a></td>
     </tr>
     <tr>
+        <td class="package">glm</td>
+        <td class="website"><a href="http://glm.g-truc.net">GLM - OpenGL Mathematics</a></td>
+    </tr>
+    <tr>
         <td class="package">gmp</td>
         <td class="website"><a href="http://www.gmplib.org/">GMP</a></td>
     </tr>

--- a/src/glm-test.cpp
+++ b/src/glm-test.cpp
@@ -1,0 +1,32 @@
+/*
+ * This file is part of MXE.
+ * See index.html for further information.
+ *
+ * This file is a test program for glm, adapted from the code sample at
+ * http://glm.g-truc.net/0.9.7/index.html.
+ */
+
+#include <glm/gtc/matrix_transform.hpp> // glm::translate, glm::rotate, glm::scale, glm::perspective
+#include <glm/mat4x4.hpp> // glm::mat4
+#include <glm/vec3.hpp> // glm::vec3
+#include <glm/vec4.hpp> // glm::vec4
+#include <glm/gtx/string_cast.hpp> // so we can print a calculation result
+#include <iostream>
+
+glm::mat4 camera(float Translate, glm::vec2 const& Rotate)
+{
+    glm::mat4 Projection = glm::perspective(45.0f, 4.0f / 3.0f, 0.1f, 100.f);
+    glm::mat4 View = glm::translate(glm::mat4(1.0f), glm::vec3(0.0f, 0.0f, -Translate));
+    View = glm::rotate(View, Rotate.y, glm::vec3(-1.0f, 0.0f, 0.0f));
+    View = glm::rotate(View, Rotate.x, glm::vec3(0.0f, 1.0f, 0.0f));
+    glm::mat4 Model = glm::scale(glm::mat4(1.0f), glm::vec3(0.5f));
+    return Projection * View * Model;
+}
+
+int main()
+{
+    glm::mat4 m = camera(0.0f, glm::vec2(0.0f, 0.0f));
+    std::cout << glm::to_string(m) << std::endl;
+
+    return 0;
+}

--- a/src/glm.mk
+++ b/src/glm.mk
@@ -1,0 +1,28 @@
+# This file is part of MXE.
+# See index.html for further information.
+
+PKG             := glm
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 0.9.7.4
+$(PKG)_CHECKSUM := 0cfa1e40041114cda8ced7e6738860fe6f9a7103d25bcc376adb9840fcf21fe1
+$(PKG)_SUBDIR   := glm-$($(PKG)_VERSION)
+$(PKG)_FILE     := $($(PKG)_VERSION).tar.gz
+$(PKG)_URL      := https://github.com/g-truc/glm/archive/$($(PKG)_VERSION).tar.gz
+$(PKG)_DEPS     := gcc
+
+define $(PKG)_UPDATE
+    $(call MXE_GET_GITHUB_TAGS, g-truc/glm)
+endef
+
+define $(PKG)_BUILD
+    mkdir '$(1).build'
+
+    cd '$(1).build' && $(TARGET)-cmake '$(1)'
+
+    $(MAKE) -C '$(1).build' -j '$(JOBS)' install
+
+    '$(TARGET)-g++' \
+        -W -Wall -Werror -ansi -pedantic \
+        '$(2).cpp' -o '$(PREFIX)/$(TARGET)/bin/test-glm.exe'
+endef
+


### PR DESCRIPTION
This pull request contains build rules for glm 0.9.7.4 (http://glm.g-truc.net/0.9.7/index.html).

glm is a header-only library, so it can be vendored in projects that use it; however, some libraries (e.g. CEGUI 0.8.7) expect to find it in the build environment.

The test program should generate the output

```
mat4x4((0.672222, 0.000000, 0.000000, 0.000000), (0.000000, 0.896295, 0.000000, 0.000000), (0.000000, 0.000000, -0.501001, -0.500000), (0.000000, 0.000000, -0.200200, 0.000000))
```