### PR TITLE
factor out var WGET_TOOL from WGET

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,8 @@ PATCH      := $(shell gpatch --help >/dev/null 2>&1 && echo g)patch
 SED        := $(shell gsed --help >/dev/null 2>&1 && echo g)sed
 SORT       := $(shell gsort --help >/dev/null 2>&1 && echo g)sort
 DEFAULT_UA := $(shell wget --version | $(SED) -n 's,GNU \(Wget\) \([0-9.]*\).*,\1/\2,p')
-WGET        = wget --user-agent='$(or $($(1)_UA),$(DEFAULT_UA))'
+WGET_TOOL   = wget
+WGET        = $(WGET_TOOL) --user-agent='$(or $($(1)_UA),$(DEFAULT_UA))'
 
 REQUIREMENTS := autoconf automake autopoint bash bison bzip2 flex \
                 $(BUILD_CC) $(BUILD_CXX) gperf intltoolize $(LIBTOOL) \


### PR DESCRIPTION
It is needed to specify a path to custom wget binary without
removing the argument passed by WGET (--user-agent).

Also can be used to add --no-check-certificate back.