### PR TITLE
crystalhd: change download URL to a mirror

### DIFF
--- a/src/crystalhd.mk
+++ b/src/crystalhd.mk
@@ -6,7 +6,7 @@ $(PKG)_VERSION  := 1
 $(PKG)_CHECKSUM := 818d72fdbebcfc0a449d9e39153370c80325f2490798f82f1ed98c6bb60bc18c
 $(PKG)_SUBDIR   := .
 $(PKG)_FILE     := crystalhd_lgpl_includes_v$($(PKG)_VERSION).zip
-$(PKG)_URL      := http://www.broadcom.com/docs/support/$(PKG)/$($(PKG)_FILE)
+$(PKG)_URL      := https://ftp.videolan.org/contrib/$(PKG)/$($(PKG)_FILE)
 $(PKG)_DEPS     := gcc
 
 define $(PKG)_UPDATE


### PR DESCRIPTION
Failed download: https://travis-ci.org/mxe/mxe/builds/181565782

http://www.broadcom.com/docs/support/crystalhd/crystalhd_lgpl_includes_v1.zip
does not work anymore.

From https://www.broadcom.com/

> Introducing the New Broadcom Limited Website
> Broadcom and Avago are one company. Now the websites
> are integrated, too. Find all the product information
> you need right here in one place.

one can conclude that the file is not expected to appear there,
so switching to mirror website https://ftp.videolan.org/contrib/crystalhd/
which hosts the same file.