### PR TITLE
fix MXE_GET_GITHUB_TAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,7 @@ define MXE_GET_GITHUB_ALL_TAGS
 endef
 
 define MXE_GET_GITHUB_TAGS
-    $(MXE_GET_GITHUB_ALL_TAGS, $(1)) \
+    $(call MXE_GET_GITHUB_ALL_TAGS, $(1)) \
     | $(SED) 's,^$(strip $(2)),,g' \
     | $(SORT) -V \
     | tail -1


### PR DESCRIPTION
Error message:

    $ make update-package-pire
    ...
    bash: -c: line 0: syntax error near unexpected token `|'
    ...

Overlooked in b52d3c0c9c24e7904908dc50f0c7c6f163556fab
See https://github.com/mxe/mxe/pull/1439