### PR TITLE
Update ffmpeg

### DIFF
--- a/src/ffmpeg.mk
+++ b/src/ffmpeg.mk
@@ -2,8 +2,8 @@
 
 PKG             := ffmpeg
 $(PKG)_IGNORE   :=
-$(PKG)_VERSION  := 3.1.1
-$(PKG)_CHECKSUM := a5bca50a90a37b983eaa17c483a387189175f37ca678ae7e51d43e7610b4b3b4
+$(PKG)_VERSION  := 3.2.1
+$(PKG)_CHECKSUM := 72abc55bea5ff5397ac82320fa5c4843a05f527d0d7912d66784c92fdfbd12fb
 $(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
 $(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.bz2
 $(PKG)_URL      := http://www.ffmpeg.org/releases/$($(PKG)_FILE)

--- a/src/x264.mk
+++ b/src/x264.mk
@@ -2,8 +2,8 @@
 
 PKG             := x264
 $(PKG)_IGNORE   :=
-$(PKG)_VERSION  := 20160706-2245
-$(PKG)_CHECKSUM := 8f9176385c3a15706fbdd08cc32c735d926471f0d33d9cf0664e9d82c38ac10f
+$(PKG)_VERSION  := 20161130-2245
+$(PKG)_CHECKSUM := 0825e14945bc373107f9a00e66d45d5389bb86368efd834b92c52cddb2ded1d8
 $(PKG)_SUBDIR   := $(PKG)-snapshot-$($(PKG)_VERSION)
 $(PKG)_FILE     := $(PKG)-snapshot-$($(PKG)_VERSION).tar.bz2
 $(PKG)_URL      := http://download.videolan.org/pub/videolan/$(PKG)/snapshots/$($(PKG)_FILE)


### PR DESCRIPTION
Tested for:
* x86_64-w64-mingw32.static and x86_64-w64-mingw32.shared targets built with gcc6
* i686-w64-mingw32.static and i686-w64-mingw32.shared targets built with gcc4.9
