### PR TITLE
use $(TEST_FILE) instead of $(2).c and other

### DIFF
--- a/plugins/examples/custom-qt-min/overrides.mk
+++ b/plugins/examples/custom-qt-min/overrides.mk
@@ -78,7 +78,7 @@ define qt_BUILD
     ln -sf '$(PREFIX)/$(TARGET)/qt/bin/qmake' '$(PREFIX)/bin/$(TARGET)'-qmake-qt4
 
     mkdir            '$(1)/test-qt'
-    cd               '$(1)/test-qt' && '$(PREFIX)/$(TARGET)/qt/bin/qmake' '$(PWD)/$(2).pro'
+    cd               '$(1)/test-qt' && '$(PREFIX)/$(TARGET)/qt/bin/qmake' '$(PWD)/src/$(PKG)-test.pro'
     $(MAKE)       -C '$(1)/test-qt' -j '$(JOBS)'
     $(INSTALL) -m755 '$(1)/test-qt/release/test-qt.exe' '$(PREFIX)/$(TARGET)/bin/'
 

--- a/src/armadillo.mk
+++ b/src/armadillo.mk
@@ -26,6 +26,6 @@ define $(PKG)_BUILD
 
     '$(TARGET)-g++' \
         -W -Wall -Werror \
-        '$(2).cpp' -o '$(PREFIX)/$(TARGET)/bin/test-armadillo.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-armadillo.exe' \
         -larmadillo -llapack -lblas -lgfortran -lquadmath
 endef

--- a/src/assimp.mk
+++ b/src/assimp.mk
@@ -30,6 +30,6 @@ define $(PKG)_BUILD
 
     '$(TARGET)-gcc' \
         -W -Wall -Werror -ansi -pedantic \
-        '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-assimp.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-assimp.exe' \
         `'$(TARGET)-pkg-config' assimp --cflags --libs`
 endef

--- a/src/aubio.mk
+++ b/src/aubio.mk
@@ -40,6 +40,6 @@ define $(PKG)_BUILD
 
     '$(TARGET)-gcc'                               \
         -W -Wall -Werror -ansi -pedantic          \
-        '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-aubio.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-aubio.exe' \
         `'$(TARGET)-pkg-config' aubio --cflags --libs`
 endef

--- a/src/boost.mk
+++ b/src/boost.mk
@@ -67,7 +67,7 @@ define $(PKG)_BUILD
 
     '$(TARGET)-g++' \
         -W -Wall -Werror -ansi -U__STRICT_ANSI__ -pedantic \
-        '$(2).cpp' -o '$(PREFIX)/$(TARGET)/bin/test-boost.exe' \
+        '$(PWD)/src/$(PKG)-test.cpp' -o '$(PREFIX)/$(TARGET)/bin/test-boost.exe' \
         -DBOOST_THREAD_USE_LIB \
         -lboost_serialization-mt \
         -lboost_thread_win32-mt \

--- a/src/bullet.mk
+++ b/src/bullet.mk
@@ -33,6 +33,6 @@ define $(PKG)_BUILD
 
     '$(TARGET)-g++' \
         -W -Wall -Werror -ansi -pedantic \
-        '$(2).cpp' -o '$(PREFIX)/$(TARGET)/bin/test-$(PKG).exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-$(PKG).exe' \
         `'$(TARGET)-pkg-config' $(PKG) --cflags --libs`
 endef

--- a/src/cegui.mk
+++ b/src/cegui.mk
@@ -53,7 +53,7 @@ define $(PKG)_BUILD
 
     '$(TARGET)-g++' \
         -W -Wall -ansi -pedantic \
-         '$(2).cpp' \
+         '$(TEST_FILE)' \
          `'$(TARGET)-pkg-config' --cflags --libs CEGUI-OPENGL glut freetype2 libpcre` \
          -lCEGUIFreeImageImageCodec -lCEGUIXercesParser -lCEGUIFalagardWRBase \
          `'$(TARGET)-pkg-config' --libs --cflags freeimage xerces-c` \

--- a/src/cfitsio.mk
+++ b/src/cfitsio.mk
@@ -27,7 +27,7 @@ define $(PKG)_BUILD
 
     '$(TARGET)-gcc' \
         -W -Wall -Werror -ansi \
-        '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-cfitsio.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-cfitsio.exe' \
         `'$(TARGET)-pkg-config' cfitsio --cflags --libs`
 endef
 

--- a/src/chipmunk.mk
+++ b/src/chipmunk.mk
@@ -34,6 +34,6 @@ define $(PKG)_BUILD
 
     '$(TARGET)-gcc' \
         -W -Wall -Werror -ansi -pedantic -std=c99 \
-        '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-chipmunk.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-chipmunk.exe' \
         -lchipmunk
 endef

--- a/src/coda.mk
+++ b/src/coda.mk
@@ -33,6 +33,6 @@ define $(PKG)_BUILD
 
     '$(TARGET)-gcc' \
         -std=c99 -W -Wall -Werror -pedantic \
-        '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-coda.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-coda.exe' \
         -lcoda
 endef

--- a/src/coin.mk
+++ b/src/coin.mk
@@ -35,6 +35,6 @@ define $(PKG)_BUILD
 
     '$(TARGET)-g++' \
         -W -Wall -pedantic \
-        '$(2).cpp' -o '$(PREFIX)/$(TARGET)/bin/test-coin.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-coin.exe' \
         `'$(TARGET)-pkg-config' Coin --cflags --libs`
 endef

--- a/src/cryptopp.mk
+++ b/src/cryptopp.mk
@@ -49,6 +49,6 @@ define $(PKG)_BUILD
 
     $(TARGET)-g++ \
         -W -Wall -Werror -ansi -pedantic \
-        '$(2).cpp' -o '$(PREFIX)/$(TARGET)/bin/test-$(PKG).exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-$(PKG).exe' \
         `$(TARGET)-pkg-config cryptopp --cflags --libs`
 endef

--- a/src/curl.mk
+++ b/src/curl.mk
@@ -30,6 +30,6 @@ define $(PKG)_BUILD
 
     '$(TARGET)-gcc' \
         -W -Wall -Werror -ansi -pedantic \
-        '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-curl.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-curl.exe' \
         `'$(TARGET)-pkg-config' libcurl --cflags --libs`
 endef

--- a/src/eigen.mk
+++ b/src/eigen.mk
@@ -25,7 +25,7 @@ define $(PKG)_BUILD
         -Drun_res=1 -Drun_res__TRYRUN_OUTPUT=""
     $(MAKE) -C '$(1)'/build -j '$(JOBS)' install VERBOSE=1
 
-    '$(TARGET)-g++' -W -Wall '$(2).cpp' -o \
+    '$(TARGET)-g++' -W -Wall '$(TEST_FILE)' -o \
         '$(PREFIX)/$(TARGET)/bin/test-$(PKG).exe' \
         `'$(TARGET)-pkg-config' --cflags --libs eigen3`
 endef

