### PR TITLE
hyperscan: update from 4.3.0 to 4.3.1

### DIFF
--- a/src/hyperscan.mk
+++ b/src/hyperscan.mk
@@ -2,8 +2,8 @@
 
 PKG             := hyperscan
 $(PKG)_IGNORE   :=
-$(PKG)_VERSION  := 4.3.0
-$(PKG)_CHECKSUM := 842527a578f58e4a8e441e6adbfd3a43667399125913ed5df20c72b94c9ccad7
+$(PKG)_VERSION  := 4.3.1
+$(PKG)_CHECKSUM := a7bce1287c06d53d1fb34266d024331a92ee24cbb2a7a75061b4ae50a30bae97
 $(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
 $(PKG)_FILE     := $($(PKG)_SUBDIR).tar.gz
 $(PKG)_URL      := https://github.com/01org/$(PKG)/archive/v$($(PKG)_VERSION).tar.gz


### PR DESCRIPTION
Changes: https://github.com/01org/hyperscan/releases/tag/v4.3.1