### PR TITLE
Upgrade PortAudio to version 19.6.0

### DIFF
--- a/src/portaudio-1-fixes-crlf.patch
+++ b/src/portaudio-1-fixes-crlf.patch
@@ -2,33 +2,10 @@ This file is part of MXE. See LICENSE.md for licensing information.
 
 Contains ad hoc patches for cross building.
 
-From dfa2eeb14b92d2bbaf1f6916b2d154b98719d470 Mon Sep 17 00:00:00 2001
-From: MXE
-Date: Tue, 30 Jun 2015 21:20:47 -0400
-Subject: [PATCH 1/4] configure: Fix wdmks source file path
-
-
-diff --git a/configure.in b/configure.in
-index 305b64e..3f3b31e 100644
---- a/configure.in
-+++ b/configure.in
-@@ -318,7 +318,7 @@ case "${host_os}" in
- 
-         if [[ "x$with_wdmks" = "xyes" ]]; then
-             DXDIR="$with_dxdir"
--            add_objects src/hostapi/wdmks/pa_win_wdmks.o src/common/pa_ringbuffer.o src/os/win/pa_win_hostapis.o src/os/win/pa_win_util.o src/os/win/pa_win_wdmks_util.o src/os/win/pa_win_waveformat.o
-+            add_objects src/hostapi/wdmks/pa_win_wdmks.o src/common/pa_ringbuffer.o src/os/win/pa_win_hostapis.o src/os/win/pa_win_util.o src/os/win/pa_win_wdmks_utils.o src/os/win/pa_win_waveformat.o
-             LIBS="${LIBS} -lwinmm -lm -luuid -lsetupapi -lole32"
-             DLL_LIBS="${DLL_LIBS} -lwinmm -lm -L$DXDIR/lib -luuid -lsetupapi -lole32"
-             #VC98="\"/c/Program Files/Microsoft Visual Studio/VC98/Include\""
--- 
-1.9.1
-
-
 From 19e458bb064fbccadecced9c20f5c05c65018c2c Mon Sep 17 00:00:00 2001
 From: MXE
 Date: Tue, 30 Jun 2015 21:21:17 -0400
-Subject: [PATCH 2/4] pa_win_ds: Add shim for macro
+Subject: [PATCH 1/2] pa_win_ds: Add shim for macro
 
 
 diff --git a/src/hostapi/dsound/pa_win_ds.c b/src/hostapi/dsound/pa_win_ds.c
@@ -59,35 +36,10 @@ index 98afb5c..2b24981 100644
 1.9.1
 
 
-From 65b0f52b1a450a7a773ec6cf6a76822e665ed266 Mon Sep 17 00:00:00 2001
-From: MXE
-Date: Tue, 30 Jun 2015 21:21:38 -0400
-Subject: [PATCH 3/4] pa_win_wdmks: Remove extraneous winioctl.h inclusion
-
-This caused compilation failure on mingw-w64.
-
-http://music.columbia.edu/pipermail/portaudio/2015-June/016833.html
-
-diff --git a/src/hostapi/wdmks/pa_win_wdmks.c b/src/hostapi/wdmks/pa_win_wdmks.c
-index f969e14..5fca590 100644
---- a/src/hostapi/wdmks/pa_win_wdmks.c
-+++ b/src/hostapi/wdmks/pa_win_wdmks.c
-@@ -87,7 +87,6 @@ of a device for the duration of active stream using those devices
- #include "pa_win_wdmks.h"
- 
- #include <windows.h>
--#include <winioctl.h>
- #include <process.h>
- 
- #include <math.h>
--- 
-1.9.1
-
-
 From 4cec0d1cc47fcf3dd71fded3678282981d5d4f74 Mon Sep 17 00:00:00 2001
 From: MXE
 Date: Tue, 30 Jun 2015 21:25:55 -0400
-Subject: [PATCH 4/4] pa_win_wasapi: Fix compilation on mingw-w64
+Subject: [PATCH 2/2] pa_win_wasapi: Fix compilation on mingw-w64
 
 
 diff --git a/configure.in b/configure.in

--- a/src/portaudio.mk
+++ b/src/portaudio.mk
@@ -2,8 +2,8 @@
 
 PKG             := portaudio
 $(PKG)_IGNORE   :=
-$(PKG)_VERSION  := 19_20140130
-$(PKG)_CHECKSUM := 8fe024a5f0681e112c6979808f684c3516061cc51d3acc0b726af98fc96c8d57
+$(PKG)_VERSION  := 190600_20161030
+$(PKG)_CHECKSUM := f5a21d7dcd6ee84397446fa1fa1a0675bb2e8a4a6dceb4305a8404698d8d1513
 $(PKG)_SUBDIR   := portaudio
 $(PKG)_FILE     := pa_stable_v$($(PKG)_VERSION).tgz
 $(PKG)_URL      := http://www.portaudio.com/archives/$($(PKG)_FILE)


### PR DESCRIPTION
I had a little problem at first:

```
$ make portaudio
[using autodetected 2 job(s)]
[check requirements]
Missing requirement: openssl
```

To make it work, I compiled it like this:

    make portaudio DONT_CHECK_REQUIREMENTS=1

But I guess this is unrelated to my changes to the PortAudio package.