### PR TITLE
Add options to strip toolchain, executables, and libs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,11 @@ PKGS       := $(call set_create,\
 BUILD      := $(shell '$(EXT_DIR)/config.guess')
 PATH       := $(PREFIX)/$(BUILD)/bin:$(PREFIX)/bin:$(PATH)
 
+# set to empty or $(false) to disable stripping
+STRIP_TOOLCHAIN := $(true)
+STRIP_LIB       := $(false)
+STRIP_EXE       := $(true)
+
 # All pkgs have (implied) order-only dependencies on MXE_CONF_PKGS.
 # These aren't meaningful to the pkg list in index.html so
 # use a list in case we want to separate autotools, cmake etc.
@@ -550,6 +555,8 @@ build-only-$(1)_$(3): LIB_SUFFIX = $(if $(findstring shared,$(3)),dll,a)
 build-only-$(1)_$(3): BITS = $(if $(findstring x86_64,$(3)),64,32)
 build-only-$(1)_$(3): BUILD_TYPE = $(if $(findstring debug,$(3) $($(1)_CONFIGURE_OPTS)),debug,release)
 build-only-$(1)_$(3): BUILD_TYPE_SUFFIX = $(if $(findstring debug,$(3) $($(1)_CONFIGURE_OPTS)),d)
+build-only-$(1)_$(3): INSTALL_STRIP_TOOLCHAIN = install$(if $(STRIP_TOOLCHAIN),-strip)
+build-only-$(1)_$(3): INSTALL_STRIP_LIB = install$(if $(STRIP_LIB),-strip)
 build-only-$(1)_$(3): SOURCE_DIR = $(or $($(1)_SOURCE_TREE),$(2)/$($(1)_SUBDIR))
 build-only-$(1)_$(3): BUILD_DIR  = $(2)/$(if $($(1)_SOURCE_TREE),local,$($(1)_SUBDIR)).build_
 build-only-$(1)_$(3): TEST_FILE  = $($(1)_TEST_FILE)
@@ -587,6 +594,7 @@ build-only-$(1)_$(3):
 	    @echo
 	    @echo 'settings.mk'
 	    @cat '$(TOP_DIR)/settings.mk'
+	    $(if $(STRIP_EXE),-$(TARGET)-strip '$(PREFIX)/$(TARGET)/bin/test-$(PKG).exe')
 	    (du -k -d 0 '$(2)' 2>/dev/null || du -k --max-depth 0 '$(2)') | $(SED) -n 's/^\(\S*\).*/du: \1 KiB/p'
 	    rm -rfv  '$(2)'
 	    )

--- a/plugins/examples/host-toolchain/binutils-host.mk
+++ b/plugins/examples/host-toolchain/binutils-host.mk
@@ -25,8 +25,7 @@ define $(PKG)_BUILD
             --prefix='$(PREFIX)/$(TARGET)' \
             --program-prefix='$(TARGET)-' \
             --host='$(TARGET)',\
-    $(subst install, install-strip,\
-    $(binutils_BUILD)))
+    $(binutils_BUILD))
 
     # install unprefixed versions also
     for p in $($(PKG)_PROGS); do \

--- a/plugins/examples/host-toolchain/gcc-host.mk
+++ b/plugins/examples/host-toolchain/gcc-host.mk
@@ -40,7 +40,7 @@ define $(PKG)_BUILD
         $($(PKG)_CONFIGURE_OPTS)
 
     $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)'
-    $(MAKE) -C '$(BUILD_DIR)' -j 1 install-strip
+    $(MAKE) -C '$(BUILD_DIR)' -j 1 $(INSTALL_STRIP_TOOLCHAIN)
 
     # shared libgcc isn't installed to version-specific locations
     # so install correctly to simplify cleanup (see gcc.mk)

--- a/src/binutils.mk
+++ b/src/binutils.mk
@@ -34,7 +34,7 @@ define $(PKG)_BUILD
         --disable-shared \
         --disable-werror
     $(MAKE) -C '$(1)' -j '$(JOBS)'
-    $(MAKE) -C '$(1)' -j 1 install
+    $(MAKE) -C '$(1)' -j 1 $(INSTALL_STRIP_TOOLCHAIN)
 
     rm -f $(addprefix $(PREFIX)/$(TARGET)/bin/, ar as dlltool ld ld.bfd nm objcopy objdump ranlib strip)
 endef

--- a/src/gcc.mk
+++ b/src/gcc.mk
@@ -83,7 +83,7 @@ define $(PKG)_BUILD_mingw-w64
     # build standalone gcc
     $($(PKG)_CONFIGURE)
     $(MAKE) -C '$(1).build' -j '$(JOBS)' all-gcc
