### PR TITLE
gcc6: fix compiling ucl

### DIFF
--- a/src/ucl.mk
+++ b/src/ucl.mk
@@ -21,7 +21,8 @@ endef
 define $(PKG)_BUILD
     cd '$(1)' && \
         ./configure \
-        $(MXE_CONFIGURE_OPTS)
+        $(MXE_CONFIGURE_OPTS) \
+        CFLAGS='-std=c90 -fPIC'
     $(MAKE) -C '$(1)' -j '$(JOBS)' LDFLAGS=-no-undefined
     $(MAKE) -C '$(1)' -j 1 install
 endef


### PR DESCRIPTION
Fixes #1351. Tested with regular `gcc.mk` and `gcc6-overlay.mk`. Haven't updated README.md since the commit hash would be wrong after merging.