### PR TITLE
patch.mk: create target subdir if it is multilevel

### DIFF
--- a/patch.mk
+++ b/patch.mk
@@ -19,6 +19,8 @@ define INIT_GIT
     rm -rf '$(GITS_DIR)/tmp'
     mkdir -p '$(GITS_DIR)/tmp/$(1)'
     cd '$(GITS_DIR)/tmp/$(1)' && $(call UNPACK_PKG_ARCHIVE,$(1))
+    # the following is really needed for multilevel subdirs (xvidcore)
+    mkdir -p '$(shell dirname $(call GIT_DIR,$(1)))'
     # if PKG_SUBDIR is ".", the following will move gits/tmp/pkg
     mv '$(abspath $(GITS_DIR)/tmp/$(1)/$($(1)_SUBDIR))' '$(call GIT_DIR,$(1))'
     rm -rf '$(GITS_DIR)/tmp'


### PR DESCRIPTION
Example: xvidcore. Its subdir is xvidcore/build/generic.
This commit adds creation of xvidcore/build prior to moving
a directory to xvidcore/build/generic.