### PR TITLE
binutils: update 2.25.1 --> 2.28

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -856,16 +856,6 @@ USE_OSGPLUGIN(&lt;plugin2&gt;)
     <h5>Certain packages have open issues on OS X</h5>
     </p>
     <p>
-    For Xcode ≥ 8.3 install an alternate compiler to build `gcc`.
-    For example, if you use Macports run:
-    <pre>sudo port install gcc5
-make cmake && \
-sudo port select gcc mp-gcc5 && \
-make gcc -j4 && \
-sudo port select gcc none && \
-make -j4 -k</pre>
-    </p>
-    <p>
     For Xcode <7.3, run:
     </p>
     <pre>make EXCLUDE_PKGS='nsis'</pre>

--- a/src/binutils-1-fixes.patch
+++ b/src/binutils-1-fixes.patch
@@ -1,0 +1,146 @@
+This file is part of MXE. See LICENSE.md for licensing information.
+
+Contains ad hoc patches for cross building.
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Stephen Kitt <skitt@debian.org>
+Date: Sat, 15 Jul 2017 00:09:40 +1000
+Subject: [PATCH] Allow the PE timestamp to be specified with SOURCE_DATE_EPOCH
+
+Taken from:
+https://sources.debian.net/patches/binutils-mingw-w64/7.4/specify-timestamp.patch/
+
+diff --git a/bfd/peXXigen.c b/bfd/peXXigen.c
+index 1111111..2222222 100644
+--- a/bfd/peXXigen.c
++++ b/bfd/peXXigen.c
+@@ -70,6 +70,9 @@
+ #include <wctype.h>
+ #endif
+ 
++#include <errno.h>
++#include <limits.h>
++
+ /* NOTE: it's strange to be including an architecture specific header
+    in what's supposed to be general (to PE/PEI) code.  However, that's
+    where the definitions are, and they don't vary per architecture
+@@ -878,10 +881,38 @@ _bfd_XXi_only_swap_filehdr_out (bfd * abfd, void * in, void * out)
+   H_PUT_16 (abfd, filehdr_in->f_nscns, filehdr_out->f_nscns);
+ 
+   /* Only use a real timestamp if the option was chosen.  */
+-  if ((pe_data (abfd)->insert_timestamp))
+-    H_PUT_32 (abfd, time (0), filehdr_out->f_timdat);
+-  else
++  if (pe_data (abfd)->insert_timestamp) {
++    time_t now;
++    char *source_date_epoch;
++    unsigned long long epoch;
++    char *endptr;
++
++    now = time(NULL);
++    source_date_epoch = getenv("SOURCE_DATE_EPOCH");
++    if (source_date_epoch) {
++      errno = 0;
++      epoch = strtoull(source_date_epoch, &endptr, 10);
++      if ((errno == ERANGE && (epoch == ULLONG_MAX || epoch == 0))
++          || (errno != 0 && epoch == 0)) {
++        _bfd_error_handler("Environment variable $SOURCE_DATE_EPOCH: strtoull: %s\n",
++                           strerror(errno));
++      } else if (endptr == source_date_epoch) {
++        _bfd_error_handler("Environment variable $SOURCE_DATE_EPOCH: No digits were found: %s\n",
++                           endptr);
++      } else if (*endptr != '\0') {
++        _bfd_error_handler("Environment variable $SOURCE_DATE_EPOCH: Trailing garbage: %s\n",
++                           endptr);
++      } else if (epoch > ULONG_MAX) {
++        _bfd_error_handler("Environment variable $SOURCE_DATE_EPOCH: value must be smaller than or equal to: %lu but was found to be: %llu\n",
++                           ULONG_MAX, epoch);
++      } else {
++        now = epoch;
++      }
++    }
++    H_PUT_32 (abfd, now, filehdr_out->f_timdat);
++  } else {
+     H_PUT_32 (abfd, 0, filehdr_out->f_timdat);
++  }
+ 
+   PUT_FILEHDR_SYMPTR (abfd, filehdr_in->f_symptr,
+ 		      filehdr_out->f_symptr);
+diff --git a/ld/emultempl/pe.em b/ld/emultempl/pe.em
+index 1111111..2222222 100644
+--- a/ld/emultempl/pe.em
++++ b/ld/emultempl/pe.em
+@@ -305,7 +305,7 @@ gld${EMULATION_NAME}_add_options
+      OPTION_USE_NUL_PREFIXED_IMPORT_TABLES},
+     {"no-leading-underscore", no_argument, NULL, OPTION_NO_LEADING_UNDERSCORE},
+     {"leading-underscore", no_argument, NULL, OPTION_LEADING_UNDERSCORE},
+-    {"insert-timestamp", no_argument, NULL, OPTION_INSERT_TIMESTAMP},
++    {"insert-timestamp", optional_argument, NULL, OPTION_INSERT_TIMESTAMP},
+     {"no-insert-timestamp", no_argument, NULL, OPTION_NO_INSERT_TIMESTAMP},
+ #ifdef DLL_SUPPORT
+     /* getopt allows abbreviations, so we do this to stop it
+diff --git a/ld/emultempl/pep.em b/ld/emultempl/pep.em
+index 1111111..2222222 100644
+--- a/ld/emultempl/pep.em
++++ b/ld/emultempl/pep.em
+@@ -321,7 +321,7 @@ gld${EMULATION_NAME}_add_options
+     {"no-bind", no_argument, NULL, OPTION_NO_BIND},
+     {"wdmdriver", no_argument, NULL, OPTION_WDM_DRIVER},
+     {"tsaware", no_argument, NULL, OPTION_TERMINAL_SERVER_AWARE},
+-    {"insert-timestamp", no_argument, NULL, OPTION_INSERT_TIMESTAMP},
++    {"insert-timestamp", optional_argument, NULL, OPTION_INSERT_TIMESTAMP},
+     {"no-insert-timestamp", no_argument, NULL, OPTION_NO_INSERT_TIMESTAMP},
+     {"build-id", optional_argument, NULL, OPTION_BUILD_ID},
+     {NULL, no_argument, NULL, 0}
+diff --git a/ld/pe-dll.c b/ld/pe-dll.c
+index 1111111..2222222 100644
+--- a/ld/pe-dll.c
++++ b/ld/pe-dll.c
+@@ -26,6 +26,8 @@
+ #include "filenames.h"
+ #include "safe-ctype.h"
+ 
++#include <errno.h>
++#include <limits.h>
+ #include <time.h>
+ 
+ #include "ld.h"
+@@ -1192,8 +1194,36 @@ fill_edata (bfd *abfd, struct bfd_link_info *info ATTRIBUTE_UNUSED)
+ 
+   memset (edata_d, 0, edata_sz);
+ 
+-  if (pe_data (abfd)->insert_timestamp)
+-    H_PUT_32 (abfd, time (0), edata_d + 4);
++  if (pe_data (abfd)->insert_timestamp) {
++    time_t now;
++    char *source_date_epoch;
++    unsigned long long epoch;
++    char *endptr;
++
++    now = time(NULL);
++    source_date_epoch = getenv("SOURCE_DATE_EPOCH");
++    if (source_date_epoch) {
++      errno = 0;
++      epoch = strtoull(source_date_epoch, &endptr, 10);
++      if ((errno == ERANGE && (epoch == ULLONG_MAX || epoch == 0))
++	  || (errno != 0 && epoch == 0)) {
++	einfo("Environment variable $SOURCE_DATE_EPOCH: strtoull: %s\n",
++	      strerror(errno));
++      } else if (endptr == source_date_epoch) {
++	einfo("Environment variable $SOURCE_DATE_EPOCH: No digits were found: %s\n",
++	      endptr);
++      } else if (*endptr != '\0') {
++	einfo("Environment variable $SOURCE_DATE_EPOCH: Trailing garbage: %s\n",
++	      endptr);
++      } else if (epoch > ULONG_MAX) {
++	einfo("Environment variable $SOURCE_DATE_EPOCH: value must be smaller than or equal to: %lu but was found to be: %llu\n",
++	      ULONG_MAX, epoch);
++      } else {
++	now = epoch;
++      }
++    }
++    H_PUT_32 (abfd, now, edata_d + 4);
++  }
+ 
+   if (pe_def_file->version_major != -1)
+     {

--- a/src/binutils.mk
+++ b/src/binutils.mk
@@ -3,11 +3,8 @@
 PKG             := binutils
 $(PKG)_WEBSITE  := https://www.gnu.org/software/binutils/
 $(PKG)_DESCR    := GNU Binutils
-# see https://lists.nongnu.org/archive/html/mingw-cross-env-list/2016-01/msg00013.html
-# 2.26 causes incorrect dlls to be built with sjlj exceptions
-$(PKG)_IGNORE   := 2.26
-$(PKG)_VERSION  := 2.25.1
-$(PKG)_CHECKSUM := b5b14added7d78a8d1ca70b5cb75fef57ce2197264f4f5835326b0df22ac9f22
+$(PKG)_VERSION  := 2.28
+$(PKG)_CHECKSUM := 6297433ee120b11b4b0a1c8f3512d7d73501753142ab9e2daa13c5a3edd32a72
 $(PKG)_SUBDIR   := binutils-$($(PKG)_VERSION)
 $(PKG)_FILE     := binutils-$($(PKG)_VERSION).tar.bz2
 $(PKG)_URL      := https://ftp.gnu.org/gnu/binutils/$($(PKG)_FILE)


### PR DESCRIPTION
* fixes original 2.26 regression with iostreams dll
    ```
    $ make gcc STRIP_TOOLCHAIN= MXE_TARGETS=i686-w64-mingw32.shared
    [...]
    $ i686-w64-mingw32.shared-nm  usr/i686-w64-mingw32.shared/bin/libstdc++-6.dll | grep InitC1
    6fefa2d0 T __ZNSt8ios_base4InitC1Ev
    ```
* replaces #1737
* fixes #1758
* tested on all four targets

WIP pending SOURCE_DATE_EPOCH patch from #1737.