### PR TITLE
cmake: add option to disable -isystem

### DIFF
--- a/src/cmake-1-fixes.patch
+++ b/src/cmake-1-fixes.patch
@@ -17,3 +17,30 @@ index 1111111..2222222 100644
 @@ -1 +1 @@
 -set(CMAKE_RC_COMPILE_OBJECT "<CMAKE_RC_COMPILER> -O coff <DEFINES> <INCLUDES> <FLAGS> <SOURCE> <OBJECT>")
 +set(CMAKE_RC_COMPILE_OBJECT "<CMAKE_RC_COMPILER> -O coff <DEFINES> <INCLUDES> <SOURCE> <OBJECT>")
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tony Theodore <tonyt@logyst.com>
+Date: Tue, 25 Jul 2017 20:34:56 +1000
+Subject: [PATCH] add option to disable -isystem
+
+taken from (not accepted):
+https://gitlab.kitware.com/cmake/cmake/merge_requests/895
+
+see also:
+https://gitlab.kitware.com/cmake/cmake/issues/16291
+https://gitlab.kitware.com/cmake/cmake/issues/16919
+
+
+diff --git a/Modules/Compiler/GNU.cmake b/Modules/Compiler/GNU.cmake
+index 1111111..2222222 100644
+--- a/Modules/Compiler/GNU.cmake
++++ b/Modules/Compiler/GNU.cmake
+@@ -42,7 +42,7 @@ macro(__compiler_gnu lang)
+   string(APPEND CMAKE_${lang}_FLAGS_RELWITHDEBINFO_INIT " -O2 -g -DNDEBUG")
+   set(CMAKE_${lang}_CREATE_PREPROCESSED_SOURCE "<CMAKE_${lang}_COMPILER> <DEFINES> <INCLUDES> <FLAGS> -E <SOURCE> > <PREPROCESSED_SOURCE>")
+   set(CMAKE_${lang}_CREATE_ASSEMBLY_SOURCE "<CMAKE_${lang}_COMPILER> <DEFINES> <INCLUDES> <FLAGS> -S <SOURCE> -o <ASSEMBLY_SOURCE>")
+-  if(NOT APPLE OR NOT CMAKE_${lang}_COMPILER_VERSION VERSION_LESS 4) # work around #4462
++  if(NOT APPLE OR NOT CMAKE_${lang}_COMPILER_VERSION VERSION_LESS 4 AND (NOT MXE_DISABLE_INCLUDE_SYSTEM_FLAG)) # work around #4462
+     set(CMAKE_INCLUDE_SYSTEM_FLAG_${lang} "-isystem ")
+   endif()
+ endmacro()

--- a/src/hyperscan.mk
+++ b/src/hyperscan.mk
@@ -15,6 +15,7 @@ define $(PKG)_BUILD
     # -DCMAKE_C_FLAGS="-march=core2" -DCMAKE_CXX_FLAGS="-march=core2"
     cd '$(BUILD_DIR)' && $(TARGET)-cmake \
         -DRAGEL='$(PREFIX)/$(BUILD)/bin/ragel' \
+        -DMXE_DISABLE_INCLUDE_SYSTEM_FLAG=TRUE \
         '$(SOURCE_DIR)'
     $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)'
     $(MAKE) -C '$(BUILD_DIR)' -j 1 install


### PR DESCRIPTION
Alternative to #1811, this seems like it should be fixed upstream
in gcc/cmake rather than individual packages
