### PR TITLE
openssl: remove libgcrypt dependency

### DIFF
--- a/src/openssl.mk
+++ b/src/openssl.mk
@@ -8,7 +8,7 @@ $(PKG)_SUBDIR   := openssl-$($(PKG)_VERSION)
 $(PKG)_FILE     := openssl-$($(PKG)_VERSION).tar.gz
 $(PKG)_URL      := http://www.openssl.org/source/$($(PKG)_FILE)
 $(PKG)_URL_2    := http://www.openssl.org/source/old/$(call tr,$([a-z]),,$($(PKG)_VERSION))/$($(PKG)_FILE)
-$(PKG)_DEPS     := gcc libgcrypt zlib
+$(PKG)_DEPS     := gcc zlib
 
 define $(PKG)_UPDATE
     $(WGET) -q -O- 'http://www.openssl.org/source/' | \


### PR DESCRIPTION
libgcrypt dependency was added in 9f465ff71479dba32e092581165a2c7256554ac9 by @vog on behalf of @mabrand.
In https://github.com/mxe/mxe/pull/1508#issuecomment-242895809 @tonytheodore said it could be removed.

Tested on i686-w64-mingw32.shared