### PR TITLE
build-pkg: blacklist {installed,lib}/.gitkeep

### DIFF
--- a/tools/build-pkg.lua
+++ b/tools/build-pkg.lua
@@ -65,6 +65,10 @@ local BLACKLIST = {
     -- usr/lib/nonetwork.so and
     -- usr/x86_64-unknown-linux-gnu/lib/nonetwork.so
     'lib/nonetwork.so',
+
+    -- https://github.com/mxe/mxe/issues/1886#issuecomment-331719282
+    'installed/.gitkeep',
+    'lib/.gitkeep',
 }
 
 local TARGETS = {


### PR DESCRIPTION
The following files are installed by both cmake-conf and mxe-conf:

usr/i686-w64-mingw32.shared/installed/.gitkeep
usr/i686-w64-mingw32.static/installed/.gitkeep
usr/x86_64-unknown-linux-gnu/installed/.gitkeep
usr/x86_64-unknown-linux-gnu/lib/.gitkeep
usr/x86_64-w64-mingw32.shared/installed/.gitkeep
usr/x86_64-w64-mingw32.static/installed/.gitkeep

In all cases a package installs other files to the same library, so these
.gitkeep files can be safely added to the blacklist.

See https://github.com/mxe/mxe/issues/1886#issuecomment-331719282