--- a/src/file.mk
+++ b/src/file.mk
@@ -39,6 +39,6 @@ define $(PKG)_BUILD
 
     '$(TARGET)-gcc' \
         -W -Wall -Werror -ansi -pedantic \
-        '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-file.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-file.exe' \
         -lmagic -lgnurx -lshlwapi
 endef

--- a/src/fltk.mk
+++ b/src/fltk.mk
@@ -30,6 +30,6 @@ define $(PKG)_BUILD
 
     '$(TARGET)-g++' \
         -W -Wall -Werror -pedantic -ansi \
-        '$(2).cpp' -o '$(PREFIX)/$(TARGET)/bin/test-fltk.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-fltk.exe' \
         `$(TARGET)-fltk-config --cxxflags --ld$(if $(BUILD_STATIC),static)flags`
 endef

--- a/src/freeglut.mk
+++ b/src/freeglut.mk
@@ -29,6 +29,6 @@ define $(PKG)_BUILD
 
     '$(TARGET)-gcc' \
         -W -Wall -Werror -ansi -pedantic \
-        '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-freeglut.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-freeglut.exe' \
         `'$(TARGET)-pkg-config' glut --cflags --libs`
 endef

--- a/src/freeimage.mk
+++ b/src/freeimage.mk
@@ -56,12 +56,12 @@ define $(PKG)_BUILD
 
     '$(TARGET)-gcc' \
         -W -Wall -Werror -ansi -pedantic \
-        '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-freeimage.exe' \
+        '$(PWD)/src/$(PKG)-test.c' -o '$(PREFIX)/$(TARGET)/bin/test-freeimage.exe' \
         `'$(TARGET)-pkg-config' freeimage --cflags --libs`
 
     '$(TARGET)-g++' \
         -W -Wall -Werror -ansi -pedantic \
-        '$(2).cpp' -o '$(PREFIX)/$(TARGET)/bin/test-freeimageplus.exe' \
+        '$(PWD)/src/$(PKG)-test.cpp' -o '$(PREFIX)/$(TARGET)/bin/test-freeimageplus.exe' \
         `'$(TARGET)-pkg-config' freeimageplus --cflags --libs`
 endef
 

--- a/src/ftgl.mk
+++ b/src/ftgl.mk
@@ -35,7 +35,7 @@ define $(PKG)_BUILD
 
     '$(TARGET)-gcc' \
         -W -Wall -Werror -ansi \
-        '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-$(PKG).exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-$(PKG).exe' \
         `'$(TARGET)-pkg-config' freetype2 --cflags --libs` \
         `'$(TARGET)-pkg-config' ftgl --cflags --libs`
 endef

--- a/src/gd.mk
+++ b/src/gd.mk
@@ -29,7 +29,7 @@ define $(PKG)_BUILD
 
     '$(TARGET)-gcc' \
         -W -Wall -Werror -ansi -pedantic \
-        '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-gd.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-gd.exe' \
         `'$(PREFIX)/$(TARGET)/bin/gdlib-config' --cflags --libs`
 endef
 

--- a/src/geos.mk
+++ b/src/geos.mk
@@ -26,6 +26,6 @@ define $(PKG)_BUILD
 
     '$(TARGET)-gcc' \
         -W -Wall -Werror -ansi -pedantic \
-        '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-geos.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-geos.exe' \
         `'$(PREFIX)/bin/$(TARGET)-geos-config' --cflags --clibs`
 endef

--- a/src/glew.mk
+++ b/src/glew.mk
@@ -60,11 +60,11 @@ define $(PKG)_BUILD
     '$(TARGET)-gcc' \
         -W -Wall -Werror -ansi -pedantic \
         `'$(TARGET)-pkg-config' glew --cflags` \
-        '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-glew.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-glew.exe' \
         `'$(TARGET)-pkg-config' glew --libs`
     '$(TARGET)-gcc' \
         -W -Wall -Werror -ansi -pedantic \
         `'$(TARGET)-pkg-config' glewmx --cflags` \
-        '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-glewmx.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-glewmx.exe' \
         `'$(TARGET)-pkg-config' glewmx --libs`
 endef

--- a/src/glfw2.mk
+++ b/src/glfw2.mk
@@ -43,7 +43,7 @@ define $(PKG)_BUILD
     #Test
     '$(TARGET)-gcc' \
         -W -Wall -Werror -ansi -pedantic \
-        '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-glfw2.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-glfw2.exe' \
         `'$(TARGET)-pkg-config' libglfw --cflags --libs`
 endef
 

--- a/src/glfw3.mk
+++ b/src/glfw3.mk
@@ -33,7 +33,7 @@ define $(PKG)_BUILD
 
     '$(TARGET)-gcc' \
         -W -Wall -Werror -ansi -pedantic \
-        '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-glfw3.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-glfw3.exe' \
         `'$(TARGET)-pkg-config' glfw3 --cflags --libs`
 endef
 

--- a/src/glm.mk
+++ b/src/glm.mk
@@ -23,6 +23,6 @@ define $(PKG)_BUILD
 
     '$(TARGET)-g++' \
         -W -Wall -Werror -ansi -pedantic \
-        '$(2).cpp' -o '$(PREFIX)/$(TARGET)/bin/test-glm.exe'
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-glm.exe'
 endef
 

--- a/src/gnutls.mk
+++ b/src/gnutls.mk
@@ -38,6 +38,6 @@ define $(PKG)_BUILD
 
     '$(TARGET)-gcc' \
         -W -Wall -Werror -ansi -pedantic \
-        '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-gnutls.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-gnutls.exe' \
         `'$(TARGET)-pkg-config' gnutls --cflags --libs`
 endef

--- a/src/graphicsmagick.mk
+++ b/src/graphicsmagick.mk
@@ -49,6 +49,6 @@ define $(PKG)_BUILD
 
     '$(TARGET)-g++' \
         -W -Wall -Werror -pedantic -std=gnu++0x \
-        '$(2).cpp' -o '$(PREFIX)/$(TARGET)/bin/test-graphicsmagick.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-graphicsmagick.exe' \
         `'$(TARGET)-pkg-config' GraphicsMagick++ --cflags --libs` -llzma
 endef

--- a/src/gsl.mk
+++ b/src/gsl.mk
@@ -29,7 +29,7 @@ define $(PKG)_BUILD
 
     '$(TARGET)-gcc' \
         -W -Wall -Werror -ansi -pedantic \
-        '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-gsl.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-gsl.exe' \
         -lgsl
 endef
 

--- a/src/gta.mk
+++ b/src/gta.mk
@@ -26,7 +26,7 @@ define $(PKG)_BUILD
 
     '$(TARGET)-gcc' \
         -W -Wall -Werror -ansi -pedantic \
-        '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-gta.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-gta.exe' \
         `'$(TARGET)-pkg-config' gta --cflags --libs`
 endef
 

--- a/src/gtk2.mk
+++ b/src/gtk2.mk
@@ -35,7 +35,7 @@ define $(PKG)_BUILD
 
     '$(TARGET)-gcc' \
         -W -Wall -Werror -ansi \
