### PR TITLE
Always use the included version of libxml

### DIFF
--- a/plugins/native/gettext.mk
+++ b/plugins/native/gettext.mk
@@ -8,7 +8,8 @@ $(PKG)_DEPS_$(BUILD) := libiconv
 define $(PKG)_BUILD_$(BUILD)
     mkdir '$(1).build'
     cd    '$(1).build' && '$(1)/configure' \
-        --prefix='$(PREFIX)/$(TARGET)'
+        --prefix='$(PREFIX)/$(TARGET)' \
+        --with-included-libxml
     $(MAKE) -C '$(1).build' -j '$(JOBS)' man1_MANS=
     $(MAKE) -C '$(1).build' -j 1 install man1_MANS=
 endef


### PR DESCRIPTION
Alternative fix to mxe/mxe#1367 - always use the version of libxml2 included in gettext instead of trying to use the system version 