### PR TITLE
log4cxx: fix invalid narrowing conversion tripping up g++ >= 6

### DIFF
--- a/src/log4cxx-5-gcc6-fix-narrowing-conversion.patch
+++ b/src/log4cxx-5-gcc6-fix-narrowing-conversion.patch
@@ -1,0 +1,105 @@
+diff --git a/src/main/cpp/locationinfo.cpp b/src/main/cpp/locationinfo.cpp
+index e76ea29..1cdcf24 100644
+--- a/src/main/cpp/locationinfo.cpp
++++ b/src/main/cpp/locationinfo.cpp
+@@ -148,7 +148,7 @@ void LocationInfo::write(ObjectOutputStream& os, Pool& p) const {
+     if (lineNumber == -1 && fileName == NA && methodName == NA_METHOD) {
+          os.writeNull(p);
+     } else {
+-        char prolog[] = {
++        unsigned char prolog[] = {
+          0x72, 0x00, 0x21, 0x6F, 0x72, 0x67, 0x2E, 
+          0x61, 0x70, 0x61, 0x63, 0x68, 0x65, 0x2E, 0x6C, 
+          0x6F, 0x67, 0x34, 0x6A, 0x2E, 0x73, 0x70, 0x69, 
+@@ -161,7 +161,7 @@ void LocationInfo::write(ObjectOutputStream& os, Pool& p) const {
+                 0x61, 0x76, 0x61, 0x2F, 0x6C, 0x61, 0x6E, 0x67, 
+                 0x2F, 0x53, 0x74, 0x72, 0x69, 0x6E, 0x67, 0x3B,
+          0x78, 0x70 };
+-      os.writeProlog("org.apache.log4j.spi.LocationInfo", 2, prolog, sizeof(prolog), p);
++      os.writeProlog("org.apache.log4j.spi.LocationInfo", 2, (char *)prolog, sizeof(prolog), p);
+         char* line = p.itoa(lineNumber);
+         //
+         //   construct Java-like fullInfo (replace "::" with ".")
+diff --git a/src/main/cpp/loggingevent.cpp b/src/main/cpp/loggingevent.cpp
+index 1c0d4be..8bd07a8 100644
+--- a/src/main/cpp/loggingevent.cpp
++++ b/src/main/cpp/loggingevent.cpp
+@@ -236,7 +236,7 @@ void LoggingEvent::setProperty(const LogString& key, const LogString& value)
+ 
+ 
+ void LoggingEvent::writeProlog(ObjectOutputStream& os, Pool& p)  {
+-     char classDesc[] = {
++     unsigned char classDesc[] = {
+         0x72, 0x00, 0x21, 
+         0x6F, 0x72, 0x67, 0x2E, 0x61, 0x70, 0x61, 0x63, 
+         0x68, 0x65, 0x2E, 0x6C, 0x6F, 0x67, 0x34, 0x6A, 
+@@ -292,7 +292,7 @@ void LoggingEvent::writeProlog(ObjectOutputStream& os, Pool& p)  {
+         0x3B, 0x78, 0x70 }; 
+ 
+      os.writeProlog("org.apache.log4j.spi.LoggingEvent", 
+-        8, classDesc, sizeof(classDesc), p);
++        8, (char *)classDesc, sizeof(classDesc), p);
+ }
+ 
+ void LoggingEvent::write(helpers::ObjectOutputStream& os, Pool& p) const {
+diff --git a/src/main/cpp/objectoutputstream.cpp b/src/main/cpp/objectoutputstream.cpp
+index 7cd696b..677d831 100644
+--- a/src/main/cpp/objectoutputstream.cpp
++++ b/src/main/cpp/objectoutputstream.cpp
+@@ -36,8 +36,8 @@ ObjectOutputStream::ObjectOutputStream(OutputStreamPtr outputStream, Pool& p)
+        objectHandle(0x7E0000),
+        classDescriptions(new ClassDescriptionMap())
+ {
+-   char start[] = { 0xAC, 0xED, 0x00, 0x05 };
+-   ByteBuffer buf(start, sizeof(start));
++   unsigned char start[] = { 0xAC, 0xED, 0x00, 0x05 };
++   ByteBuffer buf((char *)start, sizeof(start));
+    os->write(buf, p);
+ }
+ 
+@@ -81,7 +81,7 @@ void ObjectOutputStream::writeObject(const MDC::Map& val, Pool& p) {
+     //
+     //  TC_OBJECT and the classDesc for java.util.Hashtable
+     //
+-    char prolog[] = {
++    unsigned char prolog[] = {
+         0x72, 0x00, 0x13, 0x6A, 0x61, 0x76, 0x61, 
+         0x2E, 0x75, 0x74, 0x69, 0x6C, 0x2E, 0x48, 0x61, 
+         0x73, 0x68, 0x74, 0x61, 0x62, 0x6C, 0x65, 0x13, 
+@@ -90,7 +90,7 @@ void ObjectOutputStream::writeObject(const MDC::Map& val, Pool& p) {
+         0x64, 0x46, 0x61, 0x63, 0x74, 0x6F, 0x72, 0x49, 
+         0x00, 0x09, 0x74, 0x68, 0x72, 0x65, 0x73, 0x68, 
+         0x6F, 0x6C, 0x64, 0x78, 0x70  };
+-    writeProlog("java.util.Hashtable", 1, prolog, sizeof(prolog), p);
++    writeProlog("java.util.Hashtable", 1, (char *)prolog, sizeof(prolog), p);
+     //
+     //   loadFactor = 0.75, threshold = 5, blockdata start, buckets.size = 7
+     char data[] = { 0x3F, 0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x05, 
+diff --git a/src/test/cpp/xml/domtestcase.cpp b/src/test/cpp/xml/domtestcase.cpp
+index a500628..29d67dd 100644
+--- a/src/test/cpp/xml/domtestcase.cpp
++++ b/src/test/cpp/xml/domtestcase.cpp
+@@ -190,9 +190,9 @@ public:
+                 DOMConfigurator::configure(LOG4CXX_TEST_STR("input/xml/DOMTestCase3.xml"));
+                 LOG4CXX_INFO(logger, "File name is expected to end with a superscript 3");
+ #if LOG4CXX_LOGCHAR_IS_UTF8
+-                const logchar fname[] = { 0x6F, 0x75, 0x74, 0x70, 0x75, 0x74, 0x2F, 0x64, 0x6F, 0x6D, 0xC2, 0xB3, 0 };
++                const logchar fname[] = { 0x6F, 0x75, 0x74, 0x70, 0x75, 0x74, 0x2F, 0x64, 0x6F, 0x6D, static_cast<logchar>(0xC2), static_cast<logchar>(0xB3), 0 };
+ #else
+-                const logchar fname[] = { 0x6F, 0x75, 0x74, 0x70, 0x75, 0x74, 0x2F, 0x64, 0x6F, 0x6D, 0xB3, 0 };
++                const logchar fname[] = { 0x6F, 0x75, 0x74, 0x70, 0x75, 0x74, 0x2F, 0x64, 0x6F, 0x6D, static_cast<logchar>(0xB3), 0 };
+ #endif
+                 File file;
+                 file.setPath(fname);
+@@ -209,9 +209,9 @@ public:
+                 DOMConfigurator::configure(LOG4CXX_TEST_STR("input/xml/DOMTestCase4.xml"));
+                 LOG4CXX_INFO(logger, "File name is expected to end with an ideographic 4");
+ #if LOG4CXX_LOGCHAR_IS_UTF8
+-                const logchar fname[] = { 0x6F, 0x75, 0x74, 0x70, 0x75, 0x74, 0x2F, 0x64, 0x6F, 0x6D, 0xE3, 0x86, 0x95, 0 };
++                const logchar fname[] = { 0x6F, 0x75, 0x74, 0x70, 0x75, 0x74, 0x2F, 0x64, 0x6F, 0x6D, static_cast<logchar>(0xE3), static_cast<logchar>(0x86), static_cast<logchar>(0x95), 0 };
+ #else
+-                const logchar fname[] = { 0x6F, 0x75, 0x74, 0x70, 0x75, 0x74, 0x2F, 0x64, 0x6F, 0x6D, 0x3195, 0 };
++                const logchar fname[] = { 0x6F, 0x75, 0x74, 0x70, 0x75, 0x74, 0x2F, 0x64, 0x6F, 0x6D, static_cast<logchar>(0x3195), 0 };
+ #endif
+                 File file;
+                 file.setPath(fname);


### PR DESCRIPTION
g++ 6 is stricter regarding narrowing conversions in initializer
lists. This causes errors similar to the following during compilation
with the gcc6 or gcc7 overlays:

    locationinfo.cpp:163:21: error: narrowing conversion of '237'
    from 'int' to 'char' inside { } [-Wnarrowing]

This has already been fixed upstream in several consecutive patches,
but there's no release including those fixes yet. This patch consists
of the essence of said fixes.