### PR TITLE
add package qtsparkle (build with Qt5)

### DIFF
--- a/src/qtsparkle-1-fixes.patch
+++ b/src/qtsparkle-1-fixes.patch
@@ -1,0 +1,20 @@
+This file is part of MXE. See LICENSE.md for licensing information.
+
+Contains ad hoc patches for cross building.
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Pavel Vatagin <pavelvat@gmail.com>
+Date: Sat, 28 Jan 2017 03:05:58 +0300
+Subject: [PATCH] disable build exampleapp
+
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 1111111..2222222 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -34,4 +34,4 @@ SET(CMAKE_C_FLAGS    "${CMAKE_C_FLAGS} -Wall")
+ SET(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -Wall")
+ 
+ add_subdirectory(src)
+-add_subdirectory(exampleapp)
++#add_subdirectory(exampleapp)

--- a/src/qtsparkle-test.cpp
+++ b/src/qtsparkle-test.cpp
@@ -1,0 +1,17 @@
+/*
+ * This file is part of MXE. See LICENSE.md for licensing information.
+ */
+
+#include <qtsparkle-qt5/Updater>
+#include <QWidget>
+#include <QUrl>
+
+int main()
+{
+	QWidget w;
+	qtsparkle::Updater* updater = new qtsparkle::Updater(
+		QUrl("http://www.example.com/sparkle.xml"), &w);
+	updater->SetVersion("1.0");
+
+	return 0;
+}

--- a/src/qtsparkle.mk
+++ b/src/qtsparkle.mk
@@ -1,0 +1,48 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+PKG             := qtsparkle
+$(PKG)_WEBSITE  := https://github.com/davidsansome/qtsparkle
+$(PKG)_DESCR    := Qt auto-updater lib
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 4c852e57061d7928573afdf88f04f89d85167477
+$(PKG)_CHECKSUM := 6b8500de51c6a8dd402663fed99bced0588e5be50cfe8474f6d3b46f92025934
+$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.gz
+$(PKG)_URL      := https://github.com/davidsansome/$(PKG)/archive/$($(PKG)_VERSION).tar.gz
+$(PKG)_DEPS     := gcc qttools
+
+define $(PKG)_UPDATE
+    $(call MXE_GET_GITHUB_TAGS, davidsansome/qtsparkle)
+endef
+
+define $(PKG)_BUILD_COMMON
+    cd '$(BUILD_DIR)' && $(TARGET)-cmake '$(SOURCE_DIR)' \
+        -DBUILD_WITH_QT4=@qtsparkle_use_qt4@
+    $(MAKE) -C '$(BUILD_DIR)' -j $(JOBS)
+    $(MAKE) -C '$(BUILD_DIR)' -j 1 install
+
+    # create pkg-config file
+    $(INSTALL) -d '$(PREFIX)/$(TARGET)/lib/pkgconfig'
+    (echo 'prefix=$(PREFIX)/$(TARGET)'; \
+     echo 'exec_prefix=$${prefix}'; \
+     echo 'libdir=$${exec_prefix}/lib'; \
+     echo 'includedir=$${prefix}/include'; \
+     echo ''; \
+     echo 'Name: $(PKG)'; \
+     echo 'Version: '; \
+     echo 'Description: Qt auto-updater lib'; \
+     echo 'Requires: @qtsparkle_pc_requires@'; \
+     echo 'Libs: -L$${libdir} -lqtsparkle@qtsparkle_version_suffix@'; \
+     echo 'Cflags: -I$${includedir}') \
+     > '$(PREFIX)/$(TARGET)/lib/pkgconfig/qtsparkle@qtsparkle_version_suffix@.pc'
+
+    $(TARGET)-g++ \
+        -W -Wall -Werror -std=c++11 -pedantic \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-$(PKG).exe' \
+        `$(TARGET)-pkg-config qtsparkle@qtsparkle_version_suffix@ --cflags --libs`
+endef
+
+$(PKG)_BUILD = $(subst @qtsparkle_use_qt4@,OFF, \
+               $(subst @qtsparkle_version_suffix@,-qt5, \
+               $(subst @qtsparkle_pc_requires@,Qt5Core Qt5Network Qt5Widgets, \
+               $($(PKG)_BUILD_COMMON))))

--- a/src/qtsparkle_qt4.mk
+++ b/src/qtsparkle_qt4.mk
@@ -1,43 +1,22 @@
 # This file is part of MXE. See LICENSE.md for licensing information.
 
 PKG             := qtsparkle_qt4
-$(PKG)_WEBSITE  := https://github.com/davidsansome/qtsparkle
-$(PKG)_DESCR    := qtsparkle
-$(PKG)_IGNORE   :=
-$(PKG)_VERSION  := 8882e6ef86cdb79db7932307309d005411fd0c20
-$(PKG)_CHECKSUM := 86f6f010356e05e6efb956b5643ce587ffbbae45e8e7dc1b25b4b1dcf865b5f3
-$(PKG)_SUBDIR   := qtsparkle-$($(PKG)_VERSION)
-$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.gz
-$(PKG)_URL      := https://github.com/davidsansome/qtsparkle/archive/$($(PKG)_VERSION).tar.gz
+$(PKG)_WEBSITE   = $(qtsparkle_WEBSITE)
+$(PKG)_DESCR     = $(qtsparkle_DESCR)
+$(PKG)_IGNORE    = $(qtsparkle_IGNORE)
+$(PKG)_VERSION   = $(qtsparkle_VERSION)
+$(PKG)_CHECKSUM  = $(qtsparkle_CHECKSUM)
+$(PKG)_SUBDIR    = $(qtsparkle_SUBDIR)
+$(PKG)_FILE      = $(qtsparkle_FILE)
+$(PKG)_URL       = $(qtsparkle_URL)
+$(PKG)_PATCHES   = $(realpath $(sort $(wildcard $(addsuffix /qtsparkle-[0-9]*.patch, $(TOP_DIR)/src))))
 $(PKG)_DEPS     := gcc qt
 
 define $(PKG)_UPDATE
-    $(call MXE_GET_GITHUB_TAGS, davidsansome/qtsparkle)
+    echo $(qtsparkle_VERSION)
 endef
 
-define $(PKG)_BUILD
-    mkdir '$(1).build'
-    cd '$(1).build' && '$(TARGET)-cmake' '$(1)'
-    $(MAKE) -C '$(1).build' -j '$(JOBS)'
-    $(MAKE) -C '$(1).build' -j 1 install
-
-    # create pkg-config file
-    $(INSTALL) -d '$(PREFIX)/$(TARGET)/lib/pkgconfig'
-    (echo 'prefix=$(PREFIX)/$(TARGET)'; \
-     echo 'exec_prefix=$${prefix}'; \
-     echo 'libdir=$${exec_prefix}/lib'; \
-     echo 'includedir=$${prefix}/include'; \
-     echo ''; \
-     echo 'Name: $(PKG)'; \
-     echo 'Version: '; \
-     echo 'Description: $(PKG)'; \
-     echo 'Requires: QtCore QtGui QtNetwork QtXml'; \
-     echo 'Libs: -L$${libdir} -lqtsparkle'; \
-     echo 'Cflags: -I$${includedir}';) \
-     > '$(PREFIX)/$(TARGET)/lib/pkgconfig/$(PKG).pc'
-
-    $(TARGET)-g++ \
-        -W -Wall -Werror -ansi -pedantic \
-        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-$(PKG).exe' \
-        `$(TARGET)-pkg-config $(PKG) --cflags --libs`
-endef
+$(PKG)_BUILD = $(subst @qtsparkle_use_qt4@,ON, \
+               $(subst @qtsparkle_version_suffix@,, \
+               $(subst @qtsparkle_pc_requires@,QtCore QtGui QtNetwork QtXml, \
+               $(qtsparkle_BUILD_COMMON))))


### PR DESCRIPTION
Qt5 version of qtsparkle are required for https://github.com/clementine-player/Clementine/tree/qt5

Problems with linking for static targets: https://gist.github.com/pavelvat/1497b6ce639ff1f12baaad14c92c2c9a
Previously I fixed similar problem by listing all dependent libraries: https://github.com/eiskaltdcpp/eiskaltdcpp/blob/master/eiskaltdcpp-qt/CMakeLists.txt#L268-L291
Maybe anybody to know how to make universal static build (i.e. for MXE Qt5, for 
mxe/plugins/examples/custom-qt-min, for non MXE Qt5) without listing all dependent libraries in CMakeLists.txt?