### PR TITLE
upx: disable -Werror on native builds

### DIFF
--- a/plugins/gcc6/README.md
+++ b/plugins/gcc6/README.md
@@ -65,7 +65,6 @@ versions [[4](https://github.com/mxe/mxe/commit/a1cc019)].
 | smpeg              | all                                     | [57cb6bb](https://github.com/mxe/mxe/commit/57cb6bb) |
 | smpeg2             | all                                     | [1a42cbc](https://github.com/mxe/mxe/commit/1a42cbc) |
 | ucl                | all                                     | [0ac2a77](https://github.com/mxe/mxe/commit/0ac2a77) |
-| upx                | all                                     | [f907a06](https://github.com/mxe/mxe/commit/f907a06) |
 | vtk                | static (all)                            | -                                                    |
 | vtk6               | all                                     | -                                                    |
 | wxwidgets          | static (all)                            | [6869e3b](https://github.com/mxe/mxe/commit/6869e3b) |

--- a/src/upx.mk
+++ b/src/upx.mk
@@ -22,16 +22,17 @@ define $(PKG)_BUILD
     $(call PREPARE_PKG_SOURCE,ucl,$(1))
     mkdir '$(1)/lzma'
     $(call PREPARE_PKG_SOURCE,lzma,$(1)/lzma)
+
     UPX_UCLDIR='$(1)/$(ucl_SUBDIR)' \
-        UPX_LZMADIR='$(1)/lzma' \
-        UPX_LZMA_VERSION=0x$(subst .,,$(lzma_VERSION)) \
-        $(MAKE) -C '$(1)' -j '$(JOBS)' all \
-        'CXX=$(TARGET)-g++' \
-        'CC=$(TARGET)-gcc' \
-        'LD=$(TARGET)-ld' \
-        'AR=$(TARGET)-ar' \
-        'PKG_CONFIG=$(TARGET)-pkg-config' \
-        'exeext=.exe'
+    UPX_LZMADIR='$(1)/lzma' \
+    UPX_LZMA_VERSION=0x$(subst .,,$(lzma_VERSION)) \
+    $(MAKE) -C '$(1)' -j '$(JOBS)' all \
+        CXX='$(TARGET)-g++' \
+        CC='$(TARGET)-gcc' \
+        LD='$(TARGET)-ld' \
+        AR='$(TARGET)-ar' \
+        PKG_CONFIG='$(TARGET)-pkg-config' \
+        exeext='.exe'
     cp '$(1)/src/upx.exe' '$(PREFIX)/$(TARGET)/bin/'
 endef
 
@@ -39,15 +40,16 @@ define $(PKG)_BUILD_$(BUILD)
     $(call PREPARE_PKG_SOURCE,ucl,$(1))
     mkdir '$(1)/lzma'
     $(call PREPARE_PKG_SOURCE,lzma,$(1)/lzma)
+
     UPX_UCLDIR='$(1)/$(ucl_SUBDIR)' \
-        UPX_LZMADIR='$(1)/lzma' \
-        UPX_LZMA_VERSION=0x$(subst .,,$(lzma_VERSION)) \
-        $(MAKE) -C '$(1)' -j '$(JOBS)' all \
-        'CXX=$(BUILD_CXX)' \
-        'CC=$(BUILD_CC)' \
-        'PKG_CONFIG=$(PREFIX)/$(BUILD)/bin/pkgconf' \
-        'LIBS=-L$(PREFIX)/$(BUILD)/lib -lucl -lz' \
-        'CXXFLAGS_WERROR=' \
-        'exeext='
+    UPX_LZMADIR='$(1)/lzma' \
+    UPX_LZMA_VERSION=0x$(subst .,,$(lzma_VERSION)) \
+    $(MAKE) -C '$(1)' -j '$(JOBS)' all \
+        CXX='$(BUILD_CXX)' \
+        CC='$(BUILD_CC)' \
+        PKG_CONFIG='$(PREFIX)/$(BUILD)/bin/pkgconf' \
+        LIBS='-L$(PREFIX)/$(BUILD)/lib -lucl -lz' \
+        CXXFLAGS_WERROR= \
+        exeext=
     cp '$(1)/src/upx' '$(PREFIX)/$(BUILD)/bin/'
 endef

--- a/src/upx.mk
+++ b/src/upx.mk
@@ -47,9 +47,7 @@ define $(PKG)_BUILD_$(BUILD)
         'CC=$(BUILD_CC)' \
         'PKG_CONFIG=$(PREFIX)/$(BUILD)/bin/pkgconf' \
         'LIBS=-L$(PREFIX)/$(BUILD)/lib -lucl -lz' \
-        $(shell [ `uname -s` == Darwin ] && \
-            echo "CXXFLAGS=-Wno-error=unused-local-typedefs -Wno-error=misleading-indentation" || \
-            echo "CXXFLAGS=-Wno-error=misleading-indentation") \
+        'CXXFLAGS_WERROR=' \
         'exeext='
     cp '$(1)/src/upx' '$(PREFIX)/$(BUILD)/bin/'
 endef


### PR DESCRIPTION
See: https://github.com/mxe/mxe/pull/1360/files/3ab014bd5672a1c84c6d93630634a2b79cdb9b8c#r75447401

Tested on OSX clang-700.1.81, gcc6 6.1.0_0, and gcc5 5.4.0_0
