### PR TITLE
gendef: build with -Wno-implicit-fallthrough

### DIFF
--- a/src/gendef.mk
+++ b/src/gendef.mk
@@ -16,6 +16,7 @@ endef
 
 define $(PKG)_BUILD
     cd '$(1)/mingw-w64-tools/gendef' && ./configure \
+        CFLAGS='-Wno-implicit-fallthrough' \
         --host='$(BUILD)' \
         --build='$(BUILD)' \
         --prefix='$(PREFIX)/$(TARGET)' \


### PR DESCRIPTION
gcc 7 has -Wimplicit-fallthrough on by default. On systems where the
build gcc is v7 or newer building gendef will therefore fail with the
following error:

src/gendef.c: In function ‘getMemonic’:
src/gendef.c:1034:15: error: this statement may fall through [-Werror=implicit-fallthrough=]
   case c_4: sz++;

Fixes #1786.