### PR TITLE
compile qt4 with xmlpatterns module

### DIFF
--- a/src/qt.mk
+++ b/src/qt.mk
@@ -54,6 +54,7 @@ define $(PKG)_BUILD
         -nomake demos \
         -nomake docs \
         -nomake examples \
+        -xmlpatterns \
         -qt-sql-sqlite \
         -qt-sql-odbc \
         -qt-sql-psql \


### PR DESCRIPTION
The xmlpatterns module is disabled by qt4 configure by default.
