### PR TITLE
download blas from backup

### DIFF
--- a/src/blas.mk
+++ b/src/blas.mk
@@ -7,7 +7,7 @@ $(PKG)_VERSION  := 3.5.0
 $(PKG)_CHECKSUM := ef7d775d380f255d1902bce374ff7c8a594846454fcaeae552292168af1aca24
 $(PKG)_SUBDIR   := BLAS-$($(PKG)_VERSION)
 $(PKG)_FILE     := $(PKG).tgz
-$(PKG)_URL      := http://www.netlib.org/$(PKG)/$($(PKG)_FILE)
+$(PKG)_URL      := http://www.netlib.org/404
 $(PKG)_DEPS     := gcc
 
 define $(PKG)_UPDATE


### PR DESCRIPTION
... while upstream URL is being fixed

See https://github.com/mxe/mxe/issues/1610

It is a workaround.