### PR TITLE
FindFreetype.cmake: add INCLUDE_DIR

### DIFF
--- a/src/cmake/modules/FindFreetype.cmake
+++ b/src/cmake/modules/FindFreetype.cmake
@@ -9,4 +9,6 @@ endif()
 
 pkg_check_modules(FREETYPE freetype2)
 
-set(FREETYPE_LIBRARY ${FREETYPE_LIBRARIES}) #For compatibility
+#For compatibility
+set(FREETYPE_LIBRARY ${FREETYPE_LIBRARIES})
+set(FREETYPE_INCLUDE_DIR ${FREETYPE_INCLUDE_DIRS})


### PR DESCRIPTION
From https://github.com/mxe/mxe/pull/1447#issuecomment-235851175, `cegui` expects `INCLUDE_DIR` instead of `INCLUDE_DIRS`.