### PR TITLE
pkgconf sys include

### DIFF
--- a/src/pkgconf-1-fixes.patch
+++ b/src/pkgconf-1-fixes.patch
@@ -1,0 +1,50 @@
+This file is part of MXE. See LICENSE.md for licensing information.
+
+Contains ad hoc patches for cross building.
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tony Theodore <tonyt@logyst.com>
+Date: Thu, 15 Jun 2017 21:05:31 +1000
+Subject: [PATCH] main: support undocumented PKG_CONFIG_SYSTEM_INCLUDE_PATH and
+ PKG_CONFIG_SYSTEM_LIBRARY_PATH environment variables.
+
+Backported from:
+https://github.com/pkgconf/pkgconf/commit/7e6fa325eb668c3462981a16fb4c36270832e00f
+
+See:
+https://github.com/mxe/mxe/pull/1785
+
+diff --git a/main.c b/main.c
+index 1111111..2222222 100644
+--- a/main.c
++++ b/main.c
+@@ -56,16 +56,27 @@ static char *sysroot_dir = NULL;
+ 
+ FILE *error_msgout = NULL;
+ 
++static char *
++fallback_getenv(const char *envname, const char *fallback)
++{
++	const char *data = getenv(envname);
++
++	if (data == NULL)
++		data = fallback;
++
++	return strdup(data);
++}
++
+ static bool
+ fragment_has_system_dir(pkg_fragment_t *frag)
+ {
+ 	switch (frag->type)
+ 	{
+ 	case 'L':
+-		if ((want_flags & PKG_KEEP_SYSTEM_CFLAGS) == 0 && !strcasecmp(SYSTEM_LIBDIR, frag->data))
++		if ((want_flags & PKG_KEEP_SYSTEM_CFLAGS) == 0 && !strcasecmp(fallback_getenv("PKG_CONFIG_SYSTEM_LIBRARY_PATH", SYSTEM_LIBDIR), frag->data))
+ 			return true;
+ 	case 'I':
+-		if ((want_flags & PKG_KEEP_SYSTEM_LIBS) == 0 && !strcasecmp(SYSTEM_INCLUDEDIR, frag->data))
++		if ((want_flags & PKG_KEEP_SYSTEM_LIBS) == 0 && !strcasecmp(fallback_getenv("PKG_CONFIG_SYSTEM_INCLUDE_PATH", SYSTEM_INCLUDEDIR), frag->data))
+ 			return true;
+ 	default:
+ 		break;

--- a/src/pkgconf.mk
+++ b/src/pkgconf.mk
@@ -21,7 +21,10 @@ endef
 define $(PKG)_BUILD
     # create pkg-config script
     (echo '#!/bin/sh'; \
-     echo 'PKG_CONFIG_PATH="$(PREFIX)/$(TARGET)/qt5/lib/pkgconfig":"$$PKG_CONFIG_PATH_$(subst .,_,$(subst -,_,$(TARGET)))" PKG_CONFIG_LIBDIR='\''$(PREFIX)/$(TARGET)/lib/pkgconfig'\'' exec '$(PREFIX)/$(BUILD)/bin/pkgconf' $(if $(BUILD_STATIC),--static) "$$@"') \
+     echo 'PKG_CONFIG_PATH="$(PREFIX)/$(TARGET)/qt5/lib/pkgconfig":"$$PKG_CONFIG_PATH_$(subst .,_,$(subst -,_,$(TARGET)))" \
+           PKG_CONFIG_LIBDIR="$(PREFIX)/$(TARGET)/lib/pkgconfig" \
+           PKG_CONFIG_SYSTEM_INCLUDE_PATH="$(PREFIX)/$(TARGET)/include" \
+           exec "$(PREFIX)/$(BUILD)/bin/pkgconf" $(if $(BUILD_STATIC),--static) "$$@"') \
              > '$(PREFIX)/bin/$(TARGET)-pkg-config'
     chmod 0755 '$(PREFIX)/bin/$(TARGET)-pkg-config'
 


### PR DESCRIPTION
From #1785, enable stripping of system include path via env vars. This is probably less useful than the `sed` approach ;)