### PR TITLE
openmp-validation: add current directory to @INC for newer Perl

### DIFF
--- a/src/openmp-validation-2-perl-cwd-not-in-inc-anymore.patch
+++ b/src/openmp-validation-2-perl-cwd-not-in-inc-anymore.patch
@@ -1,0 +1,14 @@
+diff --git a/runtest.pl b/runtest.pl
+index 3472351..e84595b 100755
+--- a/runtest.pl
++++ b/runtest.pl
+@@ -1,5 +1,9 @@
+ #!/usr/bin/env perl
+ 
++BEGIN {
++  unshift @INC, '.';
++}
++
+ # runtest [options] FILENAME
+ #
+ # Read the file FILENAME. Each line contains a test.


### PR DESCRIPTION
Perl v5.26.0 has removed the current directory from the include
path. This breaks the `run_test.pl` script which tries to load modules
from the build directory and fails if the system Perl is 5.26.0 or
newer.

Error message: `Can't locate ompts_parserFunctions.pm in @INC`