### PR TITLE
Update liblo version from 0.28rc to 0.28, fix configure and make.

### DIFF
--- a/src/liblo.mk
+++ b/src/liblo.mk
@@ -2,8 +2,8 @@
 
 PKG             := liblo
 $(PKG)_IGNORE   :=
-$(PKG)_VERSION  := 0.28rc
-$(PKG)_CHECKSUM := 38bcde108c351aef715c6199905c5d9fc8f5f72763cb19474485aa3fd2443bb1
+$(PKG)_VERSION  := 0.28
+$(PKG)_CHECKSUM := da94a9b67b93625354dd89ff7fe31e5297fc9400b6eaf7378c82ee1caf7db909
 $(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
 $(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.gz
 $(PKG)_URL      := http://$(SOURCEFORGE_MIRROR)/project/$(PKG)/$(PKG)/$($(PKG)_VERSION)/$($(PKG)_FILE)
@@ -16,12 +16,8 @@ define $(PKG)_UPDATE
 endef
 
 define $(PKG)_BUILD
-    cd '$(1)' && ./configure \
-        --host='$(TARGET)' \
-        --disable-shared \
-        --prefix='$(PREFIX)/$(TARGET)'
-    $(MAKE) -C '$(1)' -j '$(JOBS)' bin_PROGRAMS= sbin_PROGRAMS= noinst_PROGRAMS=
-    $(MAKE) -C '$(1)' -j 1 install bin_PROGRAMS= sbin_PROGRAMS= noinst_PROGRAMS=
+    cd '$(BUILD_DIR)' && '$(SOURCE_DIR)'/configure \
+        $(MXE_CONFIGURE_OPTS)
+    $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)' $(MXE_DISABLE_CRUFT)
+    $(MAKE) -C '$(BUILD_DIR)' -j 1 install $(MXE_DISABLE_CRUFT)
 endef
-
-$(PKG)_BUILD_SHARED =


### PR DESCRIPTION
Try to use the latest (really useful) guidelines by @starius (not yet merged). Also allow for shared build, which was previously disabled.

Testing on a fresh MXE, for both shared and static with posix, the result is the following:

```
......................../mxe/usr$ find -name "liblo[\.-]*"
./x86_64-w64-mingw32.shared.posix/bin/liblo-7.dll
./x86_64-w64-mingw32.shared.posix/lib/liblo.dll.a
./x86_64-w64-mingw32.shared.posix/lib/liblo.la
./x86_64-w64-mingw32.shared.posix/lib/pkgconfig/liblo.pc
./x86_64-w64-mingw32.static.posix/lib/liblo.a
./x86_64-w64-mingw32.static.posix/lib/liblo.la
./x86_64-w64-mingw32.static.posix/lib/pkgconfig/liblo.pc
```

Not sure what else is needed. I could try it. :)