### PR TITLE
Add package file for Gumbo, an HTML5 parsing library

### DIFF
--- a/src/gumbo-test.c
+++ b/src/gumbo-test.c
@@ -1,0 +1,13 @@
+/*
+ * This file is part of MXE. See LICENSE.md for licensing information.
+ */
+
+#include <gumbo.h>
+
+int main()
+{
+    GumboOutput *output = gumbo_parse("<blink>Hello world!</blink>");
+    gumbo_destroy_output(&kGumboDefaultOptions, output);
+
+    return 0;
+}

--- a/src/gumbo.mk
+++ b/src/gumbo.mk
@@ -19,14 +19,6 @@ define $(PKG)_BUILD
         sbin_PROGRAMS= \
         noinst_PROGRAMS=
 
-    # create pkg-config files
-    $(INSTALL) -d '$(PREFIX)/$(TARGET)/lib/pkgconfig'
-    (echo 'Name: $(PKG)'; \
-     echo 'Version: $($(PKG)_VERSION)'; \
-     echo 'Description: Gumbo, an HTML5 parsing library'; \
-     echo 'Libs: -lgumbo';) \
-     > '$(PREFIX)/$(TARGET)/lib/pkgconfig/$(PKG).pc'
-
     # compile test
     '$(TARGET)-gcc' \
         -W -Wall -Werror -ansi -pedantic \

--- a/src/gumbo.mk
+++ b/src/gumbo.mk
@@ -1,0 +1,35 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+PKG             := gumbo
+$(PKG)_WEBSITE  := https://github.com/google/gumbo-parser
+$(PKG)_DESCR    := Gumbo, an HTML5 parsing library
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 0.10.1
+$(PKG)_CHECKSUM := 28463053d44a5dfbc4b77bcf49c8cee119338ffa636cc17fc3378421d714efad
+$(PKG)_GH_CONF  := google/gumbo-parser, v
+$(PKG)_DEPS     := gcc
+
+define $(PKG)_BUILD
+    # build and install the library
+    cd $(SOURCE_DIR) && ./autogen.sh
+    cd '$(BUILD_DIR)' && $(SOURCE_DIR)/configure $(MXE_CONFIGURE_OPTS)
+    $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)'
+    $(MAKE) -C '$(BUILD_DIR)' -j 1 install \
+        bin_PROGRAMS= \
+        sbin_PROGRAMS= \
+        noinst_PROGRAMS=
+
+    # create pkg-config files
+    $(INSTALL) -d '$(PREFIX)/$(TARGET)/lib/pkgconfig'
+    (echo 'Name: $(PKG)'; \
+     echo 'Version: $($(PKG)_VERSION)'; \
+     echo 'Description: Gumbo, an HTML5 parsing library'; \
+     echo 'Libs: -lgumbo';) \
+     > '$(PREFIX)/$(TARGET)/lib/pkgconfig/$(PKG).pc'
+
+    # compile test
+    '$(TARGET)-gcc' \
+        -W -Wall -Werror -ansi -pedantic \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-$(PKG).exe' \
+        `'$(TARGET)-pkg-config' $(PKG) --cflags --libs`
+endef


### PR DESCRIPTION
This PR adds a package file for [Gumbo](https://github.com/google/gumbo-parser), an HTML5 parsing library.  I have been able to compile Gumbo using this package file with the configuration

```
MXE_TARGETS := i686-w64-mingw32.shared.posix x86_64-w64-mingw32.shared.posix i686-w64-mingw32.static x86_64-w64-mingw32.static
MXE_PLUGIN_DIRS := plugins/gcc6
mingw-w64-headers_CONFIGURE_OPTS =: --enable-secure-api
```

Build checklist:

✔ install .pc file
✔ install bin/test-pkg.exe compiled with flags by pkg-config
✔ install .dll to bin/ and .a, .dll.a to lib
(N/A) use $(TARGET)-cmake instead of cmake
 ✔ build in `$(BUILD_DIR)` instead of `$(SOURCE_DIR)`
 ✔ do not run target executables with Wine
 (? [1]) do not download anything while building
  ✔ do not install documentation
  ✔ do not install .exe files except test and build systems

[1]: The package file doesn't download anything in the build phase, but I haven't checked whether the Gumbo build process proper downloads anything during build.