### PR TITLE
opencsg: update to 1.4.1

### DIFF
--- a/src/opencsg-1-fixes.patch
+++ b/src/opencsg-1-fixes.patch
@@ -2,9 +2,9 @@ This file is part of MXE. See LICENSE.md for licensing information.
 
 Contains ad hoc patches for cross building.
 
-diff -ur OpenCSG-1.4.0.orig/example/example.pro OpenCSG-1.4.0/example/example.pro
---- OpenCSG-1.4.0.orig/example/example.pro	2014-09-15 22:25:33.000000000 +0200
-+++ OpenCSG-1.4.0/example/example.pro	2015-03-22 14:08:27.706916987 +0100
+diff -ur OpenCSG-1.4.1.orig/example/example.pro OpenCSG-1.4.1/example/example.pro
+--- OpenCSG-1.4.1.orig/example/example.pro	2016-09-08 23:08:33.000000000 +0200
++++ OpenCSG-1.4.1/example/example.pro	2016-09-11 14:24:18.839741352 +0200
 @@ -1,10 +1,10 @@
  TEMPLATE = app
  TARGET = opencsgexample
@@ -28,19 +28,20 @@ diff -ur OpenCSG-1.4.0.orig/example/example.pro OpenCSG-1.4.0/example/example.pr
  }
  
  HEADERS = displaylistPrimitive.h
-diff -ur OpenCSG-1.4.0.orig/src/src.pro OpenCSG-1.4.0/src/src.pro
---- OpenCSG-1.4.0.orig/src/src.pro	2014-09-15 22:25:33.000000000 +0200
-+++ OpenCSG-1.4.0/src/src.pro	2015-03-22 14:05:18.275029066 +0100
-@@ -2,10 +2,10 @@
- TARGET = opencsg
- VERSION = 1.4.0
+diff -ur OpenCSG-1.4.1.orig/src/src.pro OpenCSG-1.4.1/src/src.pro
+--- OpenCSG-1.4.1.orig/src/src.pro	2016-09-08 23:08:33.000000000 +0200
++++ OpenCSG-1.4.1/src/src.pro	2016-09-11 14:25:15.833496135 +0200
+@@ -6,10 +6,11 @@
+   INSTALLDIR = /usr/local
+ }
  
 -CONFIG += opengl warn_on release
 +CONFIG += opengl warn_on release link_pkgconfig
- INCLUDEPATH += ../include ../
+ INCLUDEPATH += ../include ../ $$INSTALLDIR/include
  CONFIG -= qt
--LIBS += -lGLEW
+-LIBS += -L$$INSTALLDIR/lib -lGLEW
++LIBS += -L$$INSTALLDIR/lib
 +PKGCONFIG += glew glut
  
  DESTDIR = ../lib
- INSTALLDIR = /usr/local
+ headers.files = ../include/opencsg.h

--- a/src/opencsg.mk
+++ b/src/opencsg.mk
@@ -2,8 +2,8 @@
 
 PKG             := opencsg
 $(PKG)_IGNORE   :=
-$(PKG)_VERSION  := 1.4.0
-$(PKG)_CHECKSUM := ecb46be54cfb8a338d2a9b62dec90ec8da6c769078c076f58147d4a6ba1c878d
+$(PKG)_VERSION  := 1.4.1
+$(PKG)_CHECKSUM := 48182c8233e6f89cd6752679bde44ef6cc9eda4c06f4db845ec7de2cae2bb07a
 $(PKG)_SUBDIR   := OpenCSG-$($(PKG)_VERSION)
 $(PKG)_FILE     := OpenCSG-$($(PKG)_VERSION).tar.gz
 $(PKG)_URL      := http://www.opencsg.org/$($(PKG)_FILE)


### PR DESCRIPTION
Minor but important upgrade fixing an issue on Intel GPU.

This only updates the makefile and resolves the conflicts applying the qmake project file patch.

From http://opencsg.org/news.html:
_On Intel graphics hardware, the new rendering path in the SCS algorithm in OpenCSG 1.4.0 entirely failed to work. This was apparently due to an incompatibility of the fragment program with the fixed function pipeline used at the vertex stage. OpenCSG 1.4.1 implements a workaround: a vertex program is now used instead. I hope that the rendering bugs on Intel graphics hardware are now really a thing of the past._ 