-        '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-gtk2.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-gtk2.exe' \
         `'$(TARGET)-pkg-config' gtk+-2.0 gmodule-2.0 --cflags --libs`
 endef
 

--- a/src/gtk3.mk
+++ b/src/gtk3.mk
@@ -34,7 +34,7 @@ define $(PKG)_BUILD
 
     '$(TARGET)-gcc' \
         -W -Wall -Werror -ansi \
-        '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-gtk3.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-gtk3.exe' \
         `'$(TARGET)-pkg-config' gtk+-3.0 --cflags --libs`
 endef
 

--- a/src/gtkglext.mk
+++ b/src/gtkglext.mk
@@ -40,7 +40,7 @@ define $(PKG)_BUILD
 
     '$(TARGET)-gcc' \
         -W -Wall -ansi -pedantic \
-        '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-gtkglext.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-gtkglext.exe' \
         `'$(TARGET)-pkg-config' gtkglext-1.0 --cflags --libs`
 endef
 

--- a/src/gtkglextmm.mk
+++ b/src/gtkglextmm.mk
@@ -32,7 +32,7 @@ define $(PKG)_BUILD
 
     '$(TARGET)-g++' \
         -W -Wall -Werror -pedantic -std=c++0x \
-        '$(2).cpp' -o '$(PREFIX)/$(TARGET)/bin/test-gtkglextmm.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-gtkglextmm.exe' \
         `'$(TARGET)-pkg-config' gtkglextmm-1.2 --cflags --libs`
 endef
 

--- a/src/gtkimageview.mk
+++ b/src/gtkimageview.mk
@@ -38,7 +38,7 @@ define $(PKG)_BUILD
 
     '$(TARGET)-gcc' \
         -W -Wall -Werror -ansi \
-        '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-gtkimageview.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-gtkimageview.exe' \
         `'$(TARGET)-pkg-config' gtkimageview --cflags --libs`
 endef
 

--- a/src/gtkmm2.mk
+++ b/src/gtkmm2.mk
@@ -31,7 +31,7 @@ define $(PKG)_BUILD
 
     '$(TARGET)-g++' \
         -W -Wall -Werror -pedantic -std=c++0x \
-        '$(2).cpp' -o '$(PREFIX)/$(TARGET)/bin/test-gtkmm2.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-gtkmm2.exe' \
         `'$(TARGET)-pkg-config' gtkmm-2.4 --cflags --libs`
 endef
 

--- a/src/gtkmm3.mk
+++ b/src/gtkmm3.mk
@@ -30,7 +30,7 @@ define $(PKG)_BUILD
 
     '$(TARGET)-g++' \
         -W -Wall -Werror -pedantic -std=c++0x \
-        '$(2).cpp' -o '$(PREFIX)/$(TARGET)/bin/test-gtkmm3.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-gtkmm3.exe' \
         `'$(TARGET)-pkg-config' gtkmm-3.0 --cflags --libs`
 endef
 

--- a/src/guile.mk
+++ b/src/guile.mk
@@ -37,7 +37,7 @@ define $(PKG)_BUILD
 
     '$(TARGET)-gcc' \
         -W -Wall -Werror -ansi -pedantic \
-        '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-guile.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-guile.exe' \
         `'$(TARGET)-pkg-config' guile-$(call SHORT_PKG_VERSION,$(PKG)) --cflags --libs` \
         -DGUILE_MAJOR_MINOR=\"$(call SHORT_PKG_VERSION,$(PKG))\"
 endef

--- a/src/hdf-eos2.mk
+++ b/src/hdf-eos2.mk
@@ -29,7 +29,7 @@ define $(PKG)_BUILD
 
     '$(TARGET)-gcc' \
         -std=c99 -W -Wall -Werror -pedantic \
-        '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-$(PKG).exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-$(PKG).exe' \
         -lhdfeos -lmfhdf -ldf -lz -ljpeg -lportablexdr -lws2_32
 endef
 

--- a/src/hdf-eos5.mk
+++ b/src/hdf-eos5.mk
@@ -27,7 +27,7 @@ define $(PKG)_BUILD
 
     '$(TARGET)-gcc' \
         -std=c99 -W -Wall -Werror -pedantic \
-        '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-$(PKG).exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-$(PKG).exe' \
         -lhe5_hdfeos -lhdf5_hl -lhdf5 -lz
 endef
 

--- a/src/hdf5.mk
+++ b/src/hdf5.mk
@@ -67,7 +67,7 @@ define $(PKG)_BUILD
     ## test hdf5
     '$(TARGET)-g++' \
         -W -Wall -Werror -ansi -pedantic \
-        '$(2).cpp' -o '$(PREFIX)/$(TARGET)/bin/test-hdf5.exe' \
+        '$(PWD)/src/$(PKG)-test.cpp' -o '$(PREFIX)/$(TARGET)/bin/test-hdf5.exe' \
         -lhdf5_hl -lhdf5 -lz
 
     # test cmake can find hdf5

--- a/src/hunspell.mk
+++ b/src/hunspell.mk
@@ -28,6 +28,6 @@ define $(PKG)_BUILD
     # Test
     '$(TARGET)-g++' \
         -W -Wall -Werror -std=c++0x -pedantic \
-        '$(2).cpp' -o '$(PREFIX)/$(TARGET)/bin/test-hunspell.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-hunspell.exe' \
         `'$(TARGET)-pkg-config' hunspell --cflags --libs`
 endef

--- a/src/imagemagick.mk
+++ b/src/imagemagick.mk
@@ -33,6 +33,6 @@ define $(PKG)_BUILD
 
     '$(1)'/libtool --mode=link --tag=CXX \
         '$(TARGET)-g++' -Wall -Wextra -std=gnu++0x \
-        '$(2).cpp' -o '$(PREFIX)/$(TARGET)/bin/test-imagemagick.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-imagemagick.exe' \
         `'$(TARGET)-pkg-config' ImageMagick++ --cflags --libs`
 endef

--- a/src/jpeg.mk
+++ b/src/jpeg.mk
@@ -31,6 +31,6 @@ define $(PKG)_BUILD
 
     '$(TARGET)-gcc' \
         -W -Wall -Werror -ansi -pedantic \
-        '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-jpeg.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-jpeg.exe' \
         `'$(TARGET)-pkg-config' jpeg --libs`
 endef

--- a/src/json-c.mk
+++ b/src/json-c.mk
@@ -27,7 +27,7 @@ define $(PKG)_BUILD
 
     '$(TARGET)-gcc' \
         -W -Wall -Werror -ansi -pedantic \
-        '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-json-c.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-json-c.exe' \
         `'$(TARGET)-pkg-config' json-c --cflags --libs`
 endef
 

--- a/src/lapack.mk
+++ b/src/lapack.mk
@@ -29,11 +29,11 @@ define $(PKG)_BUILD
 
     '$(TARGET)-gfortran' \
         -W -Wall -Werror -pedantic \
