### PR TITLE
add new package: quazip

### DIFF
--- a/src/quazip-1-generate-pkg-config.patch
+++ b/src/quazip-1-generate-pkg-config.patch
@@ -1,0 +1,64 @@
+From e3280094b66dd3ce8a850d57cf5b148c9ae5f47d Mon Sep 17 00:00:00 2001
+From: Zoltan Gyarmati <mr.zoltan.gyarmati@gmail.com>
+Date: Sun, 4 Jun 2017 03:19:59 +0200
+Subject: [PATCH 1/2] add pkg-config generation to qmake build
+
+Sent to upstream: https://sourceforge.net/p/quazip/patches/31/
+
+Signed-off-by: Zoltan Gyarmati <mr.zoltan.gyarmati@gmail.com>
+---
+ quazip/quazip.pro | 23 ++++++++++++++++++++++-
+ 1 file changed, 22 insertions(+), 1 deletion(-)
+
+diff --git a/quazip/quazip.pro b/quazip/quazip.pro
+index 3e10f36..eb68954 100644
+--- a/quazip/quazip.pro
++++ b/quazip/quazip.pro
+@@ -2,6 +2,13 @@ TEMPLATE = lib
+ CONFIG += qt warn_on
+ QT -= gui
+ 
++# Creating pkgconfig .pc file
++CONFIG += create_prl no_install_prl create_pc
++
++QMAKE_PKGCONFIG_PREFIX = $$PREFIX
++QMAKE_PKGCONFIG_INCDIR = $$headers.path
++QMAKE_PKGCONFIG_REQUIRES = Qt5Core
++
+ # The ABI version.
+ 
+ !win32:VERSION = 1.0.0
+@@ -43,6 +50,7 @@ unix:!symbian {
+     headers.path=$$PREFIX/include/quazip
+     headers.files=$$HEADERS
+     target.path=$$PREFIX/lib/$${LIB_ARCH}
++    QMAKE_PKGCONFIG_DESTDIR = pkgconfig
+     INSTALLS += headers target
+ 
+ 	OBJECTS_DIR=.obj
+@@ -53,8 +61,21 @@ unix:!symbian {
+ win32 {
+     headers.path=$$PREFIX/include/quazip
+     headers.files=$$HEADERS
+-    target.path=$$PREFIX/lib
+     INSTALLS += headers target
++    CONFIG(staticlib){
++        target.path=$$PREFIX/lib
++        QMAKE_PKGCONFIG_LIBDIR = $$PREFIX/lib/
++    } else {
++        target.path=$$PREFIX/bin
++        QMAKE_PKGCONFIG_LIBDIR = $$PREFIX/bin/
++    }
++
++    ## odd, this path seems to be relative to the
++    ## target.path, so if we install the .dll into
++    ## the 'bin' dir, the .pc will go there as well,
++    ## unless have hack the needed path...
++    ## TODO any nicer solution?
++    QMAKE_PKGCONFIG_DESTDIR = ../lib/pkgconfig
+     # workaround for qdatetime.h macro bug
+     DEFINES += NOMINMAX
+ }
+-- 
+2.11.0
+

--- a/src/quazip-2-link-to-lz.patch
+++ b/src/quazip-2-link-to-lz.patch
@@ -1,0 +1,42 @@
+From cd5a0588c69b9d51382196c0b694f8af68f8daa1 Mon Sep 17 00:00:00 2001
+From: Zoltan Gyarmati <mr.zoltan.gyarmati@gmail.com>
+Date: Sun, 4 Jun 2017 03:22:13 +0200
+Subject: [PATCH 2/2] add -lz dir for win build
+
+Signed-off-by: Zoltan Gyarmati <mr.zoltan.gyarmati@gmail.com>
+---
+ quazip/quazip.pro | 2 ++
+ qztest/qztest.pro | 4 ++--
+ 2 files changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/quazip/quazip.pro b/quazip/quazip.pro
+index eb68954..ad0f915 100644
+--- a/quazip/quazip.pro
++++ b/quazip/quazip.pro
+@@ -78,6 +78,8 @@ win32 {
+     QMAKE_PKGCONFIG_DESTDIR = ../lib/pkgconfig
+     # workaround for qdatetime.h macro bug
+     DEFINES += NOMINMAX
++
++    LIBS += -lz
+ }
+ 
+ 
+diff --git a/qztest/qztest.pro b/qztest/qztest.pro
+index 663aee8..3a9b8e5 100644
+--- a/qztest/qztest.pro
++++ b/qztest/qztest.pro
+@@ -40,8 +40,8 @@ testquazipfile.cpp \
+ OBJECTS_DIR = .obj
+ MOC_DIR = .moc
+ 
+-win32:CONFIG(release, debug|release): LIBS += -L$$OUT_PWD/../quazip/release/ -lquazip
+-else:win32:CONFIG(debug, debug|release): LIBS += -L$$OUT_PWD/../quazip/debug/ -lquazipd
++win32:CONFIG(release, debug|release): LIBS += -L$$OUT_PWD/../quazip/release/ -lquazip -lz
++else:win32:CONFIG(debug, debug|release): LIBS += -L$$OUT_PWD/../quazip/debug/ -lquazipd -lz
+ else:mac:CONFIG(debug, debug|release): LIBS += -L$$OUT_PWD/../quazip/debug/ -lquazip_debug
+ else:unix: LIBS += -L$$OUT_PWD/../quazip/ -lquazip
+ 
+-- 
+2.11.0
+

--- a/src/quazip-3-windows_h.patch
+++ b/src/quazip-3-windows_h.patch
@@ -1,0 +1,28 @@
+From 25480f98ae0aa82e339ea696669cbf48db642f81 Mon Sep 17 00:00:00 2001
+From: Zoltan Gyarmati <mr.zoltan.gyarmati@gmail.com>
+Date: Sat, 3 Jun 2017 11:24:17 +0200
+Subject: [PATCH] use lowercase windows.h
+
+Sent to upstream: https://sourceforge.net/p/quazip/patches/30/
+
+Signed-off-by: Zoltan Gyarmati <mr.zoltan.gyarmati@gmail.com>
+---
+ qztest/testjlcompress.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/qztest/testjlcompress.cpp b/qztest/testjlcompress.cpp
+index 36d6ea3..25c763b 100644
+--- a/qztest/testjlcompress.cpp
++++ b/qztest/testjlcompress.cpp
+@@ -34,7 +34,7 @@ see quazip/(un)zip.h files for details. Basically it's the zlib license.
+ #include <quazip/JlCompress.h>
+ 
+ #ifdef Q_OS_WIN
+-#include <Windows.h>
++#include <windows.h>
+ #endif
+ 
+ void TestJlCompress::compressFile_data()
+-- 
+2.11.0
+

--- a/src/quazip-test.cpp
+++ b/src/quazip-test.cpp
@@ -1,0 +1,11 @@
+// This file is part of MXE.
+// See index.html for further information.
+
+#include <QCoreApplication>
+#include <quazip/JlCompress.h>
+
+int main(int argc, char *argv[]){
+    QCoreApplication a(argc, argv);
+    printf ("%s\n", qPrintable(a.applicationFilePath()));
+    JlCompress::compressFile("quatest.zip", a.applicationFilePath());
+}

--- a/src/quazip.mk
+++ b/src/quazip.mk
@@ -1,0 +1,38 @@
+# This file is part of MXE.
+# See index.html for further information.
+PKG             := quazip
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 0.7.3
+$(PKG)_CHECKSUM := 2ad4f354746e8260d46036cde1496c223ec79765041ea28eb920ced015e269b5
+$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.gz
+$(PKG)_URL      := http://$(SOURCEFORGE_MIRROR)/project/$(PKG)/$(PKG)/$($(PKG)_VERSION)/$($(PKG)_FILE)
+$(PKG)_DEPS     := gcc qtbase
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- 'http://sourceforge.net/projects/quazip/files/quazip/' | \
+    $(SED) -n 's,.*/\([0-9][^"]*\)/".*,\1,p' | \
+    head -1
+endef
+
+
+define $(PKG)_BUILD
+    cd '$(1)' && '$(PREFIX)/$(TARGET)/qt5/bin/qmake' \
+    $(if $(BUILD_STATIC), CONFIG\+=staticlib) \
+    PREFIX=$(PREFIX)/$(TARGET)
+    $(MAKE) -C '$(1)' -j '$(JOBS)'
+    $(if $(BUILD_STATIC), \
+        echo 'Cflags.private: -DQUAZIP_STATIC' >> $(1)/quazip/lib/pkgconfig/quazip.pc)
+    $(MAKE) -C '$(1)' -j 1 install
+
+    # qmake insists to install the static .a
+    # even when building shared lib
+    $(if $(BUILD_SHARED), \
+        rm -f $(PREFIX)/$(TARGET)/bin/libquazip.a)
+
+    '$(TARGET)-g++' \
+        -W -Wall -Werror -std=c++11 -pedantic \
+        '$(TOP_DIR)/src/$(PKG)-test.cpp' \
+        -o '$(PREFIX)/$(TARGET)/bin/test-$(PKG)-pkgconfig.exe' \
+        `'$(TARGET)-pkg-config' quazip --cflags --libs`
+endef


### PR DESCRIPTION
Continuing from #1176, cleaned up and added the requested fixes. If you spot anything further issue, please let me know. 
2 out of the 3 patches are sent to upstream, the one which adds explicit link to -lz is MXE specific, as the user free to link to other zip implementation as well (see https://sourceforge.net/p/quazip/patches/27/#6698 )
