### PR TITLE
add new variables: BUILD_CROSS, BUILD_NATIVE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -550,6 +550,7 @@ $(PREFIX)/$(3)/installed/$(1): $(PKG_MAKEFILES) \
 build-only-$(1)_$(3): PKG = $(1)
 build-only-$(1)_$(3): TARGET = $(3)
 build-only-$(1)_$(3): BUILD_$(if $(findstring shared,$(3)),SHARED,STATIC) = TRUE
+build-only-$(1)_$(3): BUILD_$(if $(call seq,$(TARGET),$(BUILD)),NATIVE,CROSS) = TRUE
 build-only-$(1)_$(3): LIB_SUFFIX = $(if $(findstring shared,$(3)),dll,a)
 build-only-$(1)_$(3): BITS = $(if $(findstring x86_64,$(3)),64,32)
 build-only-$(1)_$(3): BUILD_TYPE = $(if $(findstring debug,$(3) $($(1)_CONFIGURE_OPTS)),debug,release)

--- a/src/yasm.mk
+++ b/src/yasm.mk
@@ -19,7 +19,7 @@ endef
 
 define $(PKG)_BUILD
     # link to native yasm compiler on cross builds
-    $(if $(call sne,$(TARGET),$(BUILD)),
+    $(if $(BUILD_CROSS),
         ln -sf '$(PREFIX)/$(BUILD)/bin/yasm' '$(PREFIX)/bin/$(TARGET)-yasm')
 
     # yasm is always static


### PR DESCRIPTION
They are useful for applying flags only to cross or only to native targets.