### PR TITLE
docs: add mini-tutorial on plugins

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -1,5 +1,22 @@
 ### MXE Plugins
 
-A collection of unsupported examples, experiments, tools, and utilities.
+MXE lets you override the way packages are built and installed by offering
+plugins mechanism. This directory contains a collection of example plugins and
+experimental content. Enjoy!
 
-Enjoy!
+*Note: the files here should be considered examples only and are unmaintained.*
+
+##### Rolling your own plugin
+
+The basic usage is to drop some `*.mk` files in a directory `foo/` and set
+`MXE_PLUGIN_DIRS='foo/'` while invoking `make` like this:
+
+```console
+MXE_PLUGINS_DIR=foo/ make libpng
+```
+
+If needed, you can also pass multiple directories by separating them with a
+space: `MXE_PLUGIN_DIRS='foo1/ foo2/'`.
+
+For details on `*.mk` contents, please consult the contents of this directory
+and `src/*.mk`.


### PR DESCRIPTION
Proposed fix for #1364 

This probably should make its way in one form or another to `gh-pages` branch, as well as `MXE_VERBOSE` variable which is extremely useful.