### PR TITLE
mingw-w64: add --enable-secure-api

### DIFF
--- a/src/gcc.mk
+++ b/src/gcc.mk
@@ -78,6 +78,7 @@ define $(PKG)_BUILD_mingw-w64
         --prefix='$(PREFIX)/$(TARGET)' \
         --enable-sdk=all \
         --enable-idl \
+        --enable-secure-api \
         $(mingw-w64-headers_CONFIGURE_OPTS)
     $(MAKE) -C '$(1).headers-build' install
 


### PR DESCRIPTION
This is needed to update glib to 2.51.1. It uses strerror_s,
which is guarded by MINGW_HAS_SECURE_API.

See http://win-builds.org/bugs/index.php?do=details&task_id=79
See https://sourceforge.net/p/tdm-gcc/bugs/305/