### PR TITLE
fix launch clementine_qt4 with clean settings

### DIFF
--- a/plugins/apps/clementine_qt4-1-fixes.patch
+++ b/plugins/apps/clementine_qt4-1-fixes.patch
@@ -76,3 +76,39 @@ index 1111111..2222222 100644
    )
  endif (WIN32)
  
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Alexander Golubev <fatzer2@gmail.com>
+Date: Thu, 16 Mar 2017 14:54:55 +0300
+Subject: [PATCH] core/database: configure fts3 tokenizer support
+
+Original patch by Arfrever
+This fixes https://github.com/clementine-player/Clementine/issues/5297
+https://github.com/clementine-player/Clementine/pull/5669
+
+
+diff --git a/src/core/database.cpp b/src/core/database.cpp
+index 1111111..2222222 100644
+--- a/src/core/database.cpp
++++ b/src/core/database.cpp
+@@ -265,6 +265,20 @@ QSqlDatabase Database::Connect() {
+   StaticInit();
+
+   {
++
++#ifdef SQLITE_DBCONFIG_ENABLE_FTS3_TOKENIZER
++    // In case sqlite>=3.12 is compiled without -DSQLITE_ENABLE_FTS3_TOKENIZER (generally a good idea
++    // due to security reasons) the fts3 support should be enabled explicitly.
++    // see https://github.com/clementine-player/Clementine/issues/5297
++    QVariant v = db.driver()->handle();
++    if (v.isValid() && qstrcmp(v.typeName(), "sqlite3*") == 0) {
++      sqlite3* handle = *static_cast<sqlite3**>(v.data());
++      if (handle) {
++        sqlite3_db_config(handle, SQLITE_DBCONFIG_ENABLE_FTS3_TOKENIZER, 1, NULL);
++      }
++    }
++#endif
++
+     QSqlQuery set_fts_tokenizer("SELECT fts3_tokenizer(:name, :pointer)", db);
+     set_fts_tokenizer.bindValue(":name", "unicode");
+     set_fts_tokenizer.bindValue(


### PR DESCRIPTION
As it turned out the clementine_qt4 have the same problem that Qt5 version of clementine (launch with clean settings) https://github.com/clementine-player/Clementine/issues/5297, https://github.com/clementine-player/Clementine/pull/5669, #1630 :
```1)build is successful, but crash on launch.```
