### PR TITLE
hyperscan: fix include paths for building with gcc >= 6

### DIFF
--- a/plugins/gcc6/hyperscan-2-no-isystem.patch
+++ b/plugins/gcc6/hyperscan-2-no-isystem.patch
@@ -1,0 +1,32 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 1ceff6d..a4f227f 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -65,7 +65,7 @@ endif()
+ set(CMAKE_INCLUDE_CURRENT_DIR 1)
+ include_directories(${PROJECT_SOURCE_DIR}/src)
+ include_directories(${PROJECT_BINARY_DIR})
+-include_directories(SYSTEM include)
++include_directories(${PROJECT_SOURCE_DIR}/include)
+ 
+ set(BOOST_USE_STATIC_LIBS OFF)
+ set(BOOST_USE_MULTITHREADED OFF)
+@@ -355,12 +355,12 @@ CHECK_CXX_COMPILER_FLAG("-Wunused-variable" CXX_WUNUSED_VARIABLE)
+ 
+ endif()
+ 
+-if (NOT XCODE)
+-    include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
+-else()
+-    # cmake doesn't think Xcode supports isystem
+-    set(EXTRA_CXX_FLAGS "${EXTRA_CXX_FLAGS} -isystem ${Boost_INCLUDE_DIRS}")
+-endif()
++# if (NOT XCODE)
++#     include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
++# else()
++#     # cmake doesn't think Xcode supports isystem
++#     set(EXTRA_CXX_FLAGS "${EXTRA_CXX_FLAGS} -isystem ${Boost_INCLUDE_DIRS}")
++# endif()
+ 
+ 
+ if(CMAKE_SYSTEM_NAME MATCHES "Linux")

--- a/plugins/gcc7/hyperscan-2-no-isystem.patch
+++ b/plugins/gcc7/hyperscan-2-no-isystem.patch
@@ -1,0 +1,1 @@
+../gcc6/hyperscan-2-no-isystem.patch


### PR DESCRIPTION
gcc 6 has changed its behavior regarding the `-isystem` flag[1] and
system directories. This change causes the following error whenever
the `gcc6` or `gcc7` overlay is active:

```
/home/mosu/prog/video/mingw/cross/usr/bin/x86_64-w64-mingw32.static-g++   @CMakeFiles/hs.dir/includes_CXX.rsp -DNDEBUG -std=c++11 -Wall -Wextra -Wshadow -Wswitch -Wreturn-type -Wcast-qual -Wno-deprecated -Wnon-virtual-dtor -fno-strict-aliasing -march=native -mtune=native -fabi-version=0 -Wno-unused-local-typedefs -Wno-maybe-uninitialized -fno-omit-frame-pointer -posix -fvisibility=hidden -Wvla -Wpointer-arith -Wno-unused-const-variable -Wno-ignored-attributes -Wmissing-declarations -O2   -o CMakeFiles/hs.dir/src/grey.cpp.obj -c /home/mosu/prog/video/mingw/cross/tmp-hyperscan-x86_64-w64-mingw32.static/hyperscan-4.3.2/src/grey.cpp
In file included from /home/mosu/prog/video/mingw/cross/usr-master-20170709-f0c1b340-gcc6/lib/gcc/x86_64-w64-mingw32.static/6.3.0/include/c++/ext/string_conversions.h:41:0,
                 from /home/mosu/prog/video/mingw/cross/usr-master-20170709-f0c1b340-gcc6/lib/gcc/x86_64-w64-mingw32.static/6.3.0/include/c++/bits/basic_string.h:5402,
                 from /home/mosu/prog/video/mingw/cross/usr-master-20170709-f0c1b340-gcc6/lib/gcc/x86_64-w64-mingw32.static/6.3.0/include/c++/string:52,
                 from /home/mosu/prog/video/mingw/cross/tmp-hyperscan-x86_64-w64-mingw32.static/hyperscan-4.3.2/src/grey.h:33,
                 from /home/mosu/prog/video/mingw/cross/tmp-hyperscan-x86_64-w64-mingw32.static/hyperscan-4.3.2/src/grey.cpp:29:
/home/mosu/prog/video/mingw/cross/usr-master-20170709-f0c1b340-gcc6/lib/gcc/x86_64-w64-mingw32.static/6.3.0/include/c++/cstdlib:75:25: fatal error: stdlib.h: No such file or directory
 #include_next <stdlib.h>
```

The file in question is present in the preprocessor's default include
path, but the aforementioned change to `-isystem` causes it not to be
found.

Even though the compiler command shown above does not include
`-isystem`, it is present in the included file `includes_CXX.rsp`.

This patch converts those include directories to regular ones with
`-I…`.

[1] https://gcc.gnu.org/bugzilla/show_bug.cgi?id=70129