### PR TITLE
libdvdetect: add dependency on openssl

### DIFF
--- a/src/libdvdetect.mk
+++ b/src/libdvdetect.mk
@@ -7,7 +7,7 @@ $(PKG)_CHECKSUM := b098e04660532df78836f50bc0a8044b66c6659b07a6bff6609724ad30a87
 $(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
 $(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.gz
 $(PKG)_URL      := https://github.com/nschlia/libdvdetect/releases/download/RELEASE_0_71/$(PKG)-$($(PKG)_VERSION).tar.gz
-$(PKG)_DEPS     := gcc tinyxml
+$(PKG)_DEPS     := gcc openssl tinyxml
 
 define $(PKG)_UPDATE
     $(call MXE_GET_GITHUB_TAGS, libdvdetect/libdvdetect, release-)


### PR DESCRIPTION
It depends through Requires.private.
Broken build: https://gist.github.com/c1606f613d18fbcdf938941145f5fbbb