### PR TITLE
gcc 7 build fix: strip  standard -I path from pkg-config output

### DIFF
--- a/src/pkgconf.mk
+++ b/src/pkgconf.mk
@@ -20,8 +20,8 @@ endef
 
 define $(PKG)_BUILD
     # create pkg-config script
-    (echo '#!/bin/sh'; \
-     echo 'PKG_CONFIG_PATH="$(PREFIX)/$(TARGET)/qt5/lib/pkgconfig":"$$PKG_CONFIG_PATH_$(subst .,_,$(subst -,_,$(TARGET)))" PKG_CONFIG_LIBDIR='\''$(PREFIX)/$(TARGET)/lib/pkgconfig'\'' exec '$(PREFIX)/$(BUILD)/bin/pkgconf' $(if $(BUILD_STATIC),--static) "$$@"') \
+    (echo '#!/usr/bin/env bash'; \
+     echo 'PKG_CONFIG_PATH="$(PREFIX)/$(TARGET)/qt5/lib/pkgconfig":"$$PKG_CONFIG_PATH_$(subst .,_,$(subst -,_,$(TARGET)))" PKG_CONFIG_LIBDIR='\''$(PREFIX)/$(TARGET)/lib/pkgconfig'\'' '$(PREFIX)/$(BUILD)/bin/pkgconf' $(if $(BUILD_STATIC),--static) "$$@"' ' | ' '$(SED)' "'s,-I/*$(PREFIX)/$(TARGET)/include\($$\| \),,g;'" '; ' '( exit $${PIPESTATUS[0]} )')  \
              > '$(PREFIX)/bin/$(TARGET)-pkg-config'
     chmod 0755 '$(PREFIX)/bin/$(TARGET)-pkg-config'
 

--- a/src/sqlite.mk
+++ b/src/sqlite.mk
@@ -18,9 +18,6 @@ define $(PKG)_UPDATE
 endef
 
 define $(PKG)_BUILD
-    # The system include path doesn't belong in CFLAGS
-    # Causes problems like https://gitlab.kitware.com/cmake/cmake/issues/16919
-    $(SED) -i 's/^Cflags/#Cflags/;' '$(1)/sqlite3.pc.in'
     cd '$(1)' && ./configure \
         $(MXE_CONFIGURE_OPTS) \
         --disable-readline \


### PR DESCRIPTION
MXE's standard include directory is '$(PREFIX)/$(TARGET)/include'.

Many of the .pc files installed by packages include the standard
include directory in Cflags. This can cause gcc to search paths in
the wrong order. This typically interferes with the intended effect of
the directive #include_next in gcc headers, with "not found" errors for
headers like stdio.h. Using gcc 7, such errors occur when building
qtbase in MXE.

    https://gcc.gnu.org/bugzilla/show_bug.cgi?id=70129
    https://bugreports.qt.io/browse/QTBUG-53375

It is not obvious how to get pkg-config to strip the standard
include path when cross-compiling. According to the pkg-config manpage,
pkg-config normally strips "-I/usr/include" from Cflags.
PKG_CONFIG_SYSROOT_DIR could be set so that pkg-config would prefix
"/usr/include", but this doesn't help cross-compiling in MXE where the
standard include directory in the .pc files is the fully qualified path.
Addionally, MXE's standard include directory does not even end in
"/usr/include".

An alternative would be to patch all .pc files to remove the standard
include directory, but this requires considering each case individually
and creates a maintenance burden.

This solution offered by this patch modifies the wrapper script around
pkg-config, using sed to strip out '-I$(PREFIX)/$(TARGET)/include'.

Notes:
  - Variants of the path with extra preceding / are also handled.

  - Care is taken to get the exit code from pkg-config (not sed), so
    that "pkg-config --exists" can be used.

  - The exit code handling would be much harder without bash.

  - This change assumes the previously used "exec" in the wrappper
    script is not necessary, or at least no longer necessary.

This replaces 43214bf7e886bd310965f854dd3a37b64c685bfa, which fixed
the problem specifically for sqlite.
