### PR TITLE
add package liblastfm

### DIFF
--- a/src/liblastfm-1-fixes.patch
+++ b/src/liblastfm-1-fixes.patch
@@ -1,0 +1,30 @@
+This file is part of MXE. See LICENSE.md for licensing information.
+
+Contains ad hoc patches for cross building.
+
+From 480e2ec663ef867e7892dbbc624737cae176c717 Mon Sep 17 00:00:00 2001
+From: Dominik Schmidt <dev@dominik-schmidt.de>
+Date: Fri, 6 Feb 2015 01:55:40 +0100
+Subject: [PATCH] Add LASTFM_LIB_VERSION_SUFFIX to include dir as well
+ https://github.com/lastfm/liblastfm/commit/480e2ec663ef867e7892dbbc624737cae176c717
+
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 211ca7e..0f872fb 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -105,4 +105,4 @@ install(TARGETS ${LASTFM_LIB_TARGET_NAME}
+ 
+ file(GLOB liblastfm_HEADERS ${CMAKE_CURRENT_LIST_DIR}/*.h)
+ list(APPEND liblastfm_HEADERS ${CMAKE_CURRENT_BINARY_DIR}/global.h)
+-install(FILES ${liblastfm_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/lastfm/)
++install(FILES ${liblastfm_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/lastfm${LASTFM_LIB_VERSION_SUFFIX}/)
+diff --git a/src/fingerprint/CMakeLists.txt b/src/fingerprint/CMakeLists.txt
+index fbc492c..126f8d9 100644
+--- a/src/fingerprint/CMakeLists.txt
++++ b/src/fingerprint/CMakeLists.txt
+@@ -48,4 +48,4 @@ install(TARGETS ${FINGERPRINT_LIB_TARGET_NAME}
+     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+ )
+ 
+-install(FILES ${lastfm_fingerprint_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/lastfm/)
++install(FILES ${lastfm_fingerprint_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/lastfm${LASTFM_LIB_VERSION_SUFFIX}/)

--- a/src/liblastfm-test.cpp
+++ b/src/liblastfm-test.cpp
@@ -1,0 +1,13 @@
+/*
+ * This file is part of MXE. See LICENSE.md for licensing information.
+ */
+
+#include <lastfm5/Track.h>
+
+int main()
+{
+    lastfm::MutableTrack track;
+    track.setTitle("Track");
+
+    return 0;
+}

--- a/src/liblastfm.mk
+++ b/src/liblastfm.mk
@@ -1,0 +1,46 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+PKG             := liblastfm
+$(PKG)_WEBSITE  := https://github.com/lastfm/liblastfm
+$(PKG)_DESCR    := A Qt C++ library for the Last.fm webservices
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 1.0.9
+$(PKG)_CHECKSUM := 5276b5fe00932479ce6fe370ba3213f3ab842d70a7d55e4bead6e26738425f7b
+$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.gz
+$(PKG)_URL      := https://github.com/lastfm/$(PKG)/archive/$($(PKG)_VERSION).tar.gz
+$(PKG)_DEPS     := gcc fftw libsamplerate qtbase
+
+define $(PKG)_UPDATE
+    $(call MXE_GET_GITHUB_TAGS, lastfm/liblastfm)
+endef
+
+define $(PKG)_BUILD
+    cd '$(BUILD_DIR)' && $(TARGET)-cmake '$(SOURCE_DIR)' \
+        -DBUILD_WITH_QT4=OFF
+
+    $(MAKE) -C '$(BUILD_DIR)' -j $(JOBS)
+    $(MAKE) -C '$(BUILD_DIR)' -j 1 install
+
+    # create pkg-config file
+    $(INSTALL) -d '$(PREFIX)/$(TARGET)/lib/pkgconfig'
+    (echo 'prefix=$(PREFIX)/$(TARGET)'; \
+     echo 'exec_prefix=$${prefix}'; \
+     echo 'libdir=$${exec_prefix}/lib'; \
+     echo 'includedir=$${prefix}/include'; \
+     echo ''; \
+     echo 'Name: $(PKG)'; \
+     echo 'Version: $($(PKG)_VERSION)'; \
+     echo 'Description: A Qt C++ library for the Last.fm webservices'; \
+     echo 'Requires: Qt5Core Qt5Network Qt5Xml'; \
+     echo 'Libs: -L$${libdir} -llastfm5'; \
+     echo 'Cflags: -I$${includedir}';) \
+     > '$(PREFIX)/$(TARGET)/lib/pkgconfig/$(PKG)5.pc'
+
+    $(TARGET)-g++ \
+        -W -Wall -Werror -std=c++11 -pedantic \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-$(PKG).exe' \
+        `$(TARGET)-pkg-config $(PKG)5 --cflags --libs`
+endef
+
+$(PKG)_BUILD_STATIC =


### PR DESCRIPTION
Qt5 build.
patch is required to separate headers of lastfm for Qt4 and Qt5 builds.
#1356
Clementine from Debian has used this library.