### PR TITLE
allow to change User Agent; fix levmar download

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -458,7 +458,7 @@ download-only-$($(1)_FILE)::
 	@[ -d '$(LOG_DIR)/$(TIMESTAMP)' ] || mkdir -p '$(LOG_DIR)/$(TIMESTAMP)'
 	@if ! $(call CHECK_PKG_ARCHIVE,$(1)); then \
 	    $(PRINTF_FMT) '[download]' '$(1)' | $(RTRIM); \
-	    ($(call DOWNLOAD_PKG_ARCHIVE,$(1))) &> '$(LOG_DIR)/$(TIMESTAMP)/$(1)-download'; \
+	    (set -x; $(call DOWNLOAD_PKG_ARCHIVE,$(1))) &> '$(LOG_DIR)/$(TIMESTAMP)/$(1)-download'; \
 	    grep 'MXE Warning' '$(LOG_DIR)/$(TIMESTAMP)/$(1)-download'; \
 	    ln -sf '$(TIMESTAMP)/$(1)-download' '$(LOG_DIR)/$(1)-download'; \
 	    if ! $(call CHECK_PKG_ARCHIVE,$(1)); then \

--- a/Makefile
+++ b/Makefile
@@ -33,9 +33,9 @@ LIBTOOLIZE := $(shell glibtoolize --help >/dev/null 2>&1 && echo g)libtoolize
 PATCH      := $(shell gpatch --help >/dev/null 2>&1 && echo g)patch
 SED        := $(shell gsed --help >/dev/null 2>&1 && echo g)sed
 SORT       := $(shell gsort --help >/dev/null 2>&1 && echo g)sort
-WGET       := wget --no-check-certificate \
-                   --user-agent=$(shell wget --version | \
-                   $(SED) -n 's,GNU \(Wget\) \([0-9.]*\).*,\1/\2,p')
+DEFAULT_UA := $(shell wget --version | $(SED) -n 's,GNU \(Wget\) \([0-9.]*\).*,\1/\2,p')
+WGET0      := wget --no-check-certificate
+WGET       := $(WGET0) --user-agent='$(DEFAULT_UA)'
 
 REQUIREMENTS := autoconf automake autopoint bash bison bzip2 flex \
                 $(BUILD_CC) $(BUILD_CXX) gperf intltoolize $(LIBTOOL) \
@@ -233,10 +233,10 @@ DOWNLOAD_PKG_ARCHIVE = \
         true\
     $(else),\
         mkdir -p '$(PKG_DIR)' && ( \
-            $(WGET) -T 30 -t 3 -O- '$($(1)_URL)' \
+            $(WGET0) --user-agent='$(if $($(1)_UA),$($(1)_UA),$(DEFAULT_UA))' -T 30 -t 3 -O- '$($(1)_URL)' \
             $(if $($(1)_URL_2), \
                 || (echo "MXE Warning! Downloading $(1) from second URL." >&2 && \
-                    $(WGET) -T 30 -t 3 -O- '$($(1)_URL_2)')) \
+                    $(WGET0) --user-agent='$(if $($(1)_UA),$($(1)_UA),$(DEFAULT_UA))' -T 30 -t 3 -O- '$($(1)_URL_2)')) \
             $(if $(MXE_NO_BACKUP_DL),, \
                 || $(BACKUP_DOWNLOAD)) \
         ) \

--- a/src/levmar.mk
+++ b/src/levmar.mk
@@ -7,6 +7,7 @@ $(PKG)_CHECKSUM := 3bf4ef1ea4475ded5315e8d8fc992a725f2e7940a74ca3b0f9029d9e6e94b
 $(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
 $(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tgz
 $(PKG)_URL      := http://www.ics.forth.gr/~lourakis/$(PKG)/$($(PKG)_FILE)
+$(PKG)_UA       := MXE
 $(PKG)_DEPS     := gcc blas lapack libf2c
 
 define $(PKG)_UPDATE


### PR DESCRIPTION
Parameter $(PKG)_UA overrides default user agent used by wget to download a package. It is needed, because download server www.ics.forth.gr from where levmar is downloaded, crashes on default user agent Wget/1.13.4. User agent for levmar was set to MXE. Now the server works. Fix https://github.com/mxe/mxe/issues/1519

Extra change in this pull request: print wget command to download logs.
This command is useful for downloading problems debugging.
