### PR TITLE
gcc 6.3.0: fix compilation with gcc 7

### DIFF
--- a/plugins/gcc6/gcc-1-fixes.patch
+++ b/plugins/gcc6/gcc-1-fixes.patch
@@ -1,0 +1,13 @@
+diff --git a/gcc/ubsan.c b/gcc/ubsan.c
+index 56637d8..1093824 100644
+--- a/gcc/ubsan.c
++++ b/gcc/ubsan.c
+@@ -1471,7 +1471,7 @@ ubsan_use_new_style_p (location_t loc)
+ 
+   expanded_location xloc = expand_location (loc);
+   if (xloc.file == NULL || strncmp (xloc.file, "\1", 2) == 0
+-      || xloc.file == '\0' || xloc.file[0] == '\xff'
++      || xloc.file[0] == '\0' || xloc.file[0] == '\xff'
+       || xloc.file[1] == '\xff')
+     return false;
+ 


### PR DESCRIPTION
Compiling the gcc6 overlay (currently 6.3.0) with build gcc 7.1.1
yields the following error:

    /home/mosu/prog/video/mingw/cross/tmp-gcc-x86_64-w64-mingw32.static/gcc-6.3.0/gcc/ubsan.c: In function ‘bool ubsan_use_new_style_p(location_t)’:
    /home/mosu/prog/video/mingw/cross/tmp-gcc-x86_64-w64-mingw32.static/gcc-6.3.0/gcc/ubsan.c:1474:23: error: ISO C++ forbids comparison between pointer and integer [-fpermissive]
           || xloc.file == '\0' || xloc.file[0] == '\xff'
                           ^~~~

The test is obviously wrong; the intention is to return if the
`xloc.file` isn't a valid file name. Comparing `xloc.file[0]` to
`'\0'` instead of `xloc.file` itself does that and fixes the error.