### PR TITLE
add libidn2 and use it in curl instead of libidn

### DIFF
--- a/src/curl.mk
+++ b/src/curl.mk
@@ -9,7 +9,7 @@ $(PKG)_CHECKSUM := 4b124ff5984f2b537790a8f50dbf3d44da89e57d0505ba567128535a2426f
 $(PKG)_SUBDIR   := curl-$($(PKG)_VERSION)
 $(PKG)_FILE     := curl-$($(PKG)_VERSION).tar.lzma
 $(PKG)_URL      := https://curl.haxx.se/download/$($(PKG)_FILE)
-$(PKG)_DEPS     := gcc gnutls libidn libssh2
+$(PKG)_DEPS     := gcc gnutls libidn2 libssh2
 
 define $(PKG)_UPDATE
     $(WGET) -q -O- 'https://curl.haxx.se/download/?C=M;O=D' | \
@@ -22,7 +22,7 @@ define $(PKG)_BUILD
         $(MXE_CONFIGURE_OPTS) \
         --with-gnutls \
         --without-ssl \
-        --with-libidn \
+        --with-libidn2 \
         --enable-sspi \
         --enable-ipv6 \
         --with-libssh2

--- a/src/libidn2-1-fixes.patch
+++ b/src/libidn2-1-fixes.patch
@@ -1,0 +1,87 @@
+This file is part of MXE. See LICENSE.md for licensing information.
+
+Contains ad hoc patches for cross building.
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Boris Nagaev <bnagaev@gmail.com>
+Date: Sun, 5 Mar 2017 03:01:18 +0100
+Subject: [PATCH] disable gentr46map.exe
+
+This tool was used to regenerate tr46map_data.c.
+The release has recent version of this file anyway.
+
+diff --git a/Makefile.in b/Makefile.in
+index 1111111..2222222 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -94,7 +94,6 @@ PRE_UNINSTALL = :
+ POST_UNINSTALL = :
+ build_triplet = @build@
+ host_triplet = @host@
+-noinst_PROGRAMS = gentr46map$(EXEEXT)
+ @HAVE_LD_VERSION_SCRIPT_TRUE@am__append_1 = -Wl,--version-script=$(srcdir)/idn2.map
+ @HAVE_LD_VERSION_SCRIPT_FALSE@am__append_2 = -export-symbols-regex '^idn2_.*|_idn2_punycode_..code'
+ subdir = .
+@@ -198,9 +197,6 @@ libidn2_la_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) \
+ 	$(LIBTOOLFLAGS) --mode=link $(CCLD) $(AM_CFLAGS) $(CFLAGS) \
+ 	$(libidn2_la_LDFLAGS) $(LDFLAGS) -o $@
+ PROGRAMS = $(noinst_PROGRAMS)
+-gentr46map_SOURCES = gentr46map.c
+-gentr46map_OBJECTS = gentr46map.$(OBJEXT)
+-gentr46map_DEPENDENCIES = $(am__DEPENDENCIES_1)
+ AM_V_P = $(am__v_P_@AM_V@)
+ am__v_P_ = $(am__v_P_@AM_DEFAULT_V@)
+ am__v_P_0 = false
+@@ -235,8 +231,8 @@ AM_V_CCLD = $(am__v_CCLD_@AM_V@)
+ am__v_CCLD_ = $(am__v_CCLD_@AM_DEFAULT_V@)
+ am__v_CCLD_0 = @echo "  CCLD    " $@;
+ am__v_CCLD_1 = 
+-SOURCES = $(libidn2_la_SOURCES) gentr46map.c
+-DIST_SOURCES = $(libidn2_la_SOURCES) gentr46map.c
++SOURCES = $(libidn2_la_SOURCES)
++DIST_SOURCES = $(libidn2_la_SOURCES)
+ RECURSIVE_TARGETS = all-recursive check-recursive cscopelist-recursive \
+ 	ctags-recursive dvi-recursive html-recursive info-recursive \
+ 	install-data-recursive install-dvi-recursive \
+@@ -635,10 +631,9 @@ TR46MAP = IdnaMappingTable.txt
+ TR46MAP_URL = http://www.unicode.org/Public/idna/6.3.0/IdnaMappingTable.txt
+ NFCQC = DerivedNormalizationProps.txt
+ NFCQC_URL = http://www.unicode.org/Public/6.3.0/ucd/DerivedNormalizationProps.txt
+-BUILT_SOURCES = data.c tr46map_data.c
++BUILT_SOURCES = data.c
+ DISTCLEANFILES = tr46map_data.c
+ MAINTAINERCLEANFILES = $(IDNA_TABLE) $(TR46MAP) $(NFCQC)
+-gentr46map_LDADD = $(LTLIBUNISTRING)
+ LCOV_INFO = libidn2.info
+ all: $(BUILT_SOURCES) config.h
+ 	$(MAKE) $(AM_MAKEFLAGS) all-recursive
+@@ -744,10 +739,6 @@ clean-noinstPROGRAMS:
+ 	echo " rm -f" $$list; \
+ 	rm -f $$list
+ 
+-gentr46map$(EXEEXT): $(gentr46map_OBJECTS) $(gentr46map_DEPENDENCIES) $(EXTRA_gentr46map_DEPENDENCIES) 
+-	@rm -f gentr46map$(EXEEXT)
+-	$(AM_V_CCLD)$(LINK) $(gentr46map_OBJECTS) $(gentr46map_LDADD) $(LIBS)
+-
+ mostlyclean-compile:
+ 	-rm -f *.$(OBJEXT)
+ 
+@@ -759,7 +750,6 @@ distclean-compile:
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/data.Plo@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/error.Plo@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/free.Plo@am__quote@
+-@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/gentr46map.Po@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/idna.Plo@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/lookup.Plo@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/punycode.Plo@am__quote@
+@@ -1261,10 +1251,6 @@ data.c: $(srcdir)/gen-tables-from-iana.pl $(IDNA_TABLE)
+ 	cat $(IDNA_TABLE) | $(srcdir)/gen-tables-from-iana.pl > $@.new
+ 	mv $@.new $@
+ 
+-tr46map_data.c: gentr46map.c gentr46map$(EXEEXT) $(TR46MAP) $(NFCQC)
+-	$(builddir)/gentr46map$(EXEEXT) > $@.new
+-	mv $@.new $@
+-
+ $(IDNA_TABLE):
+ 	if ! echo "4ebaf0c72061474d20078897d254768d894507de $(IDNA_TABLE)" | sha1sum -c -; then \
+ 	  rm -f $(IDNA_TABLE); \

