### PR TITLE
Makefile: explicitly set .DEFAULT_GOAL for LOCAL_PKG_LIST

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -326,9 +326,14 @@ else
         echo '# The three lines below makes `make` build these "local'; \
         echo '# packages" instead of all packages.'; \
         echo '#LOCAL_PKG_LIST := boost curl file flac lzo pthreads vorbis wxwidgets'; \
-        echo '#.DEFAULT local-pkg-list:'; \
+        echo '#.DEFAULT_GOAL  := local-pkg-list'; \
         echo '#local-pkg-list: $$(LOCAL_PKG_LIST)'; \
     } >'$(PWD)/settings.mk')
+endif
+
+ifneq ($(LOCAL_PKG_LIST),)
+    .DEFAULT_GOAL := local-pkg-list
+    $(info [pkg-list]  $(LOCAL_PKG_LIST))
 endif
 
 # Numeric min and max list functions

--- a/docs/index.html
+++ b/docs/index.html
@@ -934,7 +934,7 @@ USE_OSGPLUGIN(&lt;plugin2&gt;)
         the package list can also be set in
         <code>settings.mk</code>
         <pre>LOCAL_PKG_LIST := foo bar
-.DEFAULT local-pkg-list:
+.DEFAULT_GOAL  := local-pkg-list
 local-pkg-list: $(LOCAL_PKG_LIST)</pre>
         </dd>
         <dd>


### PR DESCRIPTION
Use `.DEFAULT_GOAL` [special variable] instead of `.DEFAULT`
[built-in target] as the latter depends on include order and
can cause confusing behaviour.

`LOCAL_PKG_LIST` was [broken] in #1729 and this allows for any
current `settings.mk` to work correctly. Should also fix #1264
and #1267 since MXE isn't going to include any other files that
set this variable in a surprising way.

[special variable]:https://www.gnu.org/software/make/manual/make.html#Special-Variables
[built-in target]:https://www.gnu.org/software/make/manual/make.html#Special-Targets
[broken]:https://github.com/mxe/mxe/commit/1cf2afb5d3afb1dda0d7a5322be758ec2befd2a1
