### PR TITLE
hdf-eos2: install to sub-directories

### DIFF
--- a/src/hdf-eos2.mk
+++ b/src/hdf-eos2.mk
@@ -17,20 +17,26 @@ define $(PKG)_UPDATE
 endef
 
 define $(PKG)_BUILD
-    cd '$(1)' && chmod -R ugo+w .
-    cd '$(1)' && autoconf
-    cd '$(1)' && \
+    # gctp is also present in hdf-eos5 and some headers are also
+    # duplicated, so install to sub-directories
+    cd '$(SOURCE_DIR)' && chmod -R ugo+w .
+    cd '$(SOURCE_DIR)' && autoconf
+    cd '$(BUILD_DIR)' && '$(SOURCE_DIR)/configure' \
+	    $(MXE_CONFIGURE_OPTS) \
+	    --includedir='$(PREFIX)/$(TARGET)/include/$(PKG)' \
+	    --libdir='$(PREFIX)/$(TARGET)/lib/$(PKG)' \
         ac_cv_func_malloc_0_nonnull=yes \
         ac_cv_func_realloc_0_nonnull=yes \
-	./configure $(MXE_CONFIGURE_OPTS) \
         --enable-install-include
 
-    $(MAKE) -C '$(1)' -j '$(JOBS)'
-    $(MAKE) -C '$(1)' -j 1 install
+    $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)'
+    $(MAKE) -C '$(BUILD_DIR)' -j 1 install
 
     '$(TARGET)-gcc' \
         -std=c99 -W -Wall -Werror -pedantic \
         '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-$(PKG).exe' \
+        -I'$(PREFIX)/$(TARGET)/include/$(PKG)' \
+        -L'$(PREFIX)/$(TARGET)/lib/$(PKG)' \
         -lhdfeos -lmfhdf -ldf -lz -ljpeg -lportablexdr -lws2_32
 endef
 


### PR DESCRIPTION
the `gctp` external project and some headers conflict with hdf-eos5
so install to sub-directories (see #1772).
