### PR TITLE
Travis: print spaces every minute to fix build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ sudo: false
 script:
   - make docs/build-matrix.html docs/packages.json OS_SHORT_NAME=disable-native-plugins
   - if [ "$GH_TOKEN" != "" ]; then ./tools/travis-push.sh; fi
+  # Package wxwidgets is downloaded for more than 10 minutes,
+  # Travis failed because of no output for 10 minutes.
+  - while true; do sleep 60; echo -n ' '; done &
   - make download -j 6 -k MXE_PLUGIN_DIRS="$(./tools/plugins-with-additional-packages.sh)"
 
 env:

--- a/src/mxml.mk
+++ b/src/mxml.mk
@@ -1,14 +1,14 @@
 # This file is part of MXE. See LICENSE.md for licensing information.
 
 PKG             := mxml
-$(PKG)_WEBSITE  := http://www.msweet.org/projects.php?Z3
+$(PKG)_WEBSITE  := https://michaelrsweet.github.io/
 $(PKG)_DESCR    := Mini-XML
 $(PKG)_IGNORE   :=
 $(PKG)_VERSION  := 2.9
 $(PKG)_CHECKSUM := cded54653c584b24c4a78a7fa1b3b4377d49ac4f451ddf170ebbc8161d85ff92
 $(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
 $(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.gz
-$(PKG)_URL      := http://www.msweet.org/files/project3/$($(PKG)_FILE)
+$(PKG)_URL      := https://github.com/michaelrsweet/mxml/releases/download/release-$($(PKG)_VERSION)/$($(PKG)_FILE)
 $(PKG)_DEPS     := gcc pthreads
 
 define $(PKG)_UPDATE


### PR DESCRIPTION
Package wxwidgets is downloaded for more than 10 minutes,
Travis failed because of no output for 10 minutes:
https://travis-ci.org/mxe/mxe/builds/205649309