--- a/src/libidn2-test.c
+++ b/src/libidn2-test.c
@@ -1,0 +1,44 @@
+/*
+ * This file is part of MXE. See LICENSE.md for licensing information.
+ *
+ * Based on https://www.gnu.org/software/libidn/libidn2/manual/libidn2.html#Lookup
+ */
+
+#include <stdio.h> /* printf, fflush, fgets, stdin, perror, fprintf */
+#include <string.h> /* strlen */
+#include <locale.h> /* setlocale */
+#include <stdlib.h> /* free */
+#include <idn2.h> /* idn2_lookup_ul, IDN2_OK, idn2_strerror, idn2_strerror_name */
+
+int
+main ()
+{
+  int rc;
+  char src[BUFSIZ];
+  char *lookupname;
+
+  setlocale (LC_ALL, "");
+
+  printf ("Enter (possibly non-ASCII) domain name to lookup: ");
+  fflush (stdout);
+  if (!fgets (src, sizeof (src), stdin))
+    {
+      perror ("fgets");
+      return 1;
+    }
+  src[strlen (src) - 1] = '\0';
+
+  rc = idn2_lookup_ul (src, &lookupname, 0);
+  if (rc != IDN2_OK)
+    {
+      fprintf (stderr, "error: %s (%s, %d)\n",
+           idn2_strerror (rc), idn2_strerror_name (rc), rc);
+      return 1;
+    }
+
+  printf ("IDNA2008 domain name to lookup in DNS: %s\n", lookupname);
+
+  free (lookupname);
+
+  return 0;
+}

--- a/src/libidn2.mk
+++ b/src/libidn2.mk
@@ -1,0 +1,42 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+PKG             := libidn2
+$(PKG)_WEBSITE  := https://www.gnu.org/software/libidn/\#libidn2
+$(PKG)_DESCR    := implementation of IDNA2008/TR46 internationalized domain names
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 0.16
+$(PKG)_CHECKSUM := 2fad9efff4082ae2143f69df76339ca99379e0e0f4231455f5d3d9d2089c688f
+$(PKG)_SUBDIR   := libidn2-$($(PKG)_VERSION)
+$(PKG)_FILE     := libidn2-$($(PKG)_VERSION).tar.gz
+$(PKG)_URL      := https://alpha.gnu.org/gnu/libidn/$($(PKG)_FILE)
+$(PKG)_DEPS     := gcc libiconv libunistring
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- https://alpha.gnu.org/gnu/libidn/ | \
+    $(SED) -n 's,.*libidn2-\([0-9][^t]*\).tar.gz.*,\1,p' | \
+    head -1
+endef
+
+define $(PKG)_BUILD
+    # build and install the library
+    cd '$(BUILD_DIR)' && $(SOURCE_DIR)/configure \
+        $(MXE_CONFIGURE_OPTS)
+    $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)' $(MXE_DISABLE_CRUFT)
+    $(MAKE) -C '$(BUILD_DIR)' -j 1 install $(MXE_DISABLE_CRUFT)
+
+    # create pkg-config files
+    $(INSTALL) -d '$(PREFIX)/$(TARGET)/lib/pkgconfig'
+    (echo 'Name: $(PKG)'; \
+     echo 'Version: $($(PKG)_VERSION)'; \
+     echo 'Description: implementation of IDNA2008/TR46 internationalized domain names'; \
+     echo 'Libs: -lidn2'; \
+     echo 'Libs.private: -lunistring -liconv -lcharset';) \
+     > '$(PREFIX)/$(TARGET)/lib/pkgconfig/$(PKG).pc'
+    # TODO create pc files for iconv and unistring.
+
+    # compile test
+    '$(TARGET)-gcc' \
+        -W -Wall -Werror -ansi -pedantic \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-$(PKG).exe' \
+        `'$(TARGET)-pkg-config' $(PKG) --cflags --libs`
+endef

--- a/tools/build-pkg.lua
+++ b/tools/build-pkg.lua
@@ -58,6 +58,7 @@ local BLACKLIST = {
     '^usr/share/info/',
     '^usr/share/man/',
     '^usr/share/gcc',
+    '^usr/share/gtk-doc',
     '^usr/lib/nonetwork.so',
     '^usr/[^/]+/share/doc/',
     '^usr/[^/]+/share/info/',


### PR DESCRIPTION
libidn was not really used by curl:

> checking if idn2_lookup_ul can be linked... no
> checking idn2.h usability... no
> checking idn2.h presence... no
> checking for idn2.h... no
> IDN support:      no      (--with-{libidn2,winidn})

idn2 works:

> checking if idn2_lookup_ul can be linked... yes
> checking idn2.h usability... yes
> checking idn2.h presence... yes
> checking for idn2.h... yes
> IDN support:      enabled (libidn2)