### PR TITLE
qtbase: fix CMake static linking dependencies

### DIFF
--- a/src/qtbase.mk
+++ b/src/qtbase.mk
@@ -102,6 +102,11 @@ define $(PKG)_BUILD
      printf 'test-qt5.exe\r\n'; \
      printf 'test-qtbase-pkgconfig.exe\r\n';) \
      > '$(PREFIX)/$(TARGET)/bin/test-qt5.bat'
+
+    # add libs to CMake config of Qt5Core to fix static linking
+    $(SED) -i 's,set(_Qt5Core_LIB_DEPENDENCIES \"\"),set(_Qt5Core_LIB_DEPENDENCIES \"ole32;uuid;ws2_32;advapi32;shell32;user32;kernel32;mpr;version;winmm;z;pcre2-16\"),g' '$(PREFIX)/$(TARGET)/qt5/lib/cmake/Qt5Core/Qt5CoreConfig.cmake'
+    $(SED) -i 's,set(_Qt5Gui_LIB_DEPENDENCIES \"Qt5::Core\"),set(_Qt5Gui_LIB_DEPENDENCIES \"Qt5::Core;ole32;uuid;ws2_32;advapi32;shell32;user32;kernel32;mpr;version;winmm;z;pcre2-16;png16;harfbuzz;z\"),g' '$(PREFIX)/$(TARGET)/qt5/lib/cmake/Qt5Gui/Qt5GuiConfig.cmake'
+    $(SED) -i 's,set(_Qt5Widgets_LIB_DEPENDENCIES \"Qt5::Gui;Qt5::Core\"),set(_Qt5Widgets_LIB_DEPENDENCIES \"Qt5::Gui;Qt5::Core;gdi32;comdlg32;oleaut32;imm32;opengl32;png16;harfbuzz;ole32;uuid;ws2_32;advapi32;shell32;user32;kernel32;mpr;version;winmm;z;pcre2-16;shell32;uxtheme;dwmapi\"),g' '$(PREFIX)/$(TARGET)/qt5/lib/cmake/Qt5Widgets/Qt5WidgetsConfig.cmake'
 endef
 
 


### PR DESCRIPTION
This PR is part of splitting #1527 

As @mabrand said, it would be better to do this by adding a patch to src/qtbase-1-fixes.patch instead of a sed hack.
But I couldn't figure out where to put the dependencies. 
The `lib/cmake/Qt5Module/Qt5ModuleConfig.cmake` file is generated by the `mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in` template file.
This template uses the `CMAKE_INTERFACE_QT5_MODULE_DEPS` variable which is fed by the `mkspecs/features/create_cmake.prf` script.
This script is called from `mkspecs/features/qt_module.prf`
I extracted the dependencies from the pkgconfig-file, which is still generated by qmake not by the prf scripts.