### PR TITLE
add package gst-libav

### DIFF
--- a/src/gst-libav.mk
+++ b/src/gst-libav.mk
@@ -1,0 +1,25 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+PKG             := gst-libav
+$(PKG)_WEBSITE  := https://gstreamer.freedesktop.org/modules/gst-libav.html
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 1.6.2
+$(PKG)_CHECKSUM := 2597acc00171006d49f0d300440a87df51b113d557466e532153abc740db3469
+$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.xz
+$(PKG)_URL      := http://gstreamer.freedesktop.org/src/$(PKG)/$($(PKG)_FILE)
+$(PKG)_DEPS     := gcc gst-plugins-base
+
+$(PKG)_UPDATE = $(subst gstreamer/refs,gst-libav/refs,$(gstreamer_UPDATE))
+
+define $(PKG)_BUILD
+    cd '$(BUILD_DIR)' && '$(SOURCE_DIR)/configure' \
+        $(MXE_CONFIGURE_OPTS)
+    $(MAKE) -C '$(BUILD_DIR)' -j $(JOBS)
+    $(MAKE) -C '$(BUILD_DIR)' -j 1 install
+
+    # some .dlls are installed to lib - no obvious way to change
+    $(if $(BUILD_SHARED),
+        mv -vf '$(PREFIX)/$(TARGET)/lib/gstreamer-1.0/'*.dll '$(PREFIX)/$(TARGET)/bin/'
+    )
+endef


### PR DESCRIPTION
gst-libav is required by clementine for playing wma and ape formats.