-        '$(2).f' -o '$(PREFIX)/$(TARGET)/bin/test-lapack.exe' \
+        '$(PWD)/src/$(PKG)-test.f' -o '$(PREFIX)/$(TARGET)/bin/test-lapack.exe' \
         -llapack
 
     '$(TARGET)-gcc' \
         -W -Wall -Werror -pedantic \
-        '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-lapacke.exe' \
+        '$(PWD)/src/$(PKG)-test.c' -o '$(PREFIX)/$(TARGET)/bin/test-lapacke.exe' \
         -llapacke -llapack -lcblas -lblas -lgfortran -lquadmath
 endef

--- a/src/lensfun.mk
+++ b/src/lensfun.mk
@@ -28,6 +28,6 @@ define $(PKG)_BUILD
     # Don't use `-ansi`, as lensfun uses C++-style `//` comments.
     '$(TARGET)-gcc' \
         -W -Wall -Werror \
-        '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-lensfun.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-lensfun.exe' \
         `'$(TARGET)-pkg-config' lensfun glib-2.0 --cflags --libs`
 endef

--- a/src/libaacs.mk
+++ b/src/libaacs.mk
@@ -28,7 +28,7 @@ define $(PKG)_BUILD
 
     '$(TARGET)-gcc' \
         -W -Wall -Werror -std=c99 -pedantic \
-        '$(2).c' \
+        '$(TEST_FILE)' \
         -o '$(PREFIX)/$(TARGET)/bin/test-libaacs.exe' \
         `'$(TARGET)-pkg-config' libaacs --cflags --libs`
 endef

--- a/src/libarchive.mk
+++ b/src/libarchive.mk
@@ -32,6 +32,6 @@ define $(PKG)_BUILD
 
     '$(TARGET)-gcc' \
         -W -Wall -Werror -ansi -pedantic \
-        '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-libarchive.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-libarchive.exe' \
         `'$(TARGET)-pkg-config' --libs-only-l libarchive`
 endef

--- a/src/libass.mk
+++ b/src/libass.mk
@@ -32,6 +32,6 @@ define $(PKG)_BUILD
 
     '$(TARGET)-gcc' \
         -W -Wall -Werror -ansi -pedantic \
-        '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-libass.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-libass.exe' \
         `'$(TARGET)-pkg-config' libass --cflags --libs`
 endef

--- a/src/libechonest.mk
+++ b/src/libechonest.mk
@@ -31,7 +31,7 @@ define $(PKG)_BUILD
 
     '$(TARGET)-g++' \
         -W -Wall -Werror -ansi -pedantic \
-        '$(2).cpp' -o '$(PREFIX)/$(TARGET)/bin/test-$(PKG).exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-$(PKG).exe' \
         `'$(TARGET)-pkg-config' libechonest --cflags --libs`
 endef
 

--- a/src/libffi.mk
+++ b/src/libffi.mk
@@ -26,6 +26,6 @@ define $(PKG)_BUILD
 
     '$(TARGET)-gcc' \
         -W -Wall -Werror -std=c99 -pedantic \
-        '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-libffi.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-libffi.exe' \
         `'$(TARGET)-pkg-config' libffi --cflags --libs`
 endef

--- a/src/libftdi1.mk
+++ b/src/libftdi1.mk
@@ -32,6 +32,6 @@ define $(PKG)_BUILD
 
     '$(TARGET)-gcc' \
         -W -Wall -Wextra -Werror \
-        '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-libftdi1.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-libftdi1.exe' \
         `'$(TARGET)-pkg-config' libftdi1 --cflags --libs`
 endef

--- a/src/libgcrypt.mk
+++ b/src/libgcrypt.mk
@@ -30,7 +30,7 @@ define $(PKG)_MAKE
 
     '$(TARGET)-gcc' \
         -W -Wall -Werror -ansi -pedantic \
-        '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-libgcrypt.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-libgcrypt.exe' \
         `$(TARGET)-libgcrypt-config --cflags --libs`
 endef
 

--- a/src/libgsasl.mk
+++ b/src/libgsasl.mk
@@ -29,6 +29,6 @@ define $(PKG)_BUILD
 
     '$(TARGET)-gcc' \
         -W -Wall -Werror -ansi -pedantic \
-        '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-libgsasl.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-libgsasl.exe' \
         `'$(TARGET)-pkg-config' libgsasl --cflags --libs`
 endef

--- a/src/libiberty.mk
+++ b/src/libiberty.mk
@@ -27,7 +27,7 @@ define $(PKG)_BUILD
 
     '$(TARGET)-gcc' \
         -W -Wall -Werror -ansi -pedantic \
-        '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-libiberty.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-libiberty.exe' \
         -I$(PREFIX)/$(TARGET)/include/libiberty -liberty
 endef
 

--- a/src/libical.mk
+++ b/src/libical.mk
@@ -25,6 +25,6 @@ define $(PKG)_BUILD
 
     '$(TARGET)-gcc' \
         -W -Wall -Werror -ansi -pedantic \
-        '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-libical.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-libical.exe' \
         `'$(TARGET)-pkg-config' libical --cflags --libs`
 endef

--- a/src/libidn.mk
+++ b/src/libidn.mk
@@ -27,6 +27,6 @@ define $(PKG)_BUILD
 
     '$(TARGET)-gcc' \
         -W -Wall -Werror -ansi -pedantic \
-        '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-libidn.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-libidn.exe' \
         `'$(TARGET)-pkg-config' libidn --cflags --libs`
 endef

--- a/src/libircclient.mk
+++ b/src/libircclient.mk
@@ -37,7 +37,7 @@ define $(PKG)_BUILD
 
     '$(TARGET)-g++' \
         -W -Wall -Werror -ansi -pedantic \
-        '$(2).cpp' -o '$(PREFIX)/$(TARGET)/bin/test-libircclient.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-libircclient.exe' \
         -lircclient -lws2_32
 endef
 

--- a/src/liblaxjson.mk
+++ b/src/liblaxjson.mk
@@ -31,6 +31,6 @@ define $(PKG)_BUILD
 
     '$(TARGET)-gcc' \
         -W -Wall -Werror -ansi -pedantic -std=c99 \
-        '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-liblaxjson.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-liblaxjson.exe' \
         -llaxjson
 endef

--- a/src/libmicrohttpd.mk
+++ b/src/libmicrohttpd.mk
@@ -33,7 +33,7 @@ define $(PKG)_BUILD
 
     '$(TARGET)-gcc' \
         -W -Wall -Werror -std=c99 -pedantic -Wno-error=unused-parameter \
-        '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-libmicrohttpd.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-libmicrohttpd.exe' \
         `'$(TARGET)-pkg-config' --cflags --libs libmicrohttpd`
 endef
 

--- a/src/libmikmod.mk
+++ b/src/libmikmod.mk
@@ -27,6 +27,6 @@ define $(PKG)_BUILD
 
     '$(TARGET)-gcc' \
         -W -Wall -Werror -std=c99 -pedantic \
-        '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-libmikmod.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-libmikmod.exe' \
         `'$(PREFIX)/$(TARGET)/bin/libmikmod-config' --cflags --libs`
 endef

