### PR TITLE
freetype: Don't autodetect harfbuzz.

### DIFF
--- a/src/freetype-bootstrap.mk
+++ b/src/freetype-bootstrap.mk
@@ -16,5 +16,5 @@ define $(PKG)_UPDATE
 endef
 
 define $(PKG)_BUILD
-    $(freetype_BUILD_COMMON)
+    $(subst harfbuzz=yes,harfbuzz=no,$(freetype_BUILD_COMMON))
 endef

--- a/src/freetype.mk
+++ b/src/freetype.mk
@@ -18,7 +18,7 @@ define $(PKG)_UPDATE
 endef
 
 define $(PKG)_BUILD_COMMON
-    cd '$(1)' && GNUMAKE=$(MAKE) ./configure \
+    cd '$(1)' && GNUMAKE=$(MAKE) ./configure --with-harfbuzz=yes \
         $(MXE_CONFIGURE_OPTS) \
         LIBPNG_CFLAGS="`$(TARGET)-pkg-config libpng --cflags`" \
         LIBPNG_LDFLAGS="`$(TARGET)-pkg-config libpng --libs`" \


### PR DESCRIPTION
This makes the harfbuzz support explicit: freetype-bootstrap does not
use harfbuzz, but freetype does.

This is inspired by a build error where I had a leftover pkgconfig file from harfbuzz, so freetype-bootstrap target was configured WITH harfbuzz, but failed the compile. Normally, this should not happen, but this makes the build a bit more reproducible - freetype-bootstrap always builds without harfbuzz, freetype always with.