### PR TITLE
disable --no-check-certificate while updating packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ DEFAULT_MAX_JOBS   := 6
 SOURCEFORGE_MIRROR := downloads.sourceforge.net
 PKG_MIRROR         := http://s3.amazonaws.com/mxe-pkg
 PKG_CDN            := http://d1yihgixbnrglp.cloudfront.net
-GITLAB_BACKUP      := https://gitlab.com/starius/mxe-backup2/raw/master/
+GITLAB_BACKUP      := http://gitlab.com/starius/mxe-backup2/raw/master/
 
 PWD        := $(shell pwd)
 SHELL      := bash

--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,7 @@ PATCH      := $(shell gpatch --help >/dev/null 2>&1 && echo g)patch
 SED        := $(shell gsed --help >/dev/null 2>&1 && echo g)sed
 SORT       := $(shell gsort --help >/dev/null 2>&1 && echo g)sort
 DEFAULT_UA := $(shell wget --version | $(SED) -n 's,GNU \(Wget\) \([0-9.]*\).*,\1/\2,p')
-WGET        = wget --no-check-certificate \
-                   --user-agent='$(or $($(1)_UA),$(DEFAULT_UA))'
+WGET        = wget --user-agent='$(or $($(1)_UA),$(DEFAULT_UA))'
 
 REQUIREMENTS := autoconf automake autopoint bash bison bzip2 flex \
                 $(BUILD_CC) $(BUILD_CXX) gperf intltoolize $(LIBTOOL) \
@@ -248,9 +247,9 @@ ESCAPE_PKG = \
 
 BACKUP_DOWNLOAD = \
     (echo "MXE Warning! Downloading $(1) from backup." >&2 && \
-    ($(WGET) -O '$(PKG_DIR)/.tmp-$($(1)_FILE)' $(PKG_MIRROR)/`$(call ESCAPE_PKG,$(1))` || \
-    $(WGET) -O '$(PKG_DIR)/.tmp-$($(1)_FILE)' $(PKG_CDN)/`$(call ESCAPE_PKG,$(1))` || \
-    $(WGET) -O '$(PKG_DIR)/.tmp-$($(1)_FILE)' $(GITLAB_BACKUP)/`$(call ESCAPE_PKG,$(1))`_$($(1)_CHECKSUM)))
+    ($(WGET) --no-check-certificate -O '$(PKG_DIR)/.tmp-$($(1)_FILE)' $(PKG_MIRROR)/`$(call ESCAPE_PKG,$(1))` || \
+    $(WGET) --no-check-certificate -O '$(PKG_DIR)/.tmp-$($(1)_FILE)' $(PKG_CDN)/`$(call ESCAPE_PKG,$(1))` || \
+    $(WGET) --no-check-certificate -O '$(PKG_DIR)/.tmp-$($(1)_FILE)' $(GITLAB_BACKUP)/`$(call ESCAPE_PKG,$(1))`_$($(1)_CHECKSUM)))
 
 DOWNLOAD_PKG_ARCHIVE = \
     $(if $($(1)_SOURCE_TREE),\
@@ -748,6 +747,7 @@ update-package-%:
 	    $(and $($*_UPDATE),$(call UPDATE,$*,$(shell $($*_UPDATE)))), \
 	    $(error Package $* not found))
 
+update-checksum-%: MXE_NO_BACKUP_DL = true
 update-checksum-%:
 	$(if $(call set_is_member,$*,$(PKGS)), \
 	    $(call DOWNLOAD_PKG_ARCHIVE,$*) && \


### PR DESCRIPTION
Regular downloads of packages are verified by checksums, so
--no-check-certificate doesn't compromise the build system,
but the checksums themselves are often updated with update-checksum-%
which in turn calls the regular package download mechanism, so there
is a possibility of downloading and sealing a poisoned file.

On the one hand, old systems may still rely on --no-check-certificate,
so it is not nice to completely disable it for regular downloads.
However keeping this option enabled for backup servers only is enough
to support such systems because of the fallback mechanism.
On the other hand, download from a backup doesn't make sense while
updating a package, because the package is definetely not in the backup yet.

So --no-check-certificate is now enabled only for backup servers
and backup servers are disabled while updating packages.

See https://github.com/mxe/mxe/pull/1694#issuecomment-285324739