### PR TITLE
gnutls: disable tests

### DIFF
--- a/src/gnutls.mk
+++ b/src/gnutls.mk
@@ -27,6 +27,7 @@ define $(PKG)_BUILD
         --disable-nls \
         --disable-guile \
         --disable-doc \
+        --disable-tests \
         --enable-local-libopts \
         --with-included-libtasn1 \
         --with-libregex-libs="-lgnurx" \


### PR DESCRIPTION
tests install a dummy libcrypt32 which clobbers the w32api

see: https://github.com/mxe/mxe/pull/1541#issuecomment-273373973

