### PR TITLE
host-toolchain plugin: fix shared libgcc and qt tools

### DIFF
--- a/plugins/examples/host-toolchain/README.md
+++ b/plugins/examples/host-toolchain/README.md
@@ -72,9 +72,6 @@ On a windows machine, execute
 `usr\{target}\qt5\test-qt5-host-tools\test-qt5-host-tools.bat` to build and
 confirm the normal `qt` test with the cross-compiled `qtbase` libraries.
 
-**N.B.** shared `gcc` doesn't work with the test program. To build a shared
-test, use the additional option `gcc-host_CONFIGURE_OPTS=--disable-shared`.
-
 Why?
 ----
 

--- a/plugins/examples/host-toolchain/gcc-host.mk
+++ b/plugins/examples/host-toolchain/gcc-host.mk
@@ -42,6 +42,17 @@ define $(PKG)_BUILD
     $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)'
     $(MAKE) -C '$(BUILD_DIR)' -j 1 install
 
+    # shared libgcc isn't installed to version-specific locations
+    # so install correctly to simplify cleanup (see gcc.mk)
+    $(and $(BUILD_SHARED),
+    $(MAKE) -C '$(BUILD_DIR)/$(TARGET)/libgcc' -j 1 \
+        toolexecdir='$(PREFIX)/$(TARGET)/bin' \
+        SHLIB_SLIBDIR_QUAL= \
+        install-shared
+    -rm -v '$(PREFIX)/$(TARGET)/lib/gcc/$(TARGET)/'libgcc_s*.dll
+    -rm -v '$(PREFIX)/$(TARGET)/lib/gcc/$(TARGET)/lib/'libgcc_s*.a
+    -rmdir '$(PREFIX)/$(TARGET)/lib/gcc/$(TARGET)/lib/')
+
     # test compilation on host
     # strip and compare cross and host-built tests
     cp '$(TOP_DIR)/src/pthreads-libgomp-test.c' '$(PREFIX)/$(TARGET)/bin/test-$(PKG).c'

--- a/plugins/examples/host-toolchain/qt5-host-tools.mk
+++ b/plugins/examples/host-toolchain/qt5-host-tools.mk
@@ -5,7 +5,7 @@ PKG             := $(basename $(notdir $(lastword $(MAKEFILE_LIST))))
 $(PKG)_FILE      = $(qtbase_FILE)
 $(PKG)_PATCHES   = $(realpath $(sort $(wildcard $(addsuffix /qtbase-[0-9]*.patch, $(TOP_DIR)/src))))
 $(PKG)_SUBDIR    = $(qtbase_SUBDIR)
-$(PKG)_DEPS     := gcc gcc-host make-w32-bin qtbase
+$(PKG)_DEPS     := gcc gcc-host make-w32-bin qtbase winpthreads-host
 
 # main configure options: -platform -host-option -external-hostbindir
 # further testing needed: -prefix -extprefix -hostprefix -sysroot -no-gcc-sysroot
@@ -15,7 +15,7 @@ define $(PKG)_BUILD
     $(SED) -i 's,BUILD_ON_MAC=yes,BUILD_ON_MAC=no,g' '$(1)/configure'
     cd '$(BUILD_DIR)' && '$(SOURCE_DIR)/configure' \
         -prefix '$(PREFIX)/$(TARGET)/qt5' \
-        -static \
+        $(if $(BUILD_STATIC),-static,-shared) \
         -release \
         -c++std c++11 \
         -platform win32-g++ \

--- a/plugins/examples/host-toolchain/winpthreads-host.mk
+++ b/plugins/examples/host-toolchain/winpthreads-host.mk
@@ -1,0 +1,26 @@
+# This file is part of MXE.
+# See index.html for further information.
+
+PKG             := winpthreads-host
+$(PKG)_IGNORE    = $(mingw-w64_IGNORE)
+$(PKG)_VERSION   = $(mingw-w64_VERSION)
+$(PKG)_CHECKSUM  = $(mingw-w64_CHECKSUM)
+$(PKG)_SUBDIR    = $(mingw-w64_SUBDIR)
+$(PKG)_FILE      = $(mingw-w64_FILE)
+$(PKG)_URL       = $(mingw-w64_URL)
+$(PKG)_URL_2     = $(mingw-w64_URL_2)
+$(PKG)_DEPS     := gcc
+
+define $(PKG)_UPDATE
+    echo $(mingw-w64_VERSION)
+endef
+
+# temporary build until gcc is built only once per arch
+define $(PKG)_BUILD
+    cd '$(BUILD_DIR)' && '$(SOURCE_DIR)/mingw-w64-libraries/winpthreads/configure' \
+        $(MXE_CONFIGURE_OPTS) \
+        --enable-static \
+        --enable-shared
+    $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)'
+    $(MAKE) -C '$(BUILD_DIR)' -j 1 install
+endef


### PR DESCRIPTION
add winpthreads until gcc is built once per arch #1019

fixes #950