### PR TITLE
sdl_sound: fix test program compilation with gcc >= 6

### DIFF
--- a/src/sdl_sound-1-constant-integer-expression-vs-sign-bit.patch
+++ b/src/sdl_sound-1-constant-integer-expression-vs-sign-bit.patch
@@ -1,0 +1,13 @@
+diff --git a/SDL_sound.h b/SDL_sound.h
+index b0b8c97..81c1446 100644
+--- a/SDL_sound.h
++++ b/SDL_sound.h
+@@ -114,7 +114,7 @@ typedef enum
+         /* these are set during decoding... */
+     SOUND_SAMPLEFLAG_EOF     = 1 << 29, /**< End of input stream. */
+     SOUND_SAMPLEFLAG_ERROR   = 1 << 30, /**< Unrecoverable error. */
+-    SOUND_SAMPLEFLAG_EAGAIN  = 1 << 31  /**< Function would block, or temp error. */
++    SOUND_SAMPLEFLAG_EAGAIN  = (int)(1u << 31)  /**< Function would block, or temp error. */
+ } Sound_SampleFlags;
+ 
+ 


### PR DESCRIPTION
gcc 6 has added a diagnostic under `-pedantic` that emits a warning
whenever an enumerator value is not a constant integer
expression. This applies to the expression "1 << 31", too, as [1]
explains: that shifts the bit into the sign bit, and therefore it's
not constant.

This warning combined with `-Werror` means that compilation of the
test program fails.

This patch implements the workaround mentioned in [1].

Actual error message:

```
'x86_64-w64-mingw32.static-gcc' -W -Wall -Werror -std=c99 -pedantic '/home/mosu/prog/video/mingw/cross/src/sdl_sound-test.c' -o '/home/mosu/prog/video/mingw/cross/usr/x86_64-w64-mingw32.static/bin/test-sdl_sound.exe' `'x86_64-w64-mingw32.static-pkg-config' SDL_sound --cflags --libs`
In file included from /home/mosu/prog/video/mingw/cross/src/sdl_sound-test.c:11:0:
/home/mosu/prog/video/mingw/cross/usr/x86_64-w64-mingw32.static/include/SDL/SDL_sound.h:117:32:
error: enumerator value for 'SOUND_SAMPLEFLAG_EAGAIN' is not an integer constant expression [-Werror=pedantic] SOUND_SAMPLEFLAG_EAGAIN  = 1 << 31  /**< Function would block, or temp error. */
```

[1] https://gcc.gnu.org/bugzilla/show_bug.cgi?id=71803