### PR TITLE
libarchive: use nettle instead of bcrypt for CNG(Crypto Next Generation)

### DIFF
--- a/src/libarchive-1-fixes.patch
+++ b/src/libarchive-1-fixes.patch
@@ -19,3 +19,22 @@ index 1111111..2222222 100644
 -Libs.private: @LIBS@
 +Libs.private: @LIBS@ -liconv
 
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tony Theodore <tonyt@logyst.com>
+Date: Sun, 13 Aug 2017 14:38:47 +1000
+Subject: [PATCH] libarchive.pc.in: add Cflags.private for static linking
+
+taken from:
+https://github.com/libarchive/libarchive/pull/934
+
+diff --git a/build/pkgconfig/libarchive.pc.in b/build/pkgconfig/libarchive.pc.in
+index 1111111..2222222 100644
+--- a/build/pkgconfig/libarchive.pc.in
++++ b/build/pkgconfig/libarchive.pc.in
+@@ -7,5 +7,6 @@ Name: libarchive
+ Description: library that can create and read several streaming archive formats
+ Version: @VERSION@
+ Cflags: -I${includedir}
++Cflags.private: -DLIBARCHIVE_STATIC
+ Libs: -L${libdir} -larchive
+ Libs.private: @LIBS@ -liconv

--- a/src/libarchive-1-fixes.patch
+++ b/src/libarchive-1-fixes.patch
@@ -19,24 +19,3 @@ index 1111111..2222222 100644
 -Libs.private: @LIBS@
 +Libs.private: @LIBS@ -liconv
 
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Tim Kientzle <kientzle@acm.org>
-Date: Sun, 16 Jul 2017 16:10:08 -0700
-Subject: [PATCH] Issue #924: fix capitalization of bcrypt.h header
-
-taken from:
-https://github.com/libarchive/libarchive/commit/06052e47e500ef4c8c937c4c8b987433a647cb4c
-
-diff --git a/libarchive/archive_cryptor_private.h b/libarchive/archive_cryptor_private.h
-index 1111111..2222222 100644
---- a/libarchive/archive_cryptor_private.h
-+++ b/libarchive/archive_cryptor_private.h
-@@ -64,7 +64,7 @@ typedef struct {
- } archive_crypto_ctx;
- 
- #elif defined(_WIN32) && !defined(__CYGWIN__) && defined(HAVE_BCRYPT_H)
--#include <Bcrypt.h>
-+#include <bcrypt.h>
- 
- /* Common in other bcrypt implementations, but missing from VS2008. */
- #ifndef BCRYPT_SUCCESS

--- a/src/libarchive-test.c
+++ b/src/libarchive-test.c
@@ -7,6 +7,7 @@
 int main(int argc, char *argv[])
 {
     struct archive *tgz;
+    struct archive *zip;
 
     (void)argc;
     (void)argv;
@@ -15,6 +16,9 @@ int main(int argc, char *argv[])
     archive_write_set_options(tgz, "gzip=9");
     archive_write_set_format_ustar(tgz);
     archive_write_free(tgz);
+
+    zip = archive_read_new();
+    archive_read_support_format_zip(zip);
 
     return 0;
 }

--- a/src/libarchive.mk
+++ b/src/libarchive.mk
@@ -9,7 +9,7 @@ $(PKG)_CHECKSUM := ed2dbd6954792b2c054ccf8ec4b330a54b85904a80cef477a1c74643ddafa
 $(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
 $(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.gz
 $(PKG)_URL      := https://www.libarchive.org/downloads/$($(PKG)_FILE)
-$(PKG)_DEPS     := gcc bzip2 libiconv libxml2 openssl xz zlib
+$(PKG)_DEPS     := gcc bzip2 libiconv libxml2 nettle openssl xz zlib
 
 define $(PKG)_UPDATE
     $(WGET) -q -O- 'https://www.libarchive.org/downloads/' | \
@@ -22,11 +22,15 @@ define $(PKG)_BUILD
     $(if $(BUILD_STATIC),\
         $(SED) -i '1i#ifndef LIBARCHIVE_STATIC\n#define LIBARCHIVE_STATIC\n#endif' -i '$(1)/libarchive/archive.h'
         $(SED) -i '1i#ifndef LIBARCHIVE_STATIC\n#define LIBARCHIVE_STATIC\n#endif' -i '$(1)/libarchive/archive_entry.h')
+
+    # use nettle instead of bcrypt for CNG(Crypto Next Generation)
     cd '$(1)' && ./configure \
         $(MXE_CONFIGURE_OPTS) \
         --disable-bsdtar \
         --disable-bsdcpio \
         --disable-bsdcat \
+        --without-cng \
+        --with-nettle \
         XML2_CONFIG='$(PREFIX)/$(TARGET)'/bin/xml2-config
     $(MAKE) -C '$(1)' -j '$(JOBS)' man_MANS=
     $(MAKE) -C '$(1)' -j 1 install man_MANS=

--- a/src/libarchive.mk
+++ b/src/libarchive.mk
@@ -19,10 +19,6 @@ define $(PKG)_UPDATE
 endef
 
 define $(PKG)_BUILD
-    $(if $(BUILD_STATIC),\
-        $(SED) -i '1i#ifndef LIBARCHIVE_STATIC\n#define LIBARCHIVE_STATIC\n#endif' -i '$(1)/libarchive/archive.h'
-        $(SED) -i '1i#ifndef LIBARCHIVE_STATIC\n#define LIBARCHIVE_STATIC\n#endif' -i '$(1)/libarchive/archive_entry.h')
-
     # use nettle instead of bcrypt for CNG(Crypto Next Generation)
     cd '$(BUILD_DIR)' && '$(SOURCE_DIR)/configure' \
         $(MXE_CONFIGURE_OPTS) \
@@ -38,5 +34,5 @@ define $(PKG)_BUILD
     '$(TARGET)-gcc' \
         -W -Wall -Werror -ansi -pedantic \
         '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-libarchive.exe' \
-        `'$(TARGET)-pkg-config' --libs-only-l libarchive`
+        `'$(TARGET)-pkg-config' --libs-only-l --cflags libarchive`
 endef

--- a/src/libarchive.mk
+++ b/src/libarchive.mk
@@ -24,7 +24,7 @@ define $(PKG)_BUILD
         $(SED) -i '1i#ifndef LIBARCHIVE_STATIC\n#define LIBARCHIVE_STATIC\n#endif' -i '$(1)/libarchive/archive_entry.h')
 
     # use nettle instead of bcrypt for CNG(Crypto Next Generation)
-    cd '$(1)' && ./configure \
+    cd '$(BUILD_DIR)' && '$(SOURCE_DIR)/configure' \
         $(MXE_CONFIGURE_OPTS) \
         --disable-bsdtar \
         --disable-bsdcpio \
@@ -32,8 +32,8 @@ define $(PKG)_BUILD
         --without-cng \
         --with-nettle \
         XML2_CONFIG='$(PREFIX)/$(TARGET)'/bin/xml2-config
-    $(MAKE) -C '$(1)' -j '$(JOBS)' man_MANS=
-    $(MAKE) -C '$(1)' -j 1 install man_MANS=
+    $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)' man_MANS=
+    $(MAKE) -C '$(BUILD_DIR)' -j 1 install man_MANS=
 
     '$(TARGET)-gcc' \
         -W -Wall -Werror -ansi -pedantic \


### PR DESCRIPTION
fixes #1876
closes #1877
