### PR TITLE
fix for #1462 where qt3d failed to build on JOBS := 4

### DIFF
--- a/src/qt3d.mk
+++ b/src/qt3d.mk
@@ -16,6 +16,6 @@ endef
 
 define $(PKG)_BUILD
     cd '$(1)' && '$(PREFIX)/$(TARGET)/qt5/bin/qmake'
-    $(MAKE) -C '$(1)' -j '$(JOBS)'
+    $(MAKE) -C '$(1)' -j '$(JOBS)' || $(MAKE) -C '$(1)' -j  1
     $(MAKE) -C '$(1)' -j 1 install
 endef


### PR DESCRIPTION
this is fixing the issue #1462 as proposed by @tonytheodore. Testing was good now.