--- a/src/libmodplug.mk
+++ b/src/libmodplug.mk
@@ -23,6 +23,6 @@ define $(PKG)_BUILD
 
     '$(TARGET)-gcc' \
         -W -Wall -ansi -pedantic \
-        '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-libmodplug.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-libmodplug.exe' \
         `'$(TARGET)-pkg-config' libmodplug --cflags --libs`
 endef

--- a/src/libmysqlclient.mk
+++ b/src/libmysqlclient.mk
@@ -53,6 +53,6 @@ define $(PKG)_BUILD
     # build test with mysql_config
     '$(TARGET)-g++' \
         -W -Wall -Werror -ansi -pedantic \
-        '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-$(PKG).exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-$(PKG).exe' \
         `'$(PREFIX)/$(TARGET)/bin/mysql_config' --cflags --libs`
 endef

--- a/src/liboauth.mk
+++ b/src/liboauth.mk
@@ -25,6 +25,6 @@ define $(PKG)_BUILD
 
     '$(TARGET)-gcc' \
         -W -Wall -Werror -ansi -pedantic \
-        '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-liboauth.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-liboauth.exe' \
         `'$(TARGET)-pkg-config' oauth --cflags --libs`
 endef

--- a/src/libpng.mk
+++ b/src/libpng.mk
@@ -29,6 +29,6 @@ define $(PKG)_BUILD
 
     '$(TARGET)-gcc' \
         -W -Wall -Werror -std=c99 -pedantic \
-        '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-libpng.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-libpng.exe' \
         `'$(PREFIX)/$(TARGET)/bin/libpng-config' --static --cflags --libs`
 endef

--- a/src/librsvg.mk
+++ b/src/librsvg.mk
@@ -27,6 +27,6 @@ define $(PKG)_BUILD
     '$(TARGET)-gcc' \
         -mwindows -W -Wall -Werror -Wno-error=deprecated-declarations \
         -std=c99 -pedantic \
-        '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-librsvg.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-librsvg.exe' \
         `'$(TARGET)-pkg-config' librsvg-2.0 --cflags --libs`
 endef

--- a/src/libsoup.mk
+++ b/src/libsoup.mk
@@ -29,6 +29,6 @@ define $(PKG)_BUILD
 
     $(TARGET)-gcc \
         -W -Wall -Werror -ansi \
-        '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-$(PKG).exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-$(PKG).exe' \
         `$(TARGET)-pkg-config $(PKG)-$($(PKG)_APIVER) --cflags --libs`
 endef

--- a/src/libssh2.mk
+++ b/src/libssh2.mk
@@ -29,6 +29,6 @@ define $(PKG)_BUILD
 
     '$(TARGET)-gcc' \
         -W -Wall -Werror -ansi -pedantic \
-        '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-libssh2.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-libssh2.exe' \
         `'$(TARGET)-pkg-config' --cflags --libs libssh2`
 endef

--- a/src/libusb1.mk
+++ b/src/libusb1.mk
@@ -25,6 +25,6 @@ define $(PKG)_BUILD
 
     '$(TARGET)-gcc' \
         -W -Wall -Wextra -Werror \
-        '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-libusb1.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-libusb1.exe' \
         `'$(TARGET)-pkg-config' libusb-1.0 --cflags --libs`
 endef

--- a/src/libuv.mk
+++ b/src/libuv.mk
@@ -23,6 +23,6 @@ define $(PKG)_BUILD
 
     '$(TARGET)-gcc' \
         -W -Wall -Werror -pedantic \
-        '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-$(PKG).exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-$(PKG).exe' \
         `'$(TARGET)-pkg-config' $(PKG) --libs`
 endef

--- a/src/libzip.mk
+++ b/src/libzip.mk
@@ -23,6 +23,6 @@ define $(PKG)_BUILD
 
     '$(TARGET)-gcc' \
         -W -Wall -Werror -ansi -pedantic \
-        '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-libzip.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-libzip.exe' \
         `'$(TARGET)-pkg-config' libzip --cflags --libs`
 endef

--- a/src/log4cxx.mk
+++ b/src/log4cxx.mk
@@ -30,7 +30,7 @@ define $(PKG)_BUILD
 
     '$(TARGET)-g++' \
         -W -Wall -Werror -ansi -pedantic \
-        '$(2).cpp' -o '$(PREFIX)/$(TARGET)/bin/test-log4cxx.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-log4cxx.exe' \
         `$(TARGET)-pkg-config liblog4cxx --libs`
 endef
 

--- a/src/lua.mk
+++ b/src/lua.mk
@@ -34,7 +34,7 @@ define $(PKG)_BUILD_COMMON
 
     '$(TARGET)-gcc' \
         -W -Wall -Werror -ansi -pedantic \
-        '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-lua.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-lua.exe' \
         `$(TARGET)-pkg-config --libs lua`
 endef
 

--- a/src/luabind.mk
+++ b/src/luabind.mk
@@ -26,7 +26,7 @@ define $(PKG)_BUILD
 
     '$(TARGET)-g++' \
         -W -Wall \
-        '$(2).cpp' -o '$(PREFIX)/$(TARGET)/bin/test-luabind.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-luabind.exe' \
         -llua -lluabind
 endef
 

--- a/src/muparserx.mk
+++ b/src/muparserx.mk
@@ -21,6 +21,6 @@ define $(PKG)_BUILD
 
     '$(TARGET)-g++' \
         -W -Wall -Werror -ansi -pedantic \
-        '$(2).cpp' -o '$(PREFIX)/$(TARGET)/bin/test-$(PKG).exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-$(PKG).exe' \
         `'$(TARGET)-pkg-config' $(PKG) --cflags --libs`
 endef

--- a/src/mxml.mk
+++ b/src/mxml.mk
@@ -31,7 +31,7 @@ define $(PKG)_BUILD
 
     '$(TARGET)-gcc' \
         -W -Wall -Werror -ansi -pedantic \
-        '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-mxml.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-mxml.exe' \
         `'$(TARGET)-pkg-config' mxml --cflags --libs`
 endef
 

--- a/src/ocaml-cairo.mk
+++ b/src/ocaml-cairo.mk
@@ -30,7 +30,7 @@ define $(PKG)_BUILD
         -package lablgtk2.auto-init \
         -package cairo.lablgtk2 \
         -o '$(PREFIX)/$(TARGET)/bin/test-$(PKG).exe' \
-        < '$(2).ml'
+        < '$(TEST_FILE)'
 endef
 
 $(PKG)_BUILD_x86_64-w64-mingw32 =

--- a/src/ocaml-camlimages.mk
+++ b/src/ocaml-camlimages.mk
@@ -34,7 +34,7 @@ define $(PKG)_BUILD
     '$(TARGET)-ocamlfind' opt -linkpkg \
         -package camlimages \
         -o '$(PREFIX)/$(TARGET)/bin/test-$(PKG).exe' \
-        < '$(2).ml'
+        < '$(TEST_FILE)'
 endef
 
 $(PKG)_BUILD_x86_64-w64-mingw32 =

