### PR TITLE
add package glpk

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1443,6 +1443,10 @@ local-pkg-list: $(LOCAL_PKG_LIST)</pre>
         <td class="website"><a href="http://glm.g-truc.net">GLM - OpenGL Mathematics</a></td>
     </tr>
     <tr>
+        <td class="package">glpk</td>
+        <td class="website"><a href="https://www.gnu.org/software/glpk/">GNU Linear Programming Kit</a></td>
+    </tr>
+    <tr>
         <td class="package">gmp</td>
         <td class="website"><a href="http://www.gmplib.org/">GMP</a></td>
     </tr>

--- a/src/glpk.mk
+++ b/src/glpk.mk
@@ -1,0 +1,42 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+PKG             := glpk
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 4.60
+$(PKG)_CHECKSUM := 1356620cb0a0d33ac3411dd49d9fd40d53ece73eaec8f6b8d19a77887ff5e297
+$(PKG)_SUBDIR   := glpk-$($(PKG)_VERSION)
+$(PKG)_FILE     := glpk-$($(PKG)_VERSION).tar.gz
+$(PKG)_URL      := https://ftp.gnu.org/gnu/glpk/glpk-$($(PKG)_VERSION).tar.gz
+$(PKG)_DEPS     := gcc gmp
+
+# internal zlib is always used
+# libmysqlclient and odbc not supported on windows (see INSTALL and configure.ac)
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- 'http://ftp.gnu.org/gnu/glpk/?C=M;O=D' | \
+    $(SED) -n 's,.*<a href="glpk-\([0-9][^"]*\)\.tar.*,\1,p' | \
+    head -1
+endef
+
+define $(PKG)_BUILD
+    # build and install the library
+    cd '$(BUILD_DIR)' && $(SOURCE_DIR)/configure \
+        $(MXE_CONFIGURE_OPTS) \
+        --with-gmp
+    $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)'
+    $(MAKE) -C '$(BUILD_DIR)' -j 1 install
+
+    # create pkg-config files
+    $(INSTALL) -d '$(PREFIX)/$(TARGET)/lib/pkgconfig'
+    (echo 'Name: $(PKG)'; \
+     echo 'Version: $($(PKG)_VERSION)'; \
+     echo 'Description: GNU Linear Programming Kit'; \
+     echo 'Libs: -lglpk';) \
+     > '$(PREFIX)/$(TARGET)/lib/pkgconfig/$(PKG).pc'
+
+    # compile test
+    '$(TARGET)-gcc' \
+        -W -Wall -Werror -ansi -pedantic \
+        '$(SOURCE_DIR)/examples/netgen.c' -o '$(PREFIX)/$(TARGET)/bin/test-$(PKG).exe' \
+        `'$(TARGET)-pkg-config' $(PKG) --cflags --libs`
+endef


### PR DESCRIPTION
Replaces #1529.

Builds all four targets successfully on OSX and tested with Win10 x64.

@jweaton, here's a step-by-step:
```
git checkout -b add-glpk
./tools/skeleton.py \
    --name glpk \
    --file-url https://ftp.gnu.org/gnu/glpk/glpk-4.60.tar.gz \
    --description "GNU Linear Programming Kit" \
    --website https://www.gnu.org/software/glpk/
git add .
git commit -m'add package glpk'
# enable features/updates etc. and test in VM
git commit -a -m'glpk: add deps, test, and updates'
git push tonytheodore add-glpk:add-glpk
# create [WIP] github pull request
```

Next steps after review:
```
git rebase master -i
# use "fixup" to consolidate into fewer commits (single "add package" 
# in this case) and force push to update pr
git push tonytheodore add-glpk:add-glpk -f
# remove [WIP] and merge with github "merge" button
```
