### PR TITLE
dbus: avoid multiple definitions of DllMain in static builds

### DIFF
--- a/src/dbus-1-fixes.patch
+++ b/src/dbus-1-fixes.patch
@@ -1,0 +1,32 @@
+This file is part of MXE. See LICENSE.md for licensing information.
+
+Contains ad hoc patches for cross building.
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: darealshinji <djcj@gmx.de>
+Date: Mon, 3 Jul 2017 01:55:45 +0200
+Subject: [PATCH] Avoid multiple definitions of DllMain in static builds
+
+
+diff --git a/dbus/dbus-sysdeps-thread-win.c b/dbus/dbus-sysdeps-thread-win.c
+index 1111111..2222222 100644
+--- a/dbus/dbus-sysdeps-thread-win.c
++++ b/dbus/dbus-sysdeps-thread-win.c
+@@ -69,6 +69,8 @@ _dbus_win_get_dll_hmodule (void)
+ #define hinst_t HINSTANCE
+ #endif
+ 
++#ifndef DBUS_STATIC_BUILD
++
+ BOOL WINAPI DllMain (hinst_t, DWORD, LPVOID);
+ 
+ /* We need this to free the TLS events on thread exit */
+@@ -107,6 +109,8 @@ DllMain (hinst_t hinstDLL,
+   return TRUE;
+ }
+ 
++#endif /* !DBUS_STATIC_BUILD */
++
+ DBusCMutex *
+ _dbus_platform_cmutex_new (void)
+ {


### PR DESCRIPTION
Closes #1388
