### PR TITLE
devil: use $(SED) instead of patch for EOL issues

### DIFF
--- a/src/devil-1-fixes.patch
+++ b/src/devil-1-fixes.patch
@@ -57,20 +57,10 @@ From: Tony Theodore <tonyt@logyst.com>
 Date: Thu, 20 Jul 2017 16:34:51 +1000
 Subject: [PATCH] fix resource paths
 
+DevIL/src-IL/msvc/IL.rc has wierd EOL issues and patches don't
+apply - use $(SED) in build rule instead
 
-diff --git a/DevIL/src-IL/msvc/IL.rc b/DevIL/src-IL/msvc/IL.rc
-index 1111111..2222222 100644
---- a/DevIL/src-IL/msvc/IL.rc
-+++ b/DevIL/src-IL/msvc/IL.rc
-@@ -69,7 +69,7 @@ END
- 
- // Icon with lowest ID value placed first to ensure application icon
- // remains consistent on all systems.
--IDI_ICON1               ICON                    "resources\\IL Logo.ico"
-+IDI_ICON1               ICON                    "./resources/IL Logo.ico"
- 
- #ifdef APSTUDIO_INVOKED
- /////////////////////////////////////////////////////////////////////////////
+
 diff --git a/DevIL/src-ILU/msvc/ILU.rc b/DevIL/src-ILU/msvc/ILU.rc
 index 1111111..2222222 100644
 --- a/DevIL/src-ILU/msvc/ILU.rc

--- a/src/devil.mk
+++ b/src/devil.mk
@@ -10,6 +10,8 @@ $(PKG)_GH_CONF  := DentonW/DevIL/master
 $(PKG)_DEPS     := gcc freeglut jasper jpeg lcms libmng libpng openexr sdl tiff zlib
 
 define $(PKG)_BUILD
+    # for some reason, patching fails with EOL issues
+    $(SED) -i 's,resources\\\\,./resources/,' '$(SOURCE_DIR)/DevIL/src-IL/msvc/IL.rc'
     cd '$(BUILD_DIR)' && $(TARGET)-cmake '$(SOURCE_DIR)/DevIL' \
         -DIL_TESTS=OFF \
         -DCMAKE_CXX_FLAGS="-D__STDC_LIMIT_MACROS"


### PR DESCRIPTION
Can't figure out why the other two *.rc files patch correctly and
this one doesn't. Patch was created with `make export-patch-` with git
config `autocrlf = input`. Devil has it's own `.gitattributes` file
but nothing seems to work.

fixes #1856

Anyone have some pointers?