### PR TITLE
binutils: Ensure that the timestamp in PE/COFF headers is always init…

### DIFF
--- a/src/binutils-1-fixes.patch
+++ b/src/binutils-1-fixes.patch
@@ -1,0 +1,29 @@
+This file is part of MXE. See LICENSE.md for licensing information.
+
+Contains ad hoc patches for cross building.
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Sylvain Beucler <beuc@beuc.net>
+Date: Fri, 31 Mar 2017 11:59:35 +0200
+Subject: [PATCH] Ensure that the timestamp in PE/COFF headers is always
+ initialised.
+
+Source: http://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;a=commit;f=bfd/peXXigen.c;h=1c5f704fc035bc705dee887418f42cb8bca24b5d
+
+PR ld/20634
+* peXXigen.c (_bfd_XXi_only_swap_filehdr_out): Put 0 in the
+timestamp field if real time values are not being stored.
+
+diff --git a/bfd/peXXigen.c b/bfd/peXXigen.c
+index 1111111..2222222 100644
+--- a/bfd/peXXigen.c
++++ b/bfd/peXXigen.c
+@@ -875,6 +875,8 @@ _bfd_XXi_only_swap_filehdr_out (bfd * abfd, void * in, void * out)
+   /* Only use a real timestamp if the option was chosen.  */
+   if ((pe_data (abfd)->insert_timestamp))
+     H_PUT_32 (abfd, time (0), filehdr_out->f_timdat);
++  else
++    H_PUT_32 (abfd, 0, filehdr_out->f_timdat);
+ 
+   PUT_FILEHDR_SYMPTR (abfd, filehdr_in->f_symptr,
+ 		      filehdr_out->f_symptr);


### PR DESCRIPTION
Hi,

When using --no-insert-timestamp, instead of inserting a 0 timestamp, ld 2.25.1 does not initialized memory resulting in a random date timestamp. 

This pull requests applies the 2-lines fix from upstream, resulting in stable/reproducible output.

I noticed this issue when working on a reproducible build of my FreeDink game, you can see details at:
https://blog.beuc.net/posts/Practical_basics_of_reproducible_builds_2/
https://blog.beuc.net/posts/Practical_basics_of_reproducible_builds/

(For your info, Debian has a more extensive, upstream-pending patch related to the SOURCE_DATE_EPOCH specification, see specify-timestamp.patch in http://http.debian.net/debian/pool/main/b/binutils-mingw-w64/binutils-mingw-w64_7.4.tar.xz)