### PR TITLE
libgda: fix build failure on perl v5.22.1

### DIFF
--- a/src/libgda-1-fixes.patch
+++ b/src/libgda-1-fixes.patch
@@ -1,0 +1,71 @@
+This file is part of MXE. See LICENSE.md for licensing information.
+
+Contains ad hoc patches for cross building.
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Vivien Malerba <malerba@gnome-db.org>
+Date: Sun, 22 Feb 2015 21:41:46 +0100
+Subject: [PATCH] Misc. demos/ corrections
+
+Fix of libgda-ui/demos/ddl_queries.c was excluded, because
+we need this only to fix Perl failure.
+
+
+diff --git a/libgda-ui/demos/geninclude.pl.in b/libgda-ui/demos/geninclude.pl.in
+index 1111111..2222222 100755
+--- a/libgda-ui/demos/geninclude.pl.in
++++ b/libgda-ui/demos/geninclude.pl.in
+@@ -40,7 +40,7 @@ foreach $href (@demos) {
+ 	my $do_next = 0;
+ 
+ 	# parent detected
+-	if (defined @parents) {
++	if (@parents) {
+ 	    foreach $foo (@parents) {
+ 		if ($foo eq $parent_name) {
+ 		    $do_next = 1;
+@@ -54,7 +54,7 @@ foreach $href (@demos) {
+ 
+ 	push @parents, $parent_name;
+ 
+-	$tmp = (defined @child_arrays)?($#child_arrays + 1):0;
++	$tmp = (@child_arrays)?($#child_arrays + 1):0;
+ 	push @child_arrays, "child$tmp";
+ 
+ 	push @demos, {"title" => $parent_name, "file" => "NULL",
+@@ -62,7 +62,7 @@ foreach $href (@demos) {
+     }
+ }
+ 
+-if (defined @parents) {
++if (@parents) {
+     $i = 0;
+     for ($i = 0; $i <= $#parents; $i++) {
+ 	$first = 1;
+@@ -73,7 +73,7 @@ if (defined @parents) {
+ 	for ($j = 0; $j <= $#demos; $j++) {
+ 	    $href = $demos[$j];
+ 	    
+-	    if (!defined $demos[$j]) {
++	    if (!$demos[$j]) {
+ 		next;
+ 	    }
+ 	    
+@@ -105,7 +105,7 @@ if (defined @parents) {
+ } @demos_old;
+ 
+ # sort the child arrays
+-if (defined @child_arrays) {
++if (@child_arrays) {
+     for ($i = 0; $i <= $#child_arrays; $i++) {
+ 	@foo_old = @{$child_arrays[$i]};
+ 
+@@ -133,7 +133,7 @@ foreach $href (@demos) {
+ 	print ", \n";
+     }
+ 
+-    if (defined @parents) {
++    if (@parents) {
+ 	for ($i = 0; $i <= $#parents; $i++) {
+ 	    if ($parents[$i] eq $href->{title}) {
+ 


### PR DESCRIPTION
Error:

```
make[4]: Entering directory
'mxe/tmp-libgda-i686-w64-mingw32.static/libgda-4.2.13/libgda-ui/demos'
(here=`pwd` ; cd . && perl $here/geninclude.pl basic_form.c data_model_dir.c
form.c form_rw.c form_pict.c form_data_layout.c grid.c grid_rw.c grid_pict.c
grid_data_layout.c linked_grid_form.c linked_model_param.c ddl_queries.c
login.c provider_sel.c tree.c cloud.c combo.c) > demos.h
Can't use 'defined(@array)' (Maybe you should just omit the defined()?)
at mxe/tmp-libgda-i686-w64-mingw32.static/libgda-4.2.13/libgda-ui/demos/geninclude.pl line 43.
Makefile:819: recipe for target 'demos.h' failed
```

Similar to https://github.com/mxe/mxe/issues/1112
Fix https://github.com/mxe/mxe/issues/1524