### PR TITLE
travis: download packages of plugins as well

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: false
 script:
   - make docs/build-matrix.html docs/versions.json
   - if [ "$GH_TOKEN" != "" ]; then ./tools/travis-push.sh; fi
-  - make download -j 6 -k
+  - make download -j 6 -k MXE_PLUGIN_DIRS="$(./tools/plugins-with-additional-packages.sh)"
 
 env:
   global:

--- a/tools/plugins-with-additional-packages.sh
+++ b/tools/plugins-with-additional-packages.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+# List of dirs of plugins with additional packages
+# as opposed to customisation plugins.
+# See plugins/README.md for more information.
+
+echo plugins/{apps,luarocks,native,tcl.tk}

--- a/tools/s3-fetch-and-sync
+++ b/tools/s3-fetch-and-sync
@@ -22,7 +22,7 @@ file_issue=false
 
 # List of plugin dirs to include in downloads
 # Can't include all subdirs since some affect versions
-plugin_dirs=`echo plugins/{apps,luarocks,native,tcl.tk}`
+plugin_dirs=`./tools/plugins-with-additional-packages.sh`
 
 cd ~/mxe && git pull
 


### PR DESCRIPTION
List of plugins with additional packages was moved from s3-fetch-and-sync
to plugins-with-additional-packages.sh.