### PR TITLE
native upx: disable asm

### DIFF
--- a/src/upx.mk
+++ b/src/upx.mk
@@ -48,6 +48,7 @@ define $(PKG)_BUILD_$(BUILD)
         CC='$(BUILD_CC)' \
         PKG_CONFIG='$(PREFIX)/$(BUILD)/bin/pkgconf' \
         LIBS='-L$(PREFIX)/$(BUILD)/lib -lucl -lz' \
+        CXXFLAGS=-DUCL_NO_ASM \
         CXXFLAGS_WERROR= \
         exeext=
     cp '$(1)/src/upx' '$(PREFIX)/$(BUILD)/bin/'


### PR DESCRIPTION
It fails to build on 32-bit Ubuntu due to attempt to use ASM version.

See http://lists.nongnu.org/archive/html/mingw-cross-env-list/2016-12/msg00000.html