--- a/src/ocaml-core.mk
+++ b/src/ocaml-core.mk
@@ -113,10 +113,10 @@ define $(PKG)_BUILD
     done
 
     # test ocamlopt
-    cp '$(2).ml' '$(1)/test.ml'
+    cp '$(TEST_FILE)' '$(1)/test.ml'
     cd '$(1)' && '$(TARGET)-ocamlopt' test.ml
     # test ocamlbuild from package ocaml-native, now that ocamlopt works
-    mkdir '$(1)/tmp' && cp '$(2).ml' '$(1)/tmp/test.ml'
+    mkdir '$(1)/tmp' && cp '$(TEST_FILE)' '$(1)/tmp/test.ml'
     cd '$(1)/tmp' && $(TARGET)-ocamlbuild test.native
 endef
 

--- a/src/ocaml-findlib.mk
+++ b/src/ocaml-findlib.mk
@@ -52,7 +52,7 @@ define $(PKG)_BUILD
     # test
     '$(TARGET)-ocamlfind' opt \
         -o '$(PREFIX)/$(TARGET)/bin/test-$(PKG).exe' \
-        < '$(2).ml'
+        < '$(TEST_FILE)'
 
 endef
 

--- a/src/ocaml-lablgtk2.mk
+++ b/src/ocaml-lablgtk2.mk
@@ -30,7 +30,7 @@ define $(PKG)_BUILD
     '$(TARGET)-ocamlfind' opt -linkpkg \
         -package lablgtk2.gl \
         -o '$(PREFIX)/$(TARGET)/bin/test-$(PKG).exe' \
-        < '$(2).ml'
+        < '$(TEST_FILE)'
 endef
 
 $(PKG)_BUILD_x86_64-w64-mingw32 =

--- a/src/openal.mk
+++ b/src/openal.mk
@@ -27,6 +27,6 @@ define $(PKG)_BUILD
 
     '$(TARGET)-gcc' \
         -W -Wall -Werror -ansi -pedantic \
-        '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-openal.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-openal.exe' \
         `'$(TARGET)-pkg-config' openal --cflags --libs`
 endef

--- a/src/openexr.mk
+++ b/src/openexr.mk
@@ -62,6 +62,6 @@ define $(PKG)_BUILD
 
     '$(TARGET)-g++' \
         -Wall -Wextra -std=gnu++0x \
-        '$(2).cpp' -o '$(PREFIX)/$(TARGET)/bin/test-openexr.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-openexr.exe' \
         `'$(TARGET)-pkg-config' OpenEXR --cflags --libs`
 endef

--- a/src/pfstools.mk
+++ b/src/pfstools.mk
@@ -38,7 +38,7 @@ define $(PKG)_BUILD
 
     '$(TARGET)-g++' \
         -Wall -Wextra -Werror \
-        '$(2).cpp' -o '$(PREFIX)/$(TARGET)/bin/test-pfstools.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-pfstools.exe' \
         `'$(TARGET)-pkg-config' pfs --cflags --libs`
 endef
 

--- a/src/physfs.mk
+++ b/src/physfs.mk
@@ -31,7 +31,7 @@ define $(PKG)_BUILD
 
     '$(TARGET)-gcc' \
         -W -Wall -Werror -ansi -pedantic -std=c99 \
-        '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-physfs.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-physfs.exe' \
         -lphysfs -lz
 endef
 

--- a/src/plibc.mk
+++ b/src/plibc.mk
@@ -35,7 +35,7 @@ define $(PKG)_BUILD
 
     '$(TARGET)-gcc' \
         -W -Wall -Werror -std=c99 -pedantic \
-        '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-plibc.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-plibc.exe' \
         `'$(TARGET)-pkg-config' --cflags --libs plibc`
 endef
 

--- a/src/poco.mk
+++ b/src/poco.mk
@@ -32,7 +32,7 @@ define $(PKG)_BUILD
 
     '$(TARGET)-g++' \
         -W -Wall -Werror -ansi -pedantic -DPOCO_STATIC=1 \
-        '$(2).cpp' -o '$(PREFIX)/$(TARGET)/bin/test-poco.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-poco.exe' \
         -lPocoFoundation
 endef
 

--- a/src/poppler.mk
+++ b/src/poppler.mk
@@ -61,6 +61,6 @@ define $(PKG)_BUILD
     # Test program
     '$(TARGET)-g++' \
         -W -Wall -Werror -ansi -pedantic \
-        '$(2).cxx' -o '$(PREFIX)/$(TARGET)/bin/test-poppler.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-poppler.exe' \
         `'$(TARGET)-pkg-config' poppler poppler-cpp --cflags --libs`
 endef

--- a/src/portaudio.mk
+++ b/src/portaudio.mk
@@ -36,6 +36,6 @@ define $(PKG)_BUILD
 
     '$(TARGET)-gcc' \
         -W -Wall -Werror -ansi -pedantic \
-        '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-portaudio.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-portaudio.exe' \
         `'$(TARGET)-pkg-config' portaudio-2.0 --cflags --libs`
 endef

--- a/src/portmidi.mk
+++ b/src/portmidi.mk
@@ -42,6 +42,6 @@ define $(PKG)_BUILD
 
     '$(TARGET)-gcc' \
         -W -Wall -Werror -ansi -pedantic \
-        '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-portmidi.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-portmidi.exe' \
         -lportmidi -lwinmm
 endef

--- a/src/protobuf.mk
+++ b/src/protobuf.mk
@@ -31,6 +31,6 @@ define $(PKG)_BUILD
 
     '$(TARGET)-g++' \
         -W -Wall -Werror -ansi -pedantic \
-        '$(2).cpp' -o '$(PREFIX)/$(TARGET)/bin/test-protobuf.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-protobuf.exe' \
         `'$(TARGET)-pkg-config' protobuf --cflags --libs`
 endef

--- a/src/qdbm.mk
+++ b/src/qdbm.mk
@@ -44,7 +44,7 @@ define $(PKG)_BUILD
 
     '$(TARGET)-gcc' \
         -W -Wall -Werror -ansi -pedantic \
-        '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-qdbm.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-qdbm.exe' \
         `'$(TARGET)-pkg-config' qdbm --cflags --libs`
 endef
 

--- a/src/qjson.mk
+++ b/src/qjson.mk
@@ -25,6 +25,6 @@ define $(PKG)_BUILD
 
     '$(TARGET)-g++' \
         -W -Wall -Werror -ansi -pedantic \
-        '$(2).cpp' -o '$(PREFIX)/$(TARGET)/bin/test-$(PKG).exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-$(PKG).exe' \
         `'$(TARGET)-pkg-config' QJson --cflags --libs`
 endef

--- a/src/qscintilla2.mk
+++ b/src/qscintilla2.mk
@@ -26,6 +26,6 @@ define $(PKG)_BUILD
     '$(TARGET)-g++' \
         -W -Wall -Werror -std=c++0x -pedantic \
         `'$(TARGET)-pkg-config' Qt5Widgets --cflags` \
