### PR TITLE
create tmp-*/readonly instead of usr/readonly

### DIFF
--- a/src/mxe-conf.mk
+++ b/src/mxe-conf.mk
@@ -107,13 +107,6 @@ define $(PKG)_BUILD_$(BUILD)
     cd '$(1)' && autoreconf -fiv
     cd '$(1)' && ./configure
 
-    #create readonly directory to force wine to fail
-    mkdir -p "$$WINEPREFIX"
-    [ -f "$$WINEPREFIX/.gitkeep" ] \
-        || chmod 0755 "$$WINEPREFIX" \
-        && touch "$$WINEPREFIX/.gitkeep"
-    chmod 0555 "$$WINEPREFIX"
-
     #create script "wine" in a directory which is in PATH
     mkdir -p '$(PREFIX)/$(BUILD)/bin/'
     (echo '#!/usr/bin/env bash'; \


### PR DESCRIPTION
Removing MXE directory with `rm -rf` used to fail on file `usr/readonly/.gitkeep` because directory `usr/readonly` was readonly. Now readonly directory is created in `tmp-*` directory and `.gitkeep` is not created for it (because `tmp-*` is not under `usr/`). Problems with removing MXE directory are fixed even in case of interrupted build.

fix #1221