### PR TITLE
fix races of downloading and verifying

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -214,7 +214,8 @@ BACKUP_DOWNLOAD = \
     $(WGET) -O- $(PKG_CDN)/`$(call ESCAPE_PKG,$(1))`))
 
 DOWNLOAD_PKG_ARCHIVE = \
-        mkdir -p '$(PKG_DIR)' && ( \
+        mkdir -p '$(PKG_DIR)'/tmp && ( \
+        ( \
             $(WGET) -T 30 -t 3 -O- '$($(1)_URL)' \
             $(if $($(1)_URL_2), \
                 || (echo "MXE Warning! Downloading $(1) from second URL." >&2 && \
@@ -225,11 +226,13 @@ DOWNLOAD_PKG_ARCHIVE = \
         $(if $($(1)_FIX_GZIP), \
             | gzip -d | gzip -9n, \
             ) \
-        > '$(PKG_DIR)/$($(1)_FILE)' || \
+        > '$(PKG_DIR)/tmp/$($(1)_FILE).$(1)' \
+        && mv '$(PKG_DIR)/tmp/$($(1)_FILE).$(1)' '$(PKG_DIR)/$($(1)_FILE)' \
+        ) || \
         ( echo; \
           echo 'Download failed!'; \
           echo; \
-          rm -f '$(PKG_DIR)/$($(1)_FILE)'; )
+          rm -f '$(PKG_DIR)/tmp/$($(1)_FILE).$(1)' '$(PKG_DIR)/$($(1)_FILE)'; )
 
 # open issue from 2002:
 # http://savannah.gnu.org/bugs/?712


### PR DESCRIPTION
Sometimes `make download -j 6` fails with errors in downloading
package openthreads (and some other). How to reproduce:

```
    $ sed 's/wget/wget --limit-rate=1M/' -i Makefile
    $ make download-only-plib download-only-openscenegraph \
        download-only-openthreads -j 2
    ...
    Download failed or wrong checksum of package openscenegraph!
```

In previous implementation download pipe (wget, gzip) used to write
its output directly to a target file in pkg/ directory.
If multiple packages (e.g., openscenegraph and openthreads) share
the same file in pkg/ directory, the download can result in failure:
while first package is verifying the checksum, another one overwrites
the file with partially downloaded content.

(Package plib in the example is needed to shift start of download of
openthreads. `--limit-rate=1M` is needed to increase duration of download.)

To fix this problem, wget command was changed to write to a unique
file, which is renamed to a target file afterwards. Renaming is
an atomic action.