### PR TITLE
gcc5 plugin: update gcc from 5.3 to 5.4

### DIFF
--- a/plugins/gcc5/gcc5-overlay.mk
+++ b/plugins/gcc5/gcc5-overlay.mk
@@ -18,8 +18,8 @@ $(PKG)_URL      := http://isl.gforge.inria.fr/$($(PKG)_FILE)
 $(PKG)_URL_2    := ftp://gcc.gnu.org/pub/gcc/infrastructure/$($(PKG)_FILE)
 
 PKG             := gcc
-$(PKG)_VERSION  := 5.3.0
-$(PKG)_CHECKSUM := b84f5592e9218b73dbae612b5253035a7b34a9a1f7688d2e1bfaaf7267d5c4db
+$(PKG)_VERSION  := 5.4.0
+$(PKG)_CHECKSUM := 608df76dec2d34de6558249d8af4cbee21eceddbcb580d666f7a5a583ca3303a
 $(PKG)_SUBDIR   := gcc-$($(PKG)_VERSION)
 $(PKG)_FILE     := gcc-$($(PKG)_VERSION).tar.bz2
 $(PKG)_URL      := http://ftp.gnu.org/pub/gnu/gcc/gcc-$($(PKG)_VERSION)/$($(PKG)_FILE)


### PR DESCRIPTION
Gcc 5.3 fails to build with gcc 6.
The error message is:

    cfns.gperf:101:1: error: ‘const char* libc_name_p(const char*, unsigned int)’ redeclared inline with ‘gnu_inline’ attribute

See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=69959
See https://github.com/mxe/mxe/pull/1527#issuecomment-256273786