### PR TITLE
physfs: enable x86-64 build

### DIFF
--- a/src/physfs-1-cast-fixes.patch
+++ b/src/physfs-1-cast-fixes.patch
@@ -1,0 +1,44 @@
+This file is part of MXE.
+See index.html for further information.
+
+# HG changeset patch
+# User David Yip <dwyip@peach-bun.com>
+# Date 1471367884 18000
+#      Tue Aug 16 12:18:04 2016 -0500
+# Branch stable-2.0
+# Node ID 990fd55ba0c4979db59888283c7dde6c359927e2
+# Parent  34ebe997c5c07f57aff8e56695cd89856800d11d
+Replace unsigned long cast with cast to uintptr_t.
+
+When targeting MinGW-w64's x86_64 target, unsigned long is 4 bytes but void* is
+8 bytes.  This mismatch triggers the pointer-to-int-cast warning.
+
+diff -r 34ebe997c5c0 -r 990fd55ba0c4 archivers/lzma.c
+--- a/archivers/lzma.c  Fri Jan 01 12:53:41 2016 -0500
++++ b/archivers/lzma.c  Tue Aug 16 12:18:04 2016 -0500
+@@ -9,6 +9,7 @@
+ 
+ #if (defined PHYSFS_SUPPORTS_7Z)
+ 
++#include <stdint.h>
+ #include <stdlib.h>
+ #include <string.h>
+ #include <time.h>
+@@ -130,7 +131,7 @@
+ SZ_RESULT SzFileReadImp(void *object, void *buffer, size_t size,
+                         size_t *processedSize)
+ {
+-    FileInputStream *s = (FileInputStream *)((unsigned long)object - offsetof(FileInputStream, inStream)); /* HACK! */
++    FileInputStream *s = (FileInputStream *)((uintptr_t)object - offsetof(FileInputStream, inStream)); /* HACK! */
+     size_t processedSizeLoc = __PHYSFS_platformRead(s->file, buffer, 1, size);
+     if (processedSize != 0)
+         *processedSize = processedSizeLoc;
+@@ -145,7 +146,7 @@
+  */
+ SZ_RESULT SzFileSeekImp(void *object, CFileSize pos)
+ {
+-    FileInputStream *s = (FileInputStream *)((unsigned long)object - offsetof(FileInputStream, inStream)); /* HACK! */
++    FileInputStream *s = (FileInputStream *)((uintptr_t)object - offsetof(FileInputStream, inStream)); /* HACK! */
+     if (__PHYSFS_platformSeek(s->file, (PHYSFS_uint64) pos))
+         return SZ_OK;
+     return SZE_FAIL;

--- a/src/physfs-1-cast-fixes.patch
+++ b/src/physfs-1-cast-fixes.patch
@@ -1,6 +1,9 @@
 This file is part of MXE.
 See index.html for further information.
 
+This patch was adapted for PhysicsFS 2.0.3's file layout from
+https://hg.icculus.org/icculus/physfs/rev/67031168b061.
+
 # HG changeset patch
 # User David Yip <dwyip@peach-bun.com>
 # Date 1471367884 18000

--- a/src/physfs.mk
+++ b/src/physfs.mk
@@ -34,5 +34,3 @@ define $(PKG)_BUILD
         '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-physfs.exe' \
         -lphysfs -lz
 endef
-
-$(PKG)_BUILD_x86_64-w64-mingw32 =


### PR DESCRIPTION
This PR contains a patch (submitted to icculus, awaiting feedback) that works around some pointer-to-integer-cast problems.

The resulting x86-64 `test-physfs.exe` produces identical output to the i686 `test-physfs.exe`; furthermore, the application I'm building with PhysicsFS also works properly with the MXE x86-64 physfs build.

The patch was extracted from some fixes I did on the PhysicsFS Mercurial repository, which is why it's in Mercurial format.  (The MXE pipeline can apply it fine, however.)  If desired, I can change it to conform to git patch format.