### PR TITLE
fix native plugins when additional dirs are specified

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -324,7 +324,7 @@ all: all-filtered
 
 # Build native requirements for certain systems
 OS_SHORT_NAME   := $(call lc,$(shell lsb_release -sc 2>/dev/null || uname -s))
-MXE_PLUGIN_DIRS += $(realpath $(TOP_DIR)/plugins/native/$(OS_SHORT_NAME))
+override MXE_PLUGIN_DIRS += $(realpath $(TOP_DIR)/plugins/native/$(OS_SHORT_NAME))
 
 .PHONY: check-requirements
 define CHECK_REQUIREMENT


### PR DESCRIPTION
When plugins are specified on the command line, automatic native plugins
are not included (currently for darwin and wheezy):

```
$ make gmsl-print-MXE_PLUGIN_DIRS MXE_PLUGIN_DIRS=plugins/apps/
MXE_PLUGIN_DIRS = plugins/apps/
```

See:
https://www.gnu.org/software/make/manual/make.html#Override-Directive
https://github.com/mxe/mxe/issues/1259#issuecomment-217376756