-    $(MAKE) -C '$(1).build' -j 1 install-gcc
+    $(MAKE) -C '$(1).build' -j 1 $(INSTALL_STRIP_TOOLCHAIN)-gcc
 
     # build mingw-w64-crt
     mkdir '$(1).crt-build'
@@ -92,19 +92,19 @@ define $(PKG)_BUILD_mingw-w64
         --prefix='$(PREFIX)/$(TARGET)' \
         @gcc-crt-config-opts@
     $(MAKE) -C '$(1).crt-build' -j '$(JOBS)' || $(MAKE) -C '$(1).crt-build' -j '$(JOBS)'
-    $(MAKE) -C '$(1).crt-build' -j 1 install
+    $(MAKE) -C '$(1).crt-build' -j 1 $(INSTALL_STRIP_TOOLCHAIN)
 
     # build posix threads
     mkdir '$(1).pthread-build'
     cd '$(1).pthread-build' && '$(1)/$(mingw-w64_SUBDIR)/mingw-w64-libraries/winpthreads/configure' \
         $(MXE_CONFIGURE_OPTS)
     $(MAKE) -C '$(1).pthread-build' -j '$(JOBS)' || $(MAKE) -C '$(1).pthread-build' -j '$(JOBS)'
-    $(MAKE) -C '$(1).pthread-build' -j 1 install
+    $(MAKE) -C '$(1).pthread-build' -j 1 $(INSTALL_STRIP_TOOLCHAIN)
 
     # build rest of gcc
     cd '$(1).build'
     $(MAKE) -C '$(1).build' -j '$(JOBS)'
-    $(MAKE) -C '$(1).build' -j 1 install
+    $(MAKE) -C '$(1).build' -j 1 $(INSTALL_STRIP_TOOLCHAIN)
 
     # shared libgcc isn't installed to version-specific locations
     # so install correctly to simplify cleanup

--- a/src/gdal.mk
+++ b/src/gdal.mk
@@ -79,6 +79,9 @@ define $(PKG)_BUILD
         LIBS="-ljpeg -lsecur32 -lportablexdr `'$(TARGET)-pkg-config' --libs openssl libtiff-4`"
 
     $(MAKE) -C '$(1)'       -j '$(JOBS)' lib-target
+    # gdal doesn't have an install-strip target
+    # --strip-debug doesn't reduce size by much, --strip-all breaks libs
+    $(if $(STRIP_LIB),-'$(TARGET)-strip' --strip-debug '$(1)/.libs'/*)
     $(MAKE) -C '$(1)'       -j '$(JOBS)' gdal.pc
     $(MAKE) -C '$(1)'       -j '$(JOBS)' install-actions
     $(MAKE) -C '$(1)/port'  -j '$(JOBS)' install
@@ -86,6 +89,8 @@ define $(PKG)_BUILD
     $(MAKE) -C '$(1)/frmts' -j '$(JOBS)' install
     $(MAKE) -C '$(1)/alg'   -j '$(JOBS)' install
     $(MAKE) -C '$(1)/ogr'   -j '$(JOBS)' install OGR_ENABLED=
+    $(MAKE) -C '$(1)/apps'  -j '$(JOBS)' all
+    $(if $(STRIP_EXE),-'$(TARGET)-strip' '$(1)/apps'/*.exe)
     $(MAKE) -C '$(1)/apps'  -j '$(JOBS)' install
     ln -sf '$(PREFIX)/$(TARGET)/bin/gdal-config' '$(PREFIX)/bin/$(TARGET)-gdal-config'
 endef

--- a/src/geos.mk
+++ b/src/geos.mk
@@ -20,7 +20,8 @@ endef
 define $(PKG)_BUILD
     cd '$(1)' && ./configure \
         $(MXE_CONFIGURE_OPTS)
-    $(MAKE) -C '$(1)' -j '$(JOBS)' install bin_PROGRAMS= sbin_PROGRAMS= noinst_PROGRAMS=
+    $(MAKE) -C '$(1)' -j '$(JOBS)' $(MXE_DISABLE_PROGRAMS)
+    $(MAKE) -C '$(1)' -j 1 $(INSTALL_STRIP_LIB)
 
     ln -sf '$(PREFIX)/$(TARGET)/bin/geos-config' '$(PREFIX)/bin/$(TARGET)-geos-config'
 


### PR DESCRIPTION
Minimal implementation to strip the [largest files][lf-gist] by
default, mostly made up of gcc/binutils and test programs.

gdal and geos both produce large libraries, but the libs themselves
aren't worth stripping, it's the 20 odd programs produced by gdal
with those libs statically linked that consume the most space.

I'm leaving these undocumented as the defaults seems reasonable and
the interface may well change when we enable debug/release variants.

closes #985
closes #1249

[lf-gist]:https://github.com/mxe/mxe/issues/1249#issuecomment-193392038