### PR TITLE
glib 2.50.2 native build fails, libmount dependency missing

### DIFF
--- a/src/glib.mk
+++ b/src/glib.mk
@@ -47,6 +47,7 @@ define $(PKG)_NATIVE_BUILD
         --disable-fam \
         --disable-xattr \
         --disable-dtrace \
+        --disable-libmount \
         --with-libiconv=gnu \
         --with-pcre=internal \
         CPPFLAGS='-I$(1).native/$(libiconv_SUBDIR)/include -I$(1).native/$(zlib_SUBDIR)' \


### PR DESCRIPTION
Recent versions of glib require libmount on Linux. If it is unavailable,
configure fails with

    checking libmount/libmount.h presence... no
    checking for libmount/libmount.h... no
    configure: error: *** Could not find libmount

This commit disables libmount by patching `--disable-libmount` into the configure command line.

(FYI, the windows build is unaffected because libmount is only enabled by default on Linux.)