### PR TITLE
add missing gstreamer dependencies

### DIFF
--- a/src/gst-plugins-bad.mk
+++ b/src/gst-plugins-bad.mk
@@ -8,7 +8,10 @@ $(PKG)_CHECKSUM := 650855e39ff56a8bb6cb0c192109c5926ce12f536d06e19ebf829de71ef39
 $(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
 $(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.xz
 $(PKG)_URL      := https://gstreamer.freedesktop.org/src/$(PKG)/$($(PKG)_FILE)
-$(PKG)_DEPS     := gcc faad2 gst-plugins-base gstreamer libass libgcrypt libmms mpg123 neon openal openjpeg vo-aacenc vo-amrwbenc
+$(PKG)_DEPS     := gcc chromaprint faad2 fdk-aac gst-plugins-base gstreamer gtk3 \
+                   libass libbs2b libdvdnav libdvdread libgcrypt libmms libmodplug librsvg \
+                   librtmp libsndfile libwebp mpg123 neon openal opencv openexr \
+                   openjpeg openssl opus vo-aacenc vo-amrwbenc
 
 $(PKG)_UPDATE = $(subst gstreamer/refs,gst-plugins-bad/refs,$(gstreamer_UPDATE))
 

--- a/src/gst-plugins-good.mk
+++ b/src/gst-plugins-good.mk
@@ -8,8 +8,8 @@ $(PKG)_CHECKSUM := 876e54dfce93274b98e024f353258d35fa4d49d1f9010069e676c530f6eb6
 $(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
 $(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.xz
 $(PKG)_URL      := https://gstreamer.freedesktop.org/src/$(PKG)/$($(PKG)_FILE)
-$(PKG)_DEPS     := gcc cairo flac glib gst-plugins-base gstreamer jpeg \
-                   liboil libpng libshout libsoup libxml2 speex taglib wavpack
+$(PKG)_DEPS     := gcc cairo flac gdk-pixbuf glib gst-plugins-base gstreamer jpeg libcaca \
+                   liboil libpng libshout libsoup libvpx libxml2 speex taglib wavpack
 
 $(PKG)_UPDATE = $(subst gstreamer/refs,gst-plugins-good/refs,$(gstreamer_UPDATE))
 

--- a/src/gst-plugins-ugly.mk
+++ b/src/gst-plugins-ugly.mk
@@ -8,7 +8,8 @@ $(PKG)_CHECKSUM := e7f1b6321c8667fabc0dedce3998a3c6e90ce9ce9dea7186d33dc4359f9e9
 $(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
 $(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.xz
 $(PKG)_URL      := https://gstreamer.freedesktop.org/src/$(PKG)/$($(PKG)_FILE)
-$(PKG)_DEPS     := gcc a52dec gst-plugins-base gstreamer lame libcdio libdvdread libmad opencore-amr twolame x264
+$(PKG)_DEPS     := gcc a52dec gst-plugins-base gstreamer lame libcdio libdvdread \
+                   libmad opencore-amr twolame x264
 
 $(PKG)_UPDATE = $(subst gstreamer/refs,gst-plugins-ugly/refs,$(gstreamer_UPDATE))
 


### PR DESCRIPTION
 fix for https://github.com/mxe/mxe/issues/1624

https://github.com/mxe/mxe/pull/1684 was splitted on two independent PR due to unresolved problem with high CPU usage with gstreamer 1.10.4.