### PR TITLE
fix detection of openssl in Debian Sid

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -353,7 +353,7 @@ override MXE_PLUGIN_DIRS += $(realpath $(TOP_DIR)/plugins/native/$(OS_SHORT_NAME
 
 .PHONY: check-requirements
 define CHECK_REQUIREMENT
-    @if ! $(1) --help &>/dev/null; then \
+    @if ! ( $(1) --help || $(1) help ) &>/dev/null; then \
         echo 'Missing requirement: $(1)'; \
         touch check-requirements-failed; \
     fi


### PR DESCRIPTION
```
$ openssl --help
Invalid command '--help'; type "help" for a list.
$ echo $?
1

$ openssl help
...
$ echo $?
0
```

fix https://github.com/mxe/mxe/issues/1593