### PR TITLE
Windows Lua DLLs should not start with "lib"

### DIFF
--- a/plugins/luarocks/luarocks-1-fixes.patch
+++ b/plugins/luarocks/luarocks-1-fixes.patch
@@ -81,7 +81,7 @@ index 1111111..2222222 100644
 +   }
 +   defaults.runtime_external_deps_patterns = {
 +      bin = { "?.exe", "?.bat" },
-+      lib = { "?.dll", "lib?.dll" },
++      lib = { "?.dll" },
 +      include = { "?.h" }
 +   }
 +end

--- a/src/lua.mk
+++ b/src/lua.mk
@@ -6,6 +6,7 @@ $(PKG)_IGNORE   :=
 $(PKG)_VERSION  := 5.3.3
 # Shared version and luarocks subdir
 $(PKG)_SHORTVER := $(call SHORT_PKG_VERSION,$(PKG))
+$(PKG)_DLLVER   := $(subst .,,$($(PKG)_SHORTVER))
 $(PKG)_CHECKSUM := 5113c06884f7de453ce57702abaac1d618307f33f6789fa870e87a59d772aca2
 $(PKG)_SUBDIR   := lua-$($(PKG)_VERSION)
 $(PKG)_FILE     := lua-$($(PKG)_VERSION).tar.gz
@@ -66,12 +67,12 @@ define $(PKG)_BUILD_SHARED
         AR='$(TARGET)-gcc -Wl,--out-implib,liblua.dll.a -shared -o' \
         RANLIB='echo skipped ranlib' \
         SYSCFLAGS='-DLUA_BUILD_AS_DLL' \
-        LUA_A=liblua$($(PKG)_SHORTVER).dll \
+        LUA_A=lua$($(PKG)_DLLVER).dll \
         a lua
     $(MAKE) -C '$(1)' -j 1 \
         INSTALL_TOP='$(PREFIX)/$(TARGET)' \
         INSTALL_MAN='$(1)/noinstall' \
-        TO_BIN='liblua$($(PKG)_SHORTVER).dll' \
+        TO_BIN='lua$($(PKG)_DLLVER).dll' \
         INSTALL='$(INSTALL)' \
         TO_LIB='liblua.dll.a' \
         install


### PR DESCRIPTION
The canonical Lua DLL file name in Windows is either Lua5x.dll or Lua5.x.dll.