### PR TITLE
cmake: fix windres invocation

### DIFF
--- a/src/cmake-1-fixes.patch
+++ b/src/cmake-1-fixes.patch
@@ -1,0 +1,20 @@
+This file is part of MXE.
+See index.html for further information.
+
+Contains ad hoc patches for cross building.
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tony Theodore <tonyt@logyst.com>
+Date: Fri, 12 Aug 2016 02:01:20 +1000
+Subject: [PATCH] fix windres invocation options
+
+windres doesn't recognise various gcc flags like -mms-bitfields,
+-fopenmp, -mthreads etc. (basically not `-D` or `-I`)
+
+diff --git a/Modules/Platform/Windows-windres.cmake b/Modules/Platform/Windows-windres.cmake
+index 1111111..2222222 100644
+--- a/Modules/Platform/Windows-windres.cmake
++++ b/Modules/Platform/Windows-windres.cmake
+@@ -1 +1 @@
+-set(CMAKE_RC_COMPILE_OBJECT "<CMAKE_RC_COMPILER> -O coff <DEFINES> <INCLUDES> <FLAGS> <SOURCE> <OBJECT>")
++set(CMAKE_RC_COMPILE_OBJECT "<CMAKE_RC_COMPILER> -O coff <DEFINES> <INCLUDES> <SOURCE> <OBJECT>")

--- a/src/mxe-conf.mk
+++ b/src/mxe-conf.mk
@@ -20,6 +20,9 @@ define $(PKG)_BUILD
     # create the CMake toolchain file
     # individual packages (e.g. hdf5) should add their
     # own files under CMAKE_TOOLCHAIN_DIR
+    # CMAKE_RC_COMPILE_OBJECT is defined in:
+    #     <cmake root>/share/cmake-X.Y/Modules/Platform/Windows-windres.cmake
+
     mkdir -p '$(CMAKE_TOOLCHAIN_DIR)'
     touch '$(CMAKE_TOOLCHAIN_DIR)/.gitkeep'
     (echo 'set(CMAKE_SYSTEM_NAME Windows)'; \
@@ -39,7 +42,6 @@ define $(PKG)_BUILD
      echo 'set(CMAKE_INSTALL_PREFIX $(PREFIX)/$(TARGET) CACHE PATH "Installation Prefix")'; \
      echo 'set(CMAKE_BUILD_TYPE Release CACHE STRING "Debug|Release|RelWithDebInfo|MinSizeRel")'; \
      echo 'set(CMAKE_CROSS_COMPILING ON) # Workaround for http://www.cmake.org/Bug/view.php?id=14075'; \
-     echo 'set(CMAKE_RC_COMPILE_OBJECT "<CMAKE_RC_COMPILER> -O coff <FLAGS> <DEFINES> -o <OBJECT> <SOURCE>") # Workaround for buggy windres rules'; \
      echo ''; \
      echo 'file(GLOB mxe_cmake_files'; \
      echo '    "$(CMAKE_TOOLCHAIN_DIR)/*.cmake"'; \


### PR DESCRIPTION
Windres doesn't recognise various gcc flags like `-mms-bitfields`,
`-fopenmp`, `-mthreads` etc. (basically anything not `-D` or `-I`).

CMake will filter options if `add_compile_options()` is used, but not
for `add_definitions()`. The developers class it as a "won't fix" as
they believe `add_definitions()` shouldn't be used for such flags.

Fixes #1475