### PR TITLE
gtk2/3: use new-style options and remove gailutil.def

### DIFF
--- a/src/gtk2.mk
+++ b/src/gtk2.mk
@@ -21,7 +21,7 @@ define $(PKG)_UPDATE
 endef
 
 define $(PKG)_BUILD
-    cd '$(1)' && ./configure \
+    cd '$(BUILD_DIR)' && '$(SOURCE_DIR)/configure' \
         $(MXE_CONFIGURE_OPTS) \
         --enable-explicit-deps \
         --disable-glibtest \
@@ -32,7 +32,12 @@ define $(PKG)_BUILD
         --disable-man \
         --with-included-immodules \
         --without-x
-    $(MAKE) -C '$(1)' -j '$(JOBS)' install bin_PROGRAMS= sbin_PROGRAMS= noinst_PROGRAMS=
+    $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)' $(MXE_DISABLE_CRUFT) EXTRA_DIST=
+    $(MAKE) -C '$(BUILD_DIR)' -j 1 install $(MXE_DISABLE_CRUFT) EXTRA_DIST=
+
+    # cleanup to avoid gtk2/3 conflicts (EXTRA_DIST doesn't exclude it)
+    # and *.def files aren't really relevant for MXE
+    rm -f '$(PREFIX)/$(TARGET)/lib/gailutil.def'
 
     '$(TARGET)-gcc' \
         -W -Wall -Werror -ansi \

--- a/src/gtk3.mk
+++ b/src/gtk3.mk
@@ -20,7 +20,7 @@ define $(PKG)_UPDATE
 endef
 
 define $(PKG)_BUILD
-    cd '$(1)' && ./configure \
+    cd '$(BUILD_DIR)' && '$(SOURCE_DIR)/configure' \
         $(MXE_CONFIGURE_OPTS) \
         --disable-glibtest \
         --disable-cups \
@@ -29,7 +29,12 @@ define $(PKG)_BUILD
         --disable-man \
         --with-included-immodules \
         --enable-win32-backend
-    $(MAKE) -C '$(1)' -j '$(JOBS)' install bin_PROGRAMS= sbin_PROGRAMS= noinst_PROGRAMS=
+    $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)' $(MXE_DISABLE_CRUFT) EXTRA_DIST=
+    $(MAKE) -C '$(BUILD_DIR)' -j 1 install $(MXE_DISABLE_CRUFT) EXTRA_DIST=
+
+    # cleanup to avoid gtk2/3 conflicts (EXTRA_DIST doesn't exclude it)
+    # and *.def files aren't really relevant for MXE
+    rm -f '$(PREFIX)/$(TARGET)/lib/gailutil.def'
 
     '$(TARGET)-gcc' \
         -W -Wall -Werror -ansi \


### PR DESCRIPTION
`gailutil.def` causes package conflicts and `*.def` files aren't
really relevant for MXE (see #1772).
