### PR TITLE
gcc6: fix building upx

### DIFF
--- a/src/upx.mk
+++ b/src/upx.mk
@@ -47,7 +47,9 @@ define $(PKG)_BUILD_$(BUILD)
         'CC=$(BUILD_CC)' \
         'PKG_CONFIG=$(PREFIX)/$(BUILD)/bin/pkgconf' \
         'LIBS=-L$(PREFIX)/$(BUILD)/lib -lucl -lz' \
-        $(shell [ `uname -s` == Darwin ] && echo "CXXFLAGS='-Wno-error=unused-local-typedef'") \
+        $(shell [ `uname -s` == Darwin ] && \
+            echo "CXXFLAGS=-Wno-error=unused-local-typedefs -Wno-error=misleading-indentation" || \
+            echo "CXXFLAGS=-Wno-error=misleading-indentation") \
         'exeext='
     cp '$(1)/src/upx' '$(PREFIX)/$(BUILD)/bin/'
 endef


### PR DESCRIPTION
Fixes #1359. 

Additionally, I've "tested" Darwin target by swapping arguments to `echo` and it turned out the `-Wno-error=unused-local-typedef` was seemingly wrong, as there's no such option - only `-Wunused-local-typedefs` (note plural). At least according to my `man`. This might be GCC 6 thing.

I haven't tested this on GCC 4 and 5. There's a good chance they don't support `-Wmisleading-indentation`, so it would be great if someone confirmed whether this commit works for them on these versions.