-        '$(2).cpp' -o '$(PREFIX)/$(TARGET)/bin/test-qscintilla2.exe' -lqscintilla2 \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-qscintilla2.exe' -lqscintilla2 \
         `'$(TARGET)-pkg-config' Qt5Widgets --libs`
 endef

--- a/src/qt.mk
+++ b/src/qt.mk
@@ -103,7 +103,7 @@ define $(PKG)_BUILD
     $(MAKE) -C '$(1)/tools/qdbus' -j '$(JOBS)' install
 
     mkdir            '$(1)/test-qt'
-    cd               '$(1)/test-qt' && '$(PREFIX)/$(TARGET)/qt/bin/qmake' '$(PWD)/$(2).pro'
+    cd               '$(1)/test-qt' && '$(PREFIX)/$(TARGET)/qt/bin/qmake' '$(PWD)/src/$(PKG)-test.pro'
     $(MAKE)       -C '$(1)/test-qt' -j '$(JOBS)'
     $(INSTALL) -m755 '$(1)/test-qt/release/test-qt.exe' '$(PREFIX)/$(TARGET)/bin/'
 

--- a/src/qtsparkle_qt4.mk
+++ b/src/qtsparkle_qt4.mk
@@ -38,6 +38,6 @@ define $(PKG)_BUILD
 
     $(TARGET)-g++ \
         -W -Wall -Werror -ansi -pedantic \
-        '$(2).cpp' -o '$(PREFIX)/$(TARGET)/bin/test-$(PKG).exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-$(PKG).exe' \
         `$(TARGET)-pkg-config $(PKG) --cflags --libs`
 endef

--- a/src/rucksack.mk
+++ b/src/rucksack.mk
@@ -32,7 +32,7 @@ define $(PKG)_BUILD
 
     '$(TARGET)-gcc' \
         -W -Wall -Werror -ansi -pedantic -std=c99 \
-        '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-rucksack.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-rucksack.exe' \
         -lrucksack -llaxjson \
         `'$(TARGET)-pkg-config' freeimage --cflags --libs`
 endef

--- a/src/sdl.mk
+++ b/src/sdl.mk
@@ -31,7 +31,7 @@ define $(PKG)_BUILD
 
     '$(TARGET)-gcc' \
         -W -Wall -Werror -ansi -pedantic \
-        '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-sdl.exe' \
+        '$(PWD)/src/$(PKG)-test.c' -o '$(PREFIX)/$(TARGET)/bin/test-sdl.exe' \
         `'$(TARGET)-pkg-config' sdl --cflags --libs`
 
     # test cmake

--- a/src/sdl2.mk
+++ b/src/sdl2.mk
@@ -30,7 +30,7 @@ define $(PKG)_BUILD
 
     '$(TARGET)-gcc' \
         -W -Wall -Werror -ansi -pedantic \
-        '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-sdl2.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-sdl2.exe' \
         `'$(TARGET)-pkg-config' sdl2 --cflags --libs`
 
 endef

--- a/src/sdl2_gfx.mk
+++ b/src/sdl2_gfx.mk
@@ -27,6 +27,6 @@ define $(PKG)_BUILD
 
     '$(TARGET)-gcc' \
         -W -Wall -Werror -ansi -pedantic \
-        '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-sdl2_gfx.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-sdl2_gfx.exe' \
         `'$(TARGET)-pkg-config' SDL2_gfx --cflags --libs`
 endef

--- a/src/sdl2_net.mk
+++ b/src/sdl2_net.mk
@@ -26,7 +26,7 @@ define $(PKG)_BUILD
 
     '$(TARGET)-gcc' \
         -W -Wall -Werror -std=c99 -pedantic \
-        '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-sdl2_net.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-sdl2_net.exe' \
         `'$(TARGET)-pkg-config' SDL2_net --cflags --libs` \
         -lws2_32 -liphlpapi
 endef

--- a/src/sdl_gfx.mk
+++ b/src/sdl_gfx.mk
@@ -25,6 +25,6 @@ define $(PKG)_BUILD
 
     '$(TARGET)-gcc' \
         -W -Wall -Werror -ansi -pedantic \
-        '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-sdl_gfx.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-sdl_gfx.exe' \
         `'$(TARGET)-pkg-config' SDL_gfx --cflags --libs`
 endef

--- a/src/sdl_image.mk
+++ b/src/sdl_image.mk
@@ -36,12 +36,12 @@ define $(PKG)_BUILD
 
     '$(TARGET)-gcc' \
         -W -Wall -Werror -ansi -pedantic \
-        '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-sdl_image.exe' \
+        '$(PWD)/src/$(PKG)-test.c' -o '$(PREFIX)/$(TARGET)/bin/test-sdl_image.exe' \
         `'$(TARGET)-pkg-config' SDL_image --cflags --libs`
 
     mkdir -p '$(1)/cmake-build-test'
-    cp '$(2)-CMakeLists.txt' '$(1)/cmake-build-test/CMakeLists.txt'
-    cp '$(2).c' '$(1)/cmake-build-test/'
+    cp '$(PWD)/src/$(PKG)-test-CMakeLists.txt' '$(1)/cmake-build-test/CMakeLists.txt'
+    cp '$(PWD)/src/$(PKG)-test.c' '$(1)/cmake-build-test/'
     cd '$(1)/cmake-build-test' && cmake . \
         -DCMAKE_TOOLCHAIN_FILE='$(CMAKE_TOOLCHAIN_FILE)'
     $(MAKE) -C '$(1)/cmake-build-test' -j '$(JOBS)'

--- a/src/sdl_mixer.mk
+++ b/src/sdl_mixer.mk
@@ -49,7 +49,7 @@ define $(PKG)_BUILD
 
     '$(TARGET)-gcc' \
         -W -Wall -Werror -ansi -pedantic \
-        '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-sdl_mixer.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-sdl_mixer.exe' \
         `'$(TARGET)-pkg-config' SDL_mixer --cflags --libs`
 endef
 

--- a/src/sdl_net.mk
+++ b/src/sdl_net.mk
@@ -29,7 +29,7 @@ define $(PKG)_BUILD
 
     '$(TARGET)-gcc' \
         -W -Wall -Werror -ansi -pedantic \
-        '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-sdl_net.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-sdl_net.exe' \
         `'$(TARGET)-pkg-config' SDL_net --cflags --libs`
 endef
 

--- a/src/sdl_rwhttp.mk
+++ b/src/sdl_rwhttp.mk
@@ -27,7 +27,7 @@ define $(PKG)_BUILD
 
 #    '$(TARGET)-gcc' \
 #        -W -Wall -Werror -ansi -pedantic \
-#        '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-sdl_rwhttp.exe' \
+#        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-sdl_rwhttp.exe' \
 #        `'$(TARGET)-pkg-config' SDL_rwhttp --cflags --libs`
 endef
 

--- a/src/sdl_sound.mk
+++ b/src/sdl_sound.mk
@@ -55,12 +55,12 @@ define $(PKG)_BUILD
 
     '$(TARGET)-gcc' \
         -W -Wall -Werror -std=c99 -pedantic \
