### PR TITLE
libjpeg-turbo: update from 1.4.1 to 1.5.0

### DIFF
--- a/src/libjpeg-turbo-1-fixes.patch
+++ b/src/libjpeg-turbo-1-fixes.patch
@@ -3,94 +3,30 @@ See index.html for further information.
 
 Contains ad hoc patches for cross building.
 
-From aba5b24329e9f7209e47d400648e01a1de516e5e Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: MXE
 Date: Sun, 6 Sep 2015 23:16:12 +1000
-Subject: [PATCH 1/3] fix typedef conflicts
+Subject: [PATCH] fix typedef conflicts
 
 taken from:
 https://aur.archlinux.org/cgit/aur.git/tree/0001-header-compat.mingw.patch?h=mingw-w64-libjpeg-turbo
 
+
 diff --git a/jmorecfg.h b/jmorecfg.h
-index 108e7de..ea74b4f 100644
+index 1111111..2222222 100644
 --- a/jmorecfg.h
 +++ b/jmorecfg.h
-@@ -12,6 +12,12 @@
+@@ -14,7 +14,13 @@
   * optimizations.  Most users will not need to touch this file.
   */
  
 +/* prevents conflicts */
 +#if defined(__MINGW32__)
 +#include <shlwapi.h> /* typedefs INT16 and INT32 */
-+
+ 
 +#define HAVE_BOOLEAN
 +#endif
- 
++ 
  /*
   * Maximum number of components (color channels) allowed in JPEG image.
-@@ -112,6 +118,7 @@ typedef char JOCTET;
- #endif /* HAVE_UNSIGNED_CHAR */
- 
- 
-+#ifndef _BASETSD_H_		/* basestd.h from mingw-w64 defines UINT8, UINT16, INT16, INT32 */
- /* These typedefs are used for various table entries and so forth.
-  * They must be at least as wide as specified; but making them too big
-  * won't cost a huge amount of memory, so we don't provide special
-@@ -150,6 +157,7 @@ typedef short INT16;
- #ifndef XMD_H                   /* X11/xmd.h correctly defines INT32 */
- typedef long INT32;
- #endif
-+#endif
- 
- /* Datatype used for image dimensions.  The JPEG standard only supports
-  * images up to 64K*64K due to 16-bit fields in SOF markers.  Therefore
--- 
-2.3.2 (Apple Git-55)
-
-
-From 49614a87a8a028fd7ce93edbbe8b5b79b9c97213 Mon Sep 17 00:00:00 2001
-From: MXE
-Date: Sun, 6 Sep 2015 23:17:23 +1000
-Subject: [PATCH 2/3] include stdio.h
-
-taken from:
-https://aur.archlinux.org/cgit/aur.git/tree/libjpeg-turbo-1.3.1-libmng-compatibility.patch?h=mingw-w64-libjpeg-turbo
-
-diff --git a/jpeglib.h b/jpeglib.h
-index 9615c5d..f5fffe5 100644
---- a/jpeglib.h
-+++ b/jpeglib.h
-@@ -28,6 +28,7 @@
- #endif
- #include "jmorecfg.h"           /* seldom changed options */
- 
-+#include <stdio.h>
- 
- #ifdef __cplusplus
- #ifndef DONT_USE_EXTERN_C
--- 
-2.3.2 (Apple Git-55)
-
-
-From e7a2f20d69b45f76834aeb71ff08c3f4b487f944 Mon Sep 17 00:00:00 2001
-From: MXE
-Date: Mon, 21 Sep 2015 20:34:03 +1000
-Subject: [PATCH 3/3] install dll to bin
-
-
-diff --git a/ltmain.sh b/ltmain.sh
-index a968835..f9cf33d 100644
---- a/ltmain.sh
-+++ b/ltmain.sh
-@@ -5229,7 +5229,7 @@ fi\
- 	  # place dlname in correct position for cygwin
- 	  tdlname=$dlname
- 	  case $host,$output,$installed,$module,$dlname in
--	    *cygwin*,*lai,yes,no,*.dll | *mingw*,*lai,yes,no,*.dll) tdlname=../bin/$dlname ;;
-+	    *cygwin*,*lai,yes,no,*.dll | *mingw*,*lai,yes,no,*.dll) tdlname=../../bin/$dlname ;;
- 	  esac
- 	  $echo > $output "\
- # $outputname - a libtool library file
--- 
-2.3.2 (Apple Git-55)
-
+  * To meet the letter of the JPEG spec, set this to 255.  However, darn

--- a/src/libjpeg-turbo.mk
+++ b/src/libjpeg-turbo.mk
@@ -3,8 +3,8 @@
 
 PKG             := libjpeg-turbo
 $(PKG)_IGNORE   :=
-$(PKG)_VERSION  := 1.4.1
-$(PKG)_CHECKSUM := 4bf5bad4ce85625bffbbd9912211e06790e00fb982b77724af7211034efafb08
+$(PKG)_VERSION  := 1.5.0
+$(PKG)_CHECKSUM := 9f397c31a67d2b00ee37597da25898b03eb282ccd87b135a50a69993b6a2035f
 $(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
 $(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.gz
 $(PKG)_URL      := http://$(SOURCEFORGE_MIRROR)/project/$(PKG)/$($(PKG)_VERSION)/$($(PKG)_FILE)


### PR DESCRIPTION
Drop unneeded patches.