### PR TITLE
secure/update URLs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -267,9 +267,9 @@ ESCAPE_PKG = \
 
 BACKUP_DOWNLOAD = \
     (echo "MXE Warning! Downloading $(1) from backup." >&2 && \
-    ($(WGET) --no-check-certificate -O '$(PKG_DIR)/.tmp-$($(1)_FILE)' $(PKG_MIRROR)/`$(call ESCAPE_PKG,$(1))` || \
-    $(WGET) --no-check-certificate -O '$(PKG_DIR)/.tmp-$($(1)_FILE)' $(PKG_CDN)/`$(call ESCAPE_PKG,$(1))` || \
-    $(WGET) --no-check-certificate -O '$(PKG_DIR)/.tmp-$($(1)_FILE)' $(GITLAB_BACKUP)/`$(call ESCAPE_PKG,$(1))`_$($(1)_CHECKSUM)))
+    ($(WGET) -O '$(PKG_DIR)/.tmp-$($(1)_FILE)' $(PKG_MIRROR)/`$(call ESCAPE_PKG,$(1))` || \
+    $(WGET) -O '$(PKG_DIR)/.tmp-$($(1)_FILE)' $(PKG_CDN)/`$(call ESCAPE_PKG,$(1))` || \
+    $(WGET) -O '$(PKG_DIR)/.tmp-$($(1)_FILE)' $(GITLAB_BACKUP)/`$(call ESCAPE_PKG,$(1))`_$($(1)_CHECKSUM)))
 
 DOWNLOAD_PKG_ARCHIVE = \
     $(if $($(1)_SOURCE_TREE),\

--- a/src/blas.mk
+++ b/src/blas.mk
@@ -6,8 +6,8 @@ $(PKG)_IGNORE   :=
 $(PKG)_VERSION  := 3.5.0
 $(PKG)_CHECKSUM := ef7d775d380f255d1902bce374ff7c8a594846454fcaeae552292168af1aca24
 $(PKG)_SUBDIR   := BLAS-$($(PKG)_VERSION)
-$(PKG)_FILE     := $(PKG).tgz
-$(PKG)_URL      := http://www.netlib.org/404
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tgz
+$(PKG)_URL      := http://www.netlib.org/$(PKG)/$($(PKG)_FILE)
 $(PKG)_DEPS     := gcc
 
 define $(PKG)_UPDATE

--- a/src/libshout.mk
+++ b/src/libshout.mk
@@ -7,7 +7,7 @@ $(PKG)_VERSION  := 2.4.1
 $(PKG)_CHECKSUM := f3acb8dec26f2dbf6df778888e0e429a4ce9378a9d461b02a7ccbf2991bbf24d
 $(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
 $(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.gz
-$(PKG)_URL      := https://downloads.us.xiph.org/releases/$(PKG)/$($(PKG)_FILE)
+$(PKG)_URL      := https://downloads.xiph.org/releases/$(PKG)/$($(PKG)_FILE)
 $(PKG)_DEPS     := gcc ogg openssl speex theora vorbis
 
 define $(PKG)_UPDATE

--- a/src/libssh2.mk
+++ b/src/libssh2.mk
@@ -1,17 +1,17 @@
 # This file is part of MXE. See LICENSE.md for licensing information.
 
 PKG             := libssh2
-$(PKG)_WEBSITE  := https://www.libssh2.org/
+$(PKG)_WEBSITE  := https://libssh2.org/
 $(PKG)_IGNORE   :=
 $(PKG)_VERSION  := 1.8.0
 $(PKG)_CHECKSUM := 39f34e2f6835f4b992cafe8625073a88e5a28ba78f83e8099610a7b3af4676d4
 $(PKG)_SUBDIR   := libssh2-$($(PKG)_VERSION)
 $(PKG)_FILE     := libssh2-$($(PKG)_VERSION).tar.gz
-$(PKG)_URL      := https://www.libssh2.org/download/$($(PKG)_FILE)
+$(PKG)_URL      := https://libssh2.org/download/$($(PKG)_FILE)
 $(PKG)_DEPS     := gcc libgcrypt zlib
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://www.libssh2.org/download/?C=M;O=D' | \
+    $(WGET) -q -O- 'https://libssh2.org/download/?C=M;O=D' | \
     grep 'libssh2-' | \
     $(SED) -n 's,.*libssh2-\([0-9][^>]*\)\.tar.*,\1,p' | \
     head -1

--- a/src/llvm.mk
+++ b/src/llvm.mk
@@ -7,11 +7,11 @@ $(PKG)_VERSION  := 3.4
 $(PKG)_CHECKSUM := 25a5612d692c48481b9b397e2b55f4870e447966d66c96d655241702d44a2628
 $(PKG)_SUBDIR   := llvm-$($(PKG)_VERSION)
 $(PKG)_FILE     := llvm-$($(PKG)_VERSION).src.tar.gz
-$(PKG)_URL      := http://releases.llvm.org/$($(PKG)_VERSION)/$($(PKG)_FILE)
+$(PKG)_URL      := https://releases.llvm.org/$($(PKG)_VERSION)/$($(PKG)_FILE)
 $(PKG)_DEPS     := gcc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'http://releases.llvm.org/download.html' | \
+    $(WGET) -q -O- 'https://releases.llvm.org/download.html' | \
     grep 'Download LLVM' | \
     $(SED) -n 's,.*LLVM \([0-9][^<]*\).*,\1,p' | \
     head -1

--- a/src/log4cxx.mk
+++ b/src/log4cxx.mk
@@ -7,8 +7,8 @@ $(PKG)_VERSION  := 0.10.0
 $(PKG)_CHECKSUM := 0de0396220a9566a580166e66b39674cb40efd2176f52ad2c65486c99c920c8c
 $(PKG)_SUBDIR   := apache-log4cxx-$($(PKG)_VERSION)
 $(PKG)_FILE     := $($(PKG)_SUBDIR).tar.gz
-$(PKG)_URL      := http://www.eu.apache.org/dist/logging/log4cxx/$($(PKG)_VERSION)/$($(PKG)_FILE)
-$(PKG)_URL_2    := http://apache.mirror.cdnetworks.com//logging/log4cxx/0.10.0/$($(PKG)_FILE)
+$(PKG)_URL      := https://www.apache.org/dist/logging/log4cxx/$($(PKG)_VERSION)/$($(PKG)_FILE)
+$(PKG)_URL_2    := https://archive.apache.org/dist/logging/log4cxx/$($(PKG)_VERSION)/$($(PKG)_FILE)
 $(PKG)_DEPS     := gcc apr-util
 
 define $(PKG)_UPDATE

--- a/src/pcre.mk
+++ b/src/pcre.mk
@@ -1,7 +1,7 @@
 # This file is part of MXE. See LICENSE.md for licensing information.
 
 PKG             := pcre
-$(PKG)_WEBSITE  := http://www.pcre.org/
+$(PKG)_WEBSITE  := https://www.pcre.org/
 $(PKG)_DESCR    := PCRE
 $(PKG)_IGNORE   :=
 $(PKG)_VERSION  := 8.41

--- a/src/pcre2.mk
+++ b/src/pcre2.mk
@@ -1,7 +1,7 @@
 # This file is part of MXE. See LICENSE.md for licensing information.
 
 PKG             := pcre2
-$(PKG)_WEBSITE  := http://www.pcre.org/
+$(PKG)_WEBSITE  := https://www.pcre.org/
 $(PKG)_DESCR    := PCRE2
 $(PKG)_IGNORE   :=
 $(PKG)_VERSION  := 10.30

--- a/src/vtk.mk
+++ b/src/vtk.mk
@@ -6,12 +6,12 @@ $(PKG)_VERSION    := 8.0.0
 $(PKG)_CHECKSUM   := c7e727706fb689fb6fd764d3b47cac8f4dc03204806ff19a10dfd406c6072a27
 $(PKG)_SUBDIR     := VTK-$($(PKG)_VERSION)
 $(PKG)_FILE       := $($(PKG)_SUBDIR).tar.gz
-$(PKG)_URL        := http://www.vtk.org/files/release/$(call SHORT_PKG_VERSION,$(PKG))/$($(PKG)_FILE)
+$(PKG)_URL        := https://www.vtk.org/files/release/$(call SHORT_PKG_VERSION,$(PKG))/$($(PKG)_FILE)
 $(PKG)_QT_VERSION := 5
 $(PKG)_DEPS       := gcc hdf5 qtbase qttools libpng expat libxml2 jsoncpp tiff freetype lz4 hdf5 libharu glew
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'http://vtk.org/gitweb?p=VTK.git;a=tags' | \
+    $(WGET) -q -O- 'https://vtk.org/gitweb?p=VTK.git;a=tags' | \
     grep 'refs/tags/v[0-9.]*"' | \
     $(SED) 's,.*refs/tags/v\(.*\)".*,\1,g;' | \
     grep -v rc | \


### PR DESCRIPTION
* change `libssh2`/`apache`/`xiph` URLs to canonical ones
* resubmit patch to remove unnecessary
  `--no-check-certificate` option. The URLs
  are non-HTTPS anyway
* restore URL for `blas`, it's working again