-        '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-sdl_sound.exe' \
+        '$(PWD)/src/$(PKG)-test.c' -o '$(PREFIX)/$(TARGET)/bin/test-sdl_sound.exe' \
         `'$(TARGET)-pkg-config' SDL_sound --cflags --libs`
 
     mkdir -p '$(1)/cmake-build-test'
-    cp '$(2)-CMakeLists.txt' '$(1)/cmake-build-test/CMakeLists.txt'
-    cp '$(2).c' '$(1)/cmake-build-test/'
+    cp '$(PWD)/src/$(PKG)-test-CMakeLists.txt' '$(1)/cmake-build-test/CMakeLists.txt'
+    cp '$(PWD)/src/$(PKG)-test.c' '$(1)/cmake-build-test/'
     cd '$(1)/cmake-build-test' && cmake . \
         -DCMAKE_TOOLCHAIN_FILE='$(CMAKE_TOOLCHAIN_FILE)'
     $(MAKE) -C '$(1)/cmake-build-test' -j '$(JOBS)'

--- a/src/sfml.mk
+++ b/src/sfml.mk
@@ -41,7 +41,7 @@ define $(PKG)_BUILD
 
     '$(TARGET)-g++' \
         -W -Wall -Werror -ansi -pedantic \
-        '$(2).cpp' -o '$(PREFIX)/$(TARGET)/bin/test-sfml.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-sfml.exe' \
         `$(TARGET)-pkg-config --cflags --libs sfml`
 endef
 

--- a/src/smpeg.mk
+++ b/src/smpeg.mk
@@ -34,7 +34,7 @@ define $(PKG)_BUILD
 
     '$(TARGET)-gcc' \
         -W -Wall -Werror -std=c99 -pedantic \
-        '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-smpeg.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-smpeg.exe' \
         `'$(PREFIX)/$(TARGET)/bin/smpeg-config' --cflags --libs`
 endef
 

--- a/src/sox.mk
+++ b/src/sox.mk
@@ -61,7 +61,7 @@ define $(PKG)_BUILD
 
     '$(TARGET)-gcc' \
         -W -Wall -Werror -ansi -pedantic \
-        '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-sox.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-sox.exe' \
         `'$(TARGET)-pkg-config' sox --cflags --libs`
 endef
 

--- a/src/subversion.mk
+++ b/src/subversion.mk
@@ -43,7 +43,7 @@ define $(PKG)_BUILD
         install
     '$(TARGET)-gcc' \
        -mwindows -W -Wall -Werror -pedantic \
-       '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-subversion.exe' \
+       '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-subversion.exe' \
        `'$(TARGET)-pkg-config' libsvn_client --cflags --libs` -lole32
 endef
 

--- a/src/vidstab.mk
+++ b/src/vidstab.mk
@@ -26,6 +26,6 @@ define $(PKG)_BUILD
 
     '$(TARGET)-gcc' \
         -W -Wall -Werror -pedantic \
-        '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-vidstab.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-vidstab.exe' \
         `'$(TARGET)-pkg-config' --static --cflags --libs vidstab`
 endef

--- a/src/vigra.mk
+++ b/src/vigra.mk
@@ -36,7 +36,7 @@ define $(PKG)_BUILD
     $(MAKE) -C '$(1)/build' -j '$(JOBS)' install
 
     $(TARGET)-g++ \
-        '$(2).cpp' -o $(PREFIX)/$(TARGET)/bin/test-vigra.exe \
+        '$(TEST_FILE)' -o $(PREFIX)/$(TARGET)/bin/test-vigra.exe \
         -DVIGRA_STATIC_LIB \
         -lvigraimpex `'$(TARGET)-pkg-config' OpenEXR libtiff-4 libpng --cflags --libs` -ljpeg
 endef

--- a/src/wxwidgets.mk
+++ b/src/wxwidgets.mk
@@ -73,7 +73,7 @@ define $(PKG)_BUILD
     # build test program
     '$(TARGET)-g++' \
         -W -Wall -Werror -Wno-error=unused-local-typedefs -pedantic -std=gnu++0x \
-        '$(2).cpp' -o '$(PREFIX)/$(TARGET)/bin/test-wxwidgets.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-wxwidgets.exe' \
         `'$(TARGET)-wx-config' --cflags --libs`
 endef
 

--- a/src/xerces.mk
+++ b/src/xerces.mk
@@ -47,7 +47,7 @@ define $(PKG)_BUILD
 
     '$(TARGET)-g++' \
         -W -Wall -Werror -ansi -pedantic \
-        '$(2).cpp' -o '$(PREFIX)/$(TARGET)/bin/test-xerces.exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-xerces.exe' \
         `'$(TARGET)-pkg-config' xerces-c --cflags --libs`
 endef
 

--- a/src/xxhash.mk
+++ b/src/xxhash.mk
@@ -34,6 +34,6 @@ define $(PKG)_BUILD
 
     '$(TARGET)-gcc' \
         -W -Wall -Werror -ansi -pedantic \
-        '$(2).c' -o '$(PREFIX)/$(TARGET)/bin/test-$(PKG).exe' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-$(PKG).exe' \
         `'$(TARGET)-pkg-config' $(PKG) --cflags --libs`
 endef


### PR DESCRIPTION
The following script was applied:

```bash
set -xue

find src/ plugins/ -name '*.mk' -type f > mks

# special cases for test file:
# ls -d src/*-test* | sed 's@-test.*@@' | sort | uniq --repeated
sed 's@$(2).c@$(PWD)/src/$(PKG)-test.c@g' -i \
	src/{boost,freeimage,hdf5,lapack,sdl,sdl_image,sdl_sound}.mk
sed 's@$(2).f@$(PWD)/src/$(PKG)-test.f@g' -i src/lapack.mk
sed 's@$(PWD)/$(2).pro@$(PWD)/src/$(PKG)-test.pro@g' -i \
	src/qt.mk plugins/examples/custom-qt-min/overrides.mk
sed 's@$(2)-CMakeLists.txt@$(PWD)/src/$(PKG)-test-CMakeLists.txt@g' \
	-i src/{sdl_image,sdl_sound}.mk

# check
for base in $(ls -d src/*-test* | sed 's@-test.*@@' | sort | uniq --repeated); do
	! grep -q '$(2)' "${base}.mk"
done

# other $(2)
sed 's@$(2).cpp@$(TEST_FILE)@g' -i $(cat mks)
sed 's@$(2).cxx@$(TEST_FILE)@g' -i $(cat mks)
sed 's@$(2).c@$(TEST_FILE)@g' -i $(cat mks)
sed 's@$(2).ml@$(TEST_FILE)@g' -i $(cat mks)
sed 's@$(2).f@$(TEST_FILE)@g' -i $(cat mks)

# check
! grep '$(2)' $(cat mks)
```

I am building 208f5cc8508dd70d3f40fcba255e12cf8f1f9bf3 and 17e40d3884dc4b9db5b521c7e017a3fa12366370 to make sure nothing is broken. 

See https://github.com/mxe/mxe/issues/1452