### PR TITLE
s/environmental variable/environment variable/

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -3466,7 +3466,7 @@ endef</pre>
         finished porting all packages that were MinGW-only to at least
         i686-w64-mingw32 (32-bit target of MinGW-w64). Hence your existing
         commands should work out-of-the-box assuming the
-        <code>MXE_TARGETS</code> environmental variable is set correctly.
+        <code>MXE_TARGETS</code> environment variable is set correctly.
         </p>
     </dd>
 

--- a/plugins/go/go-1-fixes.patch
+++ b/plugins/go/go-1-fixes.patch
@@ -5,10 +5,10 @@ Contains ad hoc patches for cross building.
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Boris Nagaev <bnagaev@gmail.com>
 Date: Sat, 25 Jun 2016 13:51:06 +0200
-Subject: [PATCH] cgo: add environmental variable override for pkg-config
+Subject: [PATCH] cgo: add environment variable override for pkg-config
 
 Allow overriding default name of `pkg-config` utility via
-environmental variable PKG_CONFIG (same as used by autoconf
+environment variable PKG_CONFIG (same as used by autoconf
 pkg.m4 macros). This facilitates easy cross-compilation of cgo
 code.
 


### PR DESCRIPTION
"Environment variable" is more commonly used.