### PR TITLE
ricochet depends on specific parts of Qt5, not all

### DIFF
--- a/plugins/apps/ricochet.mk
+++ b/plugins/apps/ricochet.mk
@@ -9,7 +9,7 @@ $(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION)-src.tar.bz2
 $(PKG)_URL      := https://ricochet.im/releases/$($(PKG)_VERSION)/$($(PKG)_FILE)
 $(PKG)_WEBSITE  := https://ricochet.im/
 $(PKG)_OWNER    := https://github.com/starius
-$(PKG)_DEPS     := gcc openssl protobuf qt5
+$(PKG)_DEPS     := gcc openssl protobuf qtbase qtdeclarative qtmultimedia qtquickcontrols qttools
 
 define $(PKG)_UPDATE
     $(call MXE_GET_GITHUB_TAGS, ricochet-im/ricochet, v)


### PR DESCRIPTION
The list of components was deduced from official build instructions:
https://github.com/ricochet-im/ricochet/blob/master/BUILDING.md#fedora

See https://github.com/mxe/mxe/pull/1607#pullrequestreview-19498314