### PR TITLE
allow non-default exception handling targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,8 +87,26 @@ MXE_CONFIGURE_OPTS = \
         --disable-static --enable-shared ) \
     $(MXE_DISABLE_DOC_OPTS)
 
+# GCC threads and exceptions
 MXE_GCC_THREADS = \
-    $(if $(findstring posix,$(TARGET)),posix,win32)
+    $(if $(findstring posix,$(or $(TARGET),$(1))),posix,win32)
+
+# allowed exception handling for targets
+# default (first item) and alternate, revisit if gcc/mingw-w64 change defaults
+i686-w64-mingw32_EH   := sjlj dw2
+x86_64-w64-mingw32_EH := seh sjlj
+
+# functions to determine exception handling from user-specified target
+# $(or $(TARGET),$(1)) allows use as both function and inline snippet
+TARGET_EH_LIST = $($(firstword $(call split,.,$(or $(TARGET),$(1))))_EH)
+DEFAULT_EH     = $(firstword $(TARGET_EH_LIST))
+GCC_EXCEPTIONS = \
+    $(lastword $(DEFAULT_EH) \
+               $(filter $(TARGET_EH_LIST),$(call split,.,$(or $(TARGET),$(1)))))
+MXE_GCC_EXCEPTION_OPTS = \
+    $(if $(call seq,sjlj,$(GCC_EXCEPTIONS)),--enable-sjlj-exceptions) \
+    $(if $(call seq,dw2,$(GCC_EXCEPTIONS)),--disable-sjlj-exceptions)
+
 
 # Append these to the "make" and "make install" steps of autotools packages
 # in order to neither build nor install unwanted binaries, manpages,

--- a/Makefile
+++ b/Makefile
@@ -570,6 +570,7 @@ build-only-$(1)_$(3): PKG = $(1)
 build-only-$(1)_$(3): TARGET = $(3)
 build-only-$(1)_$(3): BUILD_$(if $(findstring shared,$(3)),SHARED,STATIC) = TRUE
 build-only-$(1)_$(3): BUILD_$(if $(call seq,$(TARGET),$(BUILD)),NATIVE,CROSS) = TRUE
+build-only-$(1)_$(3): $(if $(findstring posix,$(TARGET)),POSIX,WIN32)_THREADS = TRUE
 build-only-$(1)_$(3): LIB_SUFFIX = $(if $(findstring shared,$(3)),dll,a)
 build-only-$(1)_$(3): BITS = $(if $(findstring x86_64,$(3)),64,32)
 build-only-$(1)_$(3): BUILD_TYPE = $(if $(findstring debug,$(3) $($(1)_CONFIGURE_OPTS)),debug,release)

--- a/README.md
+++ b/README.md
@@ -33,5 +33,12 @@ various target platforms, which:
   * GCC Threading Libraries (`winpthreads` is always available):
     - win32
     - [posix (experimental)](https://github.com/mxe/mxe/pull/958)
+  * GCC Exception Handling:
+    - Default
+      - i686: sjlj
+      - x86_64: seh
+    - [Alternatives (experimental)](https://github.com/mxe/mxe/pull/1664)
+      - i686: dw2
+      - x86_64: sjlj
 
 Please see [mxe.cc](http://mxe.cc/) for further information and package support matrix.

--- a/docs/index.html
+++ b/docs/index.html
@@ -163,6 +163,10 @@
         Experimental support for GCC with posix threads was
         added in <a href="https://github.com/mxe/mxe/pull/958">November 2015</a>.
     </p>
+    <p>
+        Experimental support for alternate GCC Exception Handling was
+        added in <a href="https://github.com/mxe/mxe/pull/1664">February 2017</a>.
+    </p>
 
 </div>
 

--- a/src/gcc.mk
+++ b/src/gcc.mk
@@ -37,6 +37,7 @@ define $(PKG)_CONFIGURE
         --without-x \
         --disable-win32-registry \
         --enable-threads=$(MXE_GCC_THREADS) \
+        $(MXE_GCC_EXCEPTION_OPTS) \
         --enable-libgomp \
         --with-gmp='$(PREFIX)/$(BUILD)' \
         --with-isl='$(PREFIX)/$(BUILD)' \
@@ -45,7 +46,8 @@ define $(PKG)_CONFIGURE
         --with-as='$(PREFIX)/bin/$(TARGET)-as' \
         --with-ld='$(PREFIX)/bin/$(TARGET)-ld' \
         --with-nm='$(PREFIX)/bin/$(TARGET)-nm' \
-        $(shell [ `uname -s` == Darwin ] && echo "LDFLAGS='-Wl,-no_pie'")
+        $(shell [ `uname -s` == Darwin ] && echo "LDFLAGS='-Wl,-no_pie'") \
+        $($(PKG)_CONFIGURE_OPTS)
 endef
 
 define $(PKG)_BUILD_mingw-w64

--- a/src/libmysqlclient-1-fixes.patch
+++ b/src/libmysqlclient-1-fixes.patch
@@ -450,3 +450,23 @@ index 1111111..2222222 100644
  #include "mysys_priv.h"
  #include <process.h>
  #include <signal.h>
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tony Theodore <tonyt@logyst.com>
+Date: Wed, 8 Feb 2017 11:51:42 +1100
+Subject: [PATCH] only define localtime_r and gmtime_r when pthreads isn't used
+
+
+diff --git a/include/my_global.h b/include/my_global.h
+index 1111111..2222222 100644
+--- a/include/my_global.h
++++ b/include/my_global.h
+@@ -629,7 +629,7 @@ enum loglevel {
+ };
+ 
+ 
+-#ifdef _WIN32
++#if defined(_WIN32) && !defined(_POSIX_THREAD_SAFE_FUNCTIONS)
+ /****************************************************************************
+ ** Replacements for localtime_r and gmtime_r
+ ****************************************************************************/


### PR DESCRIPTION
See #1411 and #1559 allows variants like:
```
i686-w64-mingw32.static.posix.dw2
i686-w64-mingw32.static.dw2
x86_64-w64-mingw32.shared.win32.sjlj
etc.
```