### PR TITLE
fix various package conflicts

### DIFF
--- a/src/gtk2.mk
+++ b/src/gtk2.mk
@@ -21,7 +21,7 @@ define $(PKG)_UPDATE
 endef
 
 define $(PKG)_BUILD
-    cd '$(1)' && ./configure \
+    cd '$(BUILD_DIR)' && '$(SOURCE_DIR)/configure' \
         $(MXE_CONFIGURE_OPTS) \
         --enable-explicit-deps \
         --disable-glibtest \
@@ -32,7 +32,12 @@ define $(PKG)_BUILD
         --disable-man \
         --with-included-immodules \
         --without-x
-    $(MAKE) -C '$(1)' -j '$(JOBS)' install bin_PROGRAMS= sbin_PROGRAMS= noinst_PROGRAMS=
+    $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)' $(MXE_DISABLE_CRUFT) EXTRA_DIST=
+    $(MAKE) -C '$(BUILD_DIR)' -j 1 install $(MXE_DISABLE_CRUFT) EXTRA_DIST=
+
+    # cleanup to avoid gtk2/3 conflicts (EXTRA_DIST doesn't exclude it)
+    # and *.def files aren't really relevant for MXE
+    rm -f '$(PREFIX)/$(TARGET)/lib/gailutil.def'
 
     '$(TARGET)-gcc' \
         -W -Wall -Werror -ansi \

--- a/src/gtk3.mk
+++ b/src/gtk3.mk
@@ -20,7 +20,7 @@ define $(PKG)_UPDATE
 endef
 
 define $(PKG)_BUILD
-    cd '$(1)' && ./configure \
+    cd '$(BUILD_DIR)' && '$(SOURCE_DIR)/configure' \
         $(MXE_CONFIGURE_OPTS) \
         --disable-glibtest \
         --disable-cups \
@@ -29,7 +29,12 @@ define $(PKG)_BUILD
         --disable-man \
         --with-included-immodules \
         --enable-win32-backend
-    $(MAKE) -C '$(1)' -j '$(JOBS)' install bin_PROGRAMS= sbin_PROGRAMS= noinst_PROGRAMS=
+    $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)' $(MXE_DISABLE_CRUFT) EXTRA_DIST=
+    $(MAKE) -C '$(BUILD_DIR)' -j 1 install $(MXE_DISABLE_CRUFT) EXTRA_DIST=
+
+    # cleanup to avoid gtk2/3 conflicts (EXTRA_DIST doesn't exclude it)
+    # and *.def files aren't really relevant for MXE
+    rm -f '$(PREFIX)/$(TARGET)/lib/gailutil.def'
 
     '$(TARGET)-gcc' \
         -W -Wall -Werror -ansi \

--- a/src/hdf-eos2.mk
+++ b/src/hdf-eos2.mk
@@ -17,20 +17,26 @@ define $(PKG)_UPDATE
 endef
 
 define $(PKG)_BUILD
-    cd '$(1)' && chmod -R ugo+w .
-    cd '$(1)' && autoconf
-    cd '$(1)' && \
+    # gctp is also present in hdf-eos5 and some headers are also
+    # duplicated, so install to sub-directories
+    cd '$(SOURCE_DIR)' && chmod -R ugo+w .
+    cd '$(SOURCE_DIR)' && autoconf
+    cd '$(BUILD_DIR)' && '$(SOURCE_DIR)/configure' \
+	    $(MXE_CONFIGURE_OPTS) \
+	    --includedir='$(PREFIX)/$(TARGET)/include/$(PKG)' \
+	    --libdir='$(PREFIX)/$(TARGET)/lib/$(PKG)' \
+        --enable-install-include \
         ac_cv_func_malloc_0_nonnull=yes \
-        ac_cv_func_realloc_0_nonnull=yes \
-    ./configure $(MXE_CONFIGURE_OPTS) \
-        --enable-install-include
+        ac_cv_func_realloc_0_nonnull=yes
 
-    $(MAKE) -C '$(1)' -j '$(JOBS)'
-    $(MAKE) -C '$(1)' -j 1 install
+    $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)'
+    $(MAKE) -C '$(BUILD_DIR)' -j 1 install
 
     '$(TARGET)-gcc' \
         -std=c99 -W -Wall -Werror -pedantic \
         '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-$(PKG).exe' \
+        -I'$(PREFIX)/$(TARGET)/include/$(PKG)' \
+        -L'$(PREFIX)/$(TARGET)/lib/$(PKG)' \
         -lhdfeos -lmfhdf -ldf -lz -ljpeg -lportablexdr -lws2_32
 endef
 

