### PR TITLE
qt: set CMake QT_QMAKE_EXECUTABLE variable to cache

### DIFF
--- a/src/qt.mk
+++ b/src/qt.mk
@@ -131,7 +131,7 @@ define $(PKG)_BUILD
         `'$(TARGET)-pkg-config' QtGui --cflags --libs`
 
     # setup cmake toolchain
-    echo 'set(QT_QMAKE_EXECUTABLE $(PREFIX)/$(TARGET)/qt/bin/qmake)' > '$(CMAKE_TOOLCHAIN_DIR)/$(PKG).cmake'
+    echo 'set(QT_QMAKE_EXECUTABLE $(PREFIX)/$(TARGET)/qt/bin/qmake CACHE FILEPATH "Qt4 qmake executable")' > '$(CMAKE_TOOLCHAIN_DIR)/$(PKG).cmake'
     # fix static linking errors of QtGui to missing lcms2 and lzma
     # introduced by poor libmng linking
     echo 'set(MNG_LIBRARY mng lcms2 lzma)' >> '$(CMAKE_TOOLCHAIN_DIR)/$(PKG).cmake'


### PR DESCRIPTION
This PR is part of splitting #1527 

IIRC this is needed to successfully run `find_package(Qt4)` multiple times