### PR TITLE
Update fontconfig

### DIFF
--- a/src/fontconfig.mk
+++ b/src/fontconfig.mk
@@ -2,8 +2,8 @@
 
 PKG             := fontconfig
 $(PKG)_IGNORE   :=
-$(PKG)_VERSION  := 2.12.0
-$(PKG)_CHECKSUM := b433e4efff1f68fdd8aac221ed1df3ff1e580ffedbada020a703fe64017d8224
+$(PKG)_VERSION  := 2.12.1
+$(PKG)_CHECKSUM := b449a3e10c47e1d1c7a6ec6e2016cca73d3bd68fbbd4f0ae5cc6b573f7d6c7f3
 $(PKG)_SUBDIR   := fontconfig-$($(PKG)_VERSION)
 $(PKG)_FILE     := fontconfig-$($(PKG)_VERSION).tar.bz2
 $(PKG)_URL      := http://fontconfig.org/release/$($(PKG)_FILE)


### PR DESCRIPTION
Tested for:
* x86_64-w64-mingw32.static and x86_64-w64-mingw32.shared targets built with gcc6
* i686-w64-mingw32.static and i686-w64-mingw32.shared targets built with gcc4.9