### PR TITLE
boost: add test for boost.context linking

### DIFF
--- a/src/boost-test.cmake
+++ b/src/boost-test.cmake
@@ -7,7 +7,7 @@ set(TGT test-${PKG}-cmake)
 enable_language(CXX)
 add_executable(${TGT} ${CMAKE_CURRENT_LIST_DIR}/${PKG}-test.cpp)
 
-find_package(Boost ${PKG_VERSION} EXACT COMPONENTS chrono serialization system thread REQUIRED)
+find_package(Boost ${PKG_VERSION} EXACT COMPONENTS chrono context serialization system thread REQUIRED)
 target_link_libraries(${TGT} ${Boost_LIBRARIES})
 
 install(TARGETS ${TGT} DESTINATION bin)

--- a/src/boost-test.cpp
+++ b/src/boost-test.cpp
@@ -9,12 +9,33 @@
 
 boost::thread_specific_ptr<int> ptr;
 
+// http://www.boost.org/doc/libs/1_60_0/libs/context/doc/html/context/context.html
+#include <boost/context/all.hpp>
+boost::context::fcontext_t fcm,fc1,fc2;
+
 void test_thread()
 {
     if (ptr.get() == 0) {
         ptr.reset(new int(0));
     }
     std::cout << "Hello, World! from thread" << std::endl;
+}
+
+void f1(intptr_t)
+{
+    std::cout<<"f1: entered"<<std::endl;
+    std::cout<<"f1: call jump_fcontext( & fc1, fc2, 0)"<< std::endl;
+    boost::context::jump_fcontext(&fc1,fc2,0);
+    std::cout<<"f1: return"<<std::endl;
+    boost::context::jump_fcontext(&fc1,fcm,0);
+}
+
+void f2(intptr_t)
+{
+    std::cout<<"f2: entered"<<std::endl;
+    std::cout<<"f2: call jump_fcontext( & fc2, fc1, 0)"<<std::endl;
+    boost::context::jump_fcontext(&fc2,fc1,0);
+    BOOST_ASSERT(false&&!"f2: never returns");
 }
 
 int main(int argc, char *argv[])
@@ -28,6 +49,16 @@ int main(int argc, char *argv[])
 
     boost::thread thrd(test_thread);
     thrd.join();
+
+    std::size_t size(8192);
+    void* sp1(std::malloc(size));
+    void* sp2(std::malloc(size));
+
+    fc1=boost::context::make_fcontext(sp1,size,f1);
+    fc2=boost::context::make_fcontext(sp2,size,f2);
+
+    std::cout<<"main: call jump_fcontext( & fcm, fc1, 0)"<<std::endl;
+    boost::context::jump_fcontext(&fcm,fc1,0);
 
     return 0;
 }

--- a/src/boost.mk
+++ b/src/boost.mk
@@ -73,7 +73,8 @@ define $(PKG)_BUILD
         -lboost_serialization-mt \
         -lboost_thread_win32-mt \
         -lboost_system-mt \
-        -lboost_chrono-mt
+        -lboost_chrono-mt \
+        -lboost_context-mt
 
     # test cmake
     mkdir '$(1).test-cmake'


### PR DESCRIPTION
See http://lists.nongnu.org/archive/html/mingw-cross-env-list/2017-02/msg00002.html

Appears to build and run:
![image](https://cloud.githubusercontent.com/assets/537773/22585167/89825dce-ea4a-11e6-9f84-41f75a373ba9.png)
