### PR TITLE
ragel: fix build with gcc6

### DIFF
--- a/src/ragel.mk
+++ b/src/ragel.mk
@@ -19,7 +19,8 @@ endef
 
 define $(PKG)_BUILD_$(BUILD)
     cd '$(BUILD_DIR)' && '$(SOURCE_DIR)/configure' \
-        --prefix='$(PREFIX)/$(BUILD)'
+        --prefix='$(PREFIX)/$(BUILD)' \
+        CXXFLAGS=-std=c++03
     $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)'
     $(MAKE) -C '$(BUILD_DIR)' -j 1 install
 endef


### PR DESCRIPTION
tested on OS X with gcc 6.1.0 and clang

fixes #1510
