### PR TITLE
Add plugin for compiling mingw-w64 with secure APIs enabled.

### DIFF
--- a/src/gcc.mk
+++ b/src/gcc.mk
@@ -76,7 +76,8 @@ define $(PKG)_BUILD_mingw-w64
         --host='$(TARGET)' \
         --prefix='$(PREFIX)/$(TARGET)' \
         --enable-sdk=all \
-        --enable-idl
+        --enable-idl \
+        $(mingw-w64-headers_CONFIGURE_OPTS)
     $(MAKE) -C '$(1).headers-build' install
 
     # build standalone gcc


### PR DESCRIPTION
This is based off of #897.