### PR TITLE
luarocks wrapper: remove lock if failed

### DIFF
--- a/plugins/luarocks/luarocks.mk
+++ b/plugins/luarocks/luarocks.mk
@@ -49,8 +49,10 @@ define $(PKG)_BUILD_SHARED
      echo '    echo "Waiting for $(PREFIX)/$(TARGET)/lib/luarocks/lock.dir to lock"'; \
      echo '    sleep 5'; \
      echo 'done'; \
-     echo '"$(PREFIX)/$(TARGET)/bin/luarocks.lua" "$$@"'; \
+     echo 'result=0'; \
+     echo '"$(PREFIX)/$(TARGET)/bin/luarocks.lua" "$$@" || result=$$?'; \
      echo 'rmdir "$(PREFIX)/$(TARGET)/lib/luarocks/lock.dir"'; \
+     echo 'exit $$result'; \
     ) \
              > '$(PREFIX)/$(TARGET)/bin/luarocks'
     chmod 0755 '$(PREFIX)/$(TARGET)/bin/luarocks'


### PR DESCRIPTION
Luarocks wrapper used to keep lock dir not removed if luarocks process failed.
To run it again, the lock directory should have been removed manually.