### PR TITLE
qt, qtbase: -no-pch (pre-compiled header support)

### DIFF
--- a/src/qt.mk
+++ b/src/qt.mk
@@ -65,6 +65,7 @@ define $(PKG)_BUILD
         -system-sqlite \
         -openssl-linked \
         -dbus-linked \
+        -no-pch \
         -v \
         $($(PKG)_CONFIGURE_OPTS)
 

--- a/src/qtbase.mk
+++ b/src/qtbase.mk
@@ -57,6 +57,7 @@ define $(PKG)_BUILD
             -system-pcre \
             -openssl-linked \
             -dbus-linked \
+            -no-pch \
             -v \
             $($(PKG)_CONFIGURE_OPTS)
 


### PR DESCRIPTION
Qt and qtbase fail to build if host compiler is GCC 6 with the following error message:

```
cc1: error: one or more PCH files were found, but they were invalid
cc1: error: use -Winvalid-pch for more information
cc1: fatal error: .obj/release-shared/qt_pch.h: No such file or directory
```

See https://github.com/mxe/mxe/issues/1554
See https://github.com/mxe/mxe/issues/1103
See https://github.com/mxe/mxe/pull/1527#issuecomment-254001204