### PR TITLE
support overriding CMAKE_BUILD_TYPE in cmdline

### DIFF
--- a/src/cmake/conf/mxe-conf.cmake.in
+++ b/src/cmake/conf/mxe-conf.cmake.in
@@ -25,7 +25,6 @@ endif()
 ## General configuration
 set(CMAKE_SYSTEM_NAME Windows)
 set(MSYS 1)
-set(CMAKE_BUILD_TYPE Release CACHE STRING "Debug|Release|RelWithDebInfo|MinSizeRel" FORCE)
 set(CMAKE_EXPORT_NO_PACKAGE_REGISTRY ON)
 # Workaround for https://www.cmake.org/Bug/view.php?id=14075
 set(CMAKE_CROSS_COMPILING ON)

--- a/src/cmake/conf/target-cmake.in
+++ b/src/cmake/conf/target-cmake.in
@@ -18,6 +18,10 @@ else
     echo "     - warnings for unused CMAKE_POLICY_DEFAULT variables can be ignored"
     echo "== Using MXE toolchain: @CMAKE_TOOLCHAIN_FILE@"
     echo "== Using MXE runresult: @CMAKE_RUNRESULT_FILE@"
+    if ! ( echo "$@" | grep --silent "DCMAKE_BUILD_TYPE" ) ; then
+        echo '== Adding "-DCMAKE_BUILD_TYPE=Release"'
+        set -- "-DCMAKE_BUILD_TYPE=Release" "$@"
+    fi
     exec "@PREFIX@/@BUILD@/bin/cmake" \
               -DCMAKE_TOOLCHAIN_FILE="@CMAKE_TOOLCHAIN_FILE@" \
               `eval echo -DCMAKE_POLICY_DEFAULT_CMP{$POLICIES}=NEW` \


### PR DESCRIPTION
The script checks if -DCMAKE_BUILD_TYPE is passed in command line and if
it is not passed, passes -DCMAKE_BUILD_TYPE=Release. So now other build
types are supported, just pass -DCMAKE_BUILD_TYPE=<desired-type> to the
script $(TARGET)-cmake.