--- a/src/id3lib.mk
+++ b/src/id3lib.mk
@@ -8,7 +8,7 @@ $(PKG)_CHECKSUM := 2749cc3c0cd7280b299518b1ddf5a5bcfe2d1100614519b68702230e26c7d
 $(PKG)_SUBDIR   := id3lib-$($(PKG)_VERSION)
 $(PKG)_FILE     := id3lib-$($(PKG)_VERSION).tar.gz
 $(PKG)_URL      := https://$(SOURCEFORGE_MIRROR)/project/$(PKG)/$(PKG)/$($(PKG)_VERSION)/$($(PKG)_FILE)
-$(PKG)_DEPS     := gcc
+$(PKG)_DEPS     := gcc zlib
 
 define $(PKG)_UPDATE
     $(WGET) -q -O- 'https://sourceforge.net/projects/id3lib/files/id3lib/' | \

--- a/src/pdcurses.mk
+++ b/src/pdcurses.mk
@@ -18,23 +18,21 @@ define $(PKG)_UPDATE
 endef
 
 define $(PKG)_BUILD
-    $(SED) -i 's,copy,cp,' '$(1)/win32/mingwin32.mak'
-    $(MAKE) -C '$(1)' -j '$(JOBS)' libs -f '$(1)/win32/mingwin32.mak' \
+    $(SED) -i 's,copy,cp,' '$(SOURCE_DIR)/win32/mingwin32.mak'
+    $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)' libs -f '$(SOURCE_DIR)/win32/mingwin32.mak' \
         CC='$(TARGET)-gcc' \
         LIBEXE='$(TARGET)-ar' \
         DLL=N \
-        PDCURSES_SRCDIR=. \
+        PDCURSES_SRCDIR='$(SOURCE_DIR)' \
         WIDE=Y \
         UTF8=Y
-    mv '$(1)/pdcurses.a' '$(1)/libcurses.a'
-    mv '$(1)/panel.a'    '$(1)/libpanel.a'
-    $(TARGET)-ranlib '$(1)/libcurses.a' '$(1)/libpanel.a'
+    $(TARGET)-ranlib '$(BUILD_DIR)/pdcurses.a' '$(BUILD_DIR)/panel.a'
     $(INSTALL) -d '$(PREFIX)/$(TARGET)/include/'
-    $(INSTALL) -m644 '$(1)/curses.h' '$(1)/panel.h' '$(1)/term.h' '$(PREFIX)/$(TARGET)/include/'
+    $(INSTALL) -m644 '$(SOURCE_DIR)/curses.h' '$(SOURCE_DIR)/panel.h' '$(SOURCE_DIR)/term.h' '$(PREFIX)/$(TARGET)/include/'
     $(INSTALL) -d '$(PREFIX)/$(TARGET)/lib/'
     $(if $(BUILD_STATIC), \
-        $(INSTALL) -m644 '$(1)/libcurses.a' '$(1)/libpanel.a' '$(PREFIX)/$(TARGET)/lib/', \
-        $(MAKE_SHARED_FROM_STATIC) '$(1)/libcurses.a' && \
-        $(MAKE_SHARED_FROM_STATIC) '$(1)/libpanel.a' \
+        $(INSTALL) -m644 '$(BUILD_DIR)/pdcurses.a' '$(BUILD_DIR)/panel.a' '$(PREFIX)/$(TARGET)/lib/', \
+        $(MAKE_SHARED_FROM_STATIC) '$(BUILD_DIR)/pdcurses.a' && \
+        $(MAKE_SHARED_FROM_STATIC) '$(BUILD_DIR)/panel.a' \
     )
 endef

--- a/tools/build-pkg.lua
+++ b/tools/build-pkg.lua
@@ -61,6 +61,7 @@ local BLACKLIST = {
     '^usr/share/gtk-doc',
     '^usr/[^/]+/share/doc/',
     '^usr/[^/]+/share/info/',
+    '^usr/[^/]+/bin/%.waf%-.*',
 
     -- usr/lib/nonetwork.so and
     -- usr/x86_64-unknown-linux-gnu/lib/nonetwork.so


### PR DESCRIPTION
When `waf` executes, it creates a cache directory in:
`./usr/$(BUILD)/bin/.waf-<version>-<checksum>`

This causes conflicting files in `build-pkg` (see #1840) and should
be blacklisted.
