### PR TITLE
pdcurses: use new-style options and don't rename libs

### DIFF
--- a/src/pdcurses.mk
+++ b/src/pdcurses.mk
@@ -18,23 +18,21 @@ define $(PKG)_UPDATE
 endef
 
 define $(PKG)_BUILD
-    $(SED) -i 's,copy,cp,' '$(1)/win32/mingwin32.mak'
-    $(MAKE) -C '$(1)' -j '$(JOBS)' libs -f '$(1)/win32/mingwin32.mak' \
+    $(SED) -i 's,copy,cp,' '$(SOURCE_DIR)/win32/mingwin32.mak'
+    $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)' libs -f '$(SOURCE_DIR)/win32/mingwin32.mak' \
         CC='$(TARGET)-gcc' \
         LIBEXE='$(TARGET)-ar' \
         DLL=N \
-        PDCURSES_SRCDIR=. \
+        PDCURSES_SRCDIR='$(SOURCE_DIR)' \
         WIDE=Y \
         UTF8=Y
-    mv '$(1)/pdcurses.a' '$(1)/libcurses.a'
-    mv '$(1)/panel.a'    '$(1)/libpanel.a'
-    $(TARGET)-ranlib '$(1)/libcurses.a' '$(1)/libpanel.a'
+    $(TARGET)-ranlib '$(BUILD_DIR)/pdcurses.a' '$(BUILD_DIR)/panel.a'
     $(INSTALL) -d '$(PREFIX)/$(TARGET)/include/'
-    $(INSTALL) -m644 '$(1)/curses.h' '$(1)/panel.h' '$(1)/term.h' '$(PREFIX)/$(TARGET)/include/'
+    $(INSTALL) -m644 '$(SOURCE_DIR)/curses.h' '$(SOURCE_DIR)/panel.h' '$(SOURCE_DIR)/term.h' '$(PREFIX)/$(TARGET)/include/'
     $(INSTALL) -d '$(PREFIX)/$(TARGET)/lib/'
     $(if $(BUILD_STATIC), \
-        $(INSTALL) -m644 '$(1)/libcurses.a' '$(1)/libpanel.a' '$(PREFIX)/$(TARGET)/lib/', \
-        $(MAKE_SHARED_FROM_STATIC) '$(1)/libcurses.a' && \
-        $(MAKE_SHARED_FROM_STATIC) '$(1)/libpanel.a' \
+        $(INSTALL) -m644 '$(BUILD_DIR)/pdcurses.a' '$(BUILD_DIR)/panel.a' '$(PREFIX)/$(TARGET)/lib/', \
+        $(MAKE_SHARED_FROM_STATIC) '$(BUILD_DIR)/pdcurses.a' && \
+        $(MAKE_SHARED_FROM_STATIC) '$(BUILD_DIR)/panel.a' \
     )
 endef


### PR DESCRIPTION
Renaming to `libpanel` causes conflicts with `ncurses` (see #1772).

There are no packages in MXE that depend on `pdcurses` any longer,
other downstream users should be able to remove any workarounds they
have in place for the current renaming.
