### PR TITLE
Update gdal

### DIFF
--- a/src/gdal.mk
+++ b/src/gdal.mk
@@ -2,8 +2,8 @@
 
 PKG             := gdal
 $(PKG)_IGNORE   :=
-$(PKG)_VERSION  := 2.1.0
-$(PKG)_CHECKSUM := eb499b18e5c5262a803bb7530ae56e95c3293be7b26c74bcadf67489203bf2cd
+$(PKG)_VERSION  := 2.1.2
+$(PKG)_CHECKSUM := 69761c38acac8c6d3ea71304341f6982b5d66125a1a80d9088b6bfd2019125c9
 $(PKG)_SUBDIR   := gdal-$($(PKG)_VERSION)
 $(PKG)_FILE     := gdal-$($(PKG)_VERSION).tar.gz
 $(PKG)_URL      := http://download.osgeo.org/gdal/$($(PKG)_VERSION)/$($(PKG)_FILE)

--- a/src/proj.mk
+++ b/src/proj.mk
@@ -2,8 +2,8 @@
 
 PKG             := proj
 $(PKG)_IGNORE   :=
-$(PKG)_VERSION  := 4.9.2
-$(PKG)_CHECKSUM := 60bf9ad1ed1c18158e652dfff97865ba6fb2b67f1511bc8dceae4b3c7e657796
+$(PKG)_VERSION  := 4.9.3
+$(PKG)_CHECKSUM := 6984542fea333488de5c82eea58d699e4aff4b359200a9971537cd7e047185f7
 $(PKG)_SUBDIR   := proj-$($(PKG)_VERSION)
 $(PKG)_FILE     := proj-$($(PKG)_VERSION).tar.gz
 $(PKG)_URL      := http://download.osgeo.org/proj/$($(PKG)_FILE)

--- a/src/tiff.mk
+++ b/src/tiff.mk
@@ -2,8 +2,8 @@
 
 PKG             := tiff
 $(PKG)_IGNORE   :=
-$(PKG)_VERSION  := 4.0.6
-$(PKG)_CHECKSUM := 4d57a50907b510e3049a4bba0d7888930fdfc16ce49f1bf693e5b6247370d68c
+$(PKG)_VERSION  := 4.0.7
+$(PKG)_CHECKSUM := 9f43a2cfb9589e5cecaa66e16bf87f814c945f22df7ba600d63aac4632c4f019
 $(PKG)_SUBDIR   := tiff-$($(PKG)_VERSION)
 $(PKG)_FILE     := tiff-$($(PKG)_VERSION).tar.gz
 $(PKG)_URL      := http://download.osgeo.org/libtiff/$($(PKG)_FILE)


### PR DESCRIPTION
Tested for:
* x86_64-w64-mingw32.static and x86_64-w64-mingw32.shared targets built with gcc6
* i686-w64-mingw32.static and i686-w64-mingw32.shared targets built with gcc4.9