### PR TITLE
gcc6: fix compiling gcc 4.9.3

### DIFF
--- a/src/gcc-2.patch
+++ b/src/gcc-2.patch
@@ -1,0 +1,39 @@
+This file is part of MXE.
+See index.html for further information.
+
+2015-08-06  Mike Frysinger  <vapier@gentoo.org>
+
+This patch has been taken from:
+https://gcc.gnu.org/ml/gcc-patches/2015-08/msg00375.html
+
+diff --git a/gcc/cp/cfns.gperf b/gcc/cp/cfns.gperf
+index 68acd3d..953262f 100644
+--- a/gcc/cp/cfns.gperf
++++ b/gcc/cp/cfns.gperf
+@@ -22,6 +22,9 @@ __inline
+ static unsigned int hash (const char *, unsigned int);
+ #ifdef __GNUC__
+ __inline
++#ifdef __GNUC_STDC_INLINE__
++__attribute__ ((__gnu_inline__))
++#endif
+ #endif
+ const char * libc_name_p (const char *, unsigned int);
+ %}
+diff --git a/gcc/cp/cfns.h b/gcc/cp/cfns.h
+index 1c6665d..6d00c0e 100644
+--- a/gcc/cp/cfns.h
++++ b/gcc/cp/cfns.h
+@@ -53,6 +53,9 @@ __inline
+ static unsigned int hash (const char *, unsigned int);
+ #ifdef __GNUC__
+ __inline
++#ifdef __GNUC_STDC_INLINE__
++__attribute__ ((__gnu_inline__))
++#endif
+ #endif
+ const char * libc_name_p (const char *, unsigned int);
+ /* maximum key range = 391, duplicates = 0 */
+-- 
+2.4.4
+


### PR DESCRIPTION
Fixes #1361 by adding patch from the linked mailing list.

I haven't tested this on GCC 4 and 5, so it would be great if someone confirmed whether this commit works for them on these versions.