### PR TITLE
gcc: fix Darwin build with Xcode9

### DIFF
--- a/src/gcc-1-fixes.patch
+++ b/src/gcc-1-fixes.patch
@@ -25,3 +25,283 @@ index 1111111..2222222 100644
  #include "cpuid.h"
  
  struct cache_desc
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: iains <iains@138bc75d-0d04-0410-961f-82ee72b054a4>
+Date: Mon, 25 Sep 2017 23:49:58 +0000
+Subject: [PATCH] Fix 81037 by adjutng headers
+
+taken from:
+https://github.com/gcc-mirror/gcc/commit/8e49ac832c6ef83afa52e59f0e7e0e6151f5bd3d
+
+2017-09-26  Iain Sandoe  <iain@codesourcery.com>
+            Ryan Mounce  <ryan@mounce.com.au>
+
+	PR bootstrap/81037
+ 	Backport from mainline r235362
+ 	2016-04-22  Szabolcs Nagy  <szabolcs.nagy@arm.com>
+
+	* system.h (list, map, set, vector): Include conditionally.
+	* auto-profile.c (INCLUDE_MAP, INCLUDE_SET): Define.
+	* graphite-isl-ast-to-gimple.c (INCLUDE_MAP): Define.
+	* ipa-icf.c (INCLUDE_LIST): Define.
+	* ipa-icf-gimple.c (INCLUDE_LIST): Define.
+	* config/sh/sh.c (INCLUDE_VECTOR): Define.
+	* config/sh/sh_treg_combine.cc (INCLUDE_ALGORITHM): Define.
+	(INCLUDE_LIST, INCLUDE_VECTOR): Define.
+	* fortran/trans-common.c (INCLUDE_MAP): Define.
+
+	Backport from mainline r235361
+	2016-04-22  Szabolcs Nagy  <szabolcs.nagy@arm.com>
+
+	* auto-profile.c: Remove <string.h> include.
+	* diagnostic.c: Remove <new> include.
+	* genmatch.c: Likewise.
+	* pretty-print.c: Likewise.
+	* toplev.c: Likewise
+	* c/c-objc-common.c: Likewise.
+	* cp/error.c: Likewise.
+	* fortran/error.c: Likewise.
+
+git-svn-id: svn+ssh://gcc.gnu.org/svn/gcc/branches/gcc-5-branch@253181 138bc75d-0d04-0410-961f-82ee72b054a4
+
+diff --git a/gcc/auto-profile.c b/gcc/auto-profile.c
+index 1111111..2222222 100644
+--- a/gcc/auto-profile.c
++++ b/gcc/auto-profile.c
+@@ -19,12 +19,10 @@ along with GCC; see the file COPYING3.  If not see
+ <http://www.gnu.org/licenses/>.  */
+ 
+ #include "config.h"
++#define INCLUDE_MAP
++#define INCLUDE_SET
+ #include "system.h"
+ 
+-#include <string.h>
+-#include <map>
+-#include <set>
+-
+ #include "coretypes.h"
+ #include "hash-set.h"
+ #include "machmode.h"
+diff --git a/gcc/c/c-objc-common.c b/gcc/c/c-objc-common.c
+index 1111111..2222222 100644
+--- a/gcc/c/c-objc-common.c
++++ b/gcc/c/c-objc-common.c
+@@ -38,8 +38,6 @@ along with GCC; see the file COPYING3.  If not see
+ #include "langhooks.h"
+ #include "c-objc-common.h"
+ 
+-#include <new>                          // For placement new.
+-
+ static bool c_tree_printer (pretty_printer *, text_info *, const char *,
+ 			    int, bool, bool, bool);
+ 
+diff --git a/gcc/config/sh/sh.c b/gcc/config/sh/sh.c
+index 1111111..2222222 100644
+--- a/gcc/config/sh/sh.c
++++ b/gcc/config/sh/sh.c
+@@ -20,9 +20,9 @@ along with GCC; see the file COPYING3.  If not see
+ <http://www.gnu.org/licenses/>.  */
+ 
+ #include <sstream>
+-#include <vector>
+ 
+ #include "config.h"
++#define INCLUDE_VECTOR
+ #include "system.h"
+ #include "coretypes.h"
+ #include "tm.h"
+diff --git a/gcc/config/sh/sh_treg_combine.cc b/gcc/config/sh/sh_treg_combine.cc
+index 1111111..2222222 100644
+--- a/gcc/config/sh/sh_treg_combine.cc
++++ b/gcc/config/sh/sh_treg_combine.cc
+@@ -19,6 +19,9 @@ along with GCC; see the file COPYING3.  If not see
+ <http://www.gnu.org/licenses/>.  */
+ 
+ #include "config.h"
++#define INCLUDE_ALGORITHM
++#define INCLUDE_LIST
++#define INCLUDE_VECTOR
+ #include "system.h"
+ #include "coretypes.h"
+ #include "machmode.h"
+@@ -65,10 +68,6 @@ along with GCC; see the file COPYING3.  If not see
+ #include "stmt.h"
+ #include "expr.h"
+ 
+-#include <algorithm>
+-#include <list>
+-#include <vector>
+-
+ /*
+ This pass tries to optimize for example this:
+ 	mov.l	@(4,r4),r1
+diff --git a/gcc/cp/error.c b/gcc/cp/error.c
+index 1111111..2222222 100644
+--- a/gcc/cp/error.c
++++ b/gcc/cp/error.c
+@@ -44,8 +44,6 @@ along with GCC; see the file COPYING3.  If not see
+ #include "ubsan.h"
+ #include "internal-fn.h"
+ 
+-#include <new>                    // For placement-new.
+-
+ #define pp_separate_with_comma(PP) pp_cxx_separate_with (PP, ',')
+ #define pp_separate_with_semicolon(PP) pp_cxx_separate_with (PP, ';')
+ 
+diff --git a/gcc/diagnostic.c b/gcc/diagnostic.c
+index 1111111..2222222 100644
+--- a/gcc/diagnostic.c
++++ b/gcc/diagnostic.c
+@@ -41,8 +41,6 @@ along with GCC; see the file COPYING3.  If not see
+ # include <sys/ioctl.h>
+ #endif
+ 
+-#include <new>                     // For placement new.
+-
+ #define pedantic_warning_kind(DC)			\
+   ((DC)->pedantic_errors ? DK_ERROR : DK_WARNING)
+ #define permissive_error_kind(DC) ((DC)->permissive ? DK_WARNING : DK_ERROR)
+diff --git a/gcc/fortran/error.c b/gcc/fortran/error.c
+index 1111111..2222222 100644
+--- a/gcc/fortran/error.c
++++ b/gcc/fortran/error.c
+@@ -34,8 +34,6 @@ along with GCC; see the file COPYING3.  If not see
+ #include "diagnostic-color.h"
+ #include "tree-diagnostic.h" /* tree_diagnostics_defaults */
+ 
+-#include <new> /* For placement-new */
+-
+ static int suppress_errors = 0;
+ 
+ static bool warnings_not_errors = false;
+diff --git a/gcc/fortran/trans-common.c b/gcc/fortran/trans-common.c
+index 1111111..2222222 100644
+--- a/gcc/fortran/trans-common.c
++++ b/gcc/fortran/trans-common.c
+@@ -92,8 +92,8 @@ along with GCC; see the file COPYING3.  If not see
+    is examined for still-unused equivalence conditions.  We create a
+    block for each merged equivalence list.  */
+ 
+-#include <map>
+ #include "config.h"
++#define INCLUDE_MAP
+ #include "system.h"
+ #include "coretypes.h"
+ #include "tm.h"
+diff --git a/gcc/genmatch.c b/gcc/genmatch.c
+index 1111111..2222222 100644
+--- a/gcc/genmatch.c
++++ b/gcc/genmatch.c
+@@ -22,7 +22,6 @@ along with GCC; see the file COPYING3.  If not see
+ <http://www.gnu.org/licenses/>.  */
+ 
+ #include "bconfig.h"
+-#include <new>
+ #include "system.h"
+ #include "coretypes.h"
+ #include "ggc.h"
+diff --git a/gcc/graphite-isl-ast-to-gimple.c b/gcc/graphite-isl-ast-to-gimple.c
+index 1111111..2222222 100644
+--- a/gcc/graphite-isl-ast-to-gimple.c
++++ b/gcc/graphite-isl-ast-to-gimple.c
+@@ -38,6 +38,7 @@ extern "C" {
+ #endif
+ #endif
+ 
++#define INCLUDE_MAP
+ #include "system.h"
+ #include "coretypes.h"
+ #include "hash-set.h"
+@@ -75,7 +76,6 @@ extern "C" {
+ #include "tree-scalar-evolution.h"
+ #include "gimple-ssa.h"
+ #include "tree-into-ssa.h"
+-#include <map>
+ 
+ #ifdef HAVE_isl
+ #include "graphite-poly.h"
+diff --git a/gcc/ipa-icf-gimple.c b/gcc/ipa-icf-gimple.c
+index 1111111..2222222 100644
+--- a/gcc/ipa-icf-gimple.c
++++ b/gcc/ipa-icf-gimple.c
+@@ -20,6 +20,7 @@ along with GCC; see the file COPYING3.  If not see
+ <http://www.gnu.org/licenses/>.  */
+ 
+ #include "config.h"
++#define INCLUDE_LIST
+ #include "system.h"
+ #include "coretypes.h"
+ #include "hash-set.h"
+@@ -74,7 +75,6 @@ along with GCC; see the file COPYING3.  If not see
+ #include "cgraph.h"
+ #include "data-streamer.h"
+ #include "ipa-utils.h"
+-#include <list>
+ #include "tree-ssanames.h"
+ #include "tree-eh.h"
+ #include "builtins.h"
+diff --git a/gcc/ipa-icf.c b/gcc/ipa-icf.c
+index 1111111..2222222 100644
+--- a/gcc/ipa-icf.c
++++ b/gcc/ipa-icf.c
+@@ -52,8 +52,8 @@ along with GCC; see the file COPYING3.  If not see
+ */
+ 
+ #include "config.h"
++#define INCLUDE_LIST
+ #include "system.h"
+-#include <list>
+ #include "coretypes.h"
+ #include "hash-set.h"
+ #include "machmode.h"
+diff --git a/gcc/pretty-print.c b/gcc/pretty-print.c
+index 1111111..2222222 100644
+--- a/gcc/pretty-print.c
++++ b/gcc/pretty-print.c
+@@ -25,8 +25,6 @@ along with GCC; see the file COPYING3.  If not see
+ #include "pretty-print.h"
+ #include "diagnostic-color.h"
+ 
+-#include <new>                    // For placement-new.
+-
+ #if HAVE_ICONV
+ #include <iconv.h>
+ #endif
+diff --git a/gcc/system.h b/gcc/system.h
+index 1111111..2222222 100644
+--- a/gcc/system.h
++++ b/gcc/system.h
+@@ -215,6 +215,18 @@ extern int errno;
+ #endif
+ 
+ #ifdef __cplusplus
++# ifdef INCLUDE_LIST
++#  include <list>
++# endif
++# ifdef INCLUDE_MAP
++#  include <map>
++# endif
++# ifdef INCLUDE_SET
++#  include <set>
++# endif
++# ifdef INCLUDE_VECTOR
++#  include <vector>
++# endif
+ # include <algorithm>
+ # include <cstring>
+ # include <utility>
+diff --git a/gcc/toplev.c b/gcc/toplev.c
+index 1111111..2222222 100644
+--- a/gcc/toplev.c
++++ b/gcc/toplev.c
+@@ -135,8 +135,6 @@ along with GCC; see the file COPYING3.  If not see
+ #define HAVE_prologue 0
+ #endif
+ 
+-#include <new>
+-
+ static void general_init (const char *, bool);
+ static void do_compile ();
+ static void process_options (void);

--- a/src/gcc.mk
+++ b/src/gcc.mk
@@ -86,6 +86,8 @@ define $(PKG)_BUILD_mingw-w64
     $(MAKE) -C '$(BUILD_DIR).pthreads' -j 1 $(INSTALL_STRIP_TOOLCHAIN)
 
     # build rest of gcc
+    # `all-target-libstdc++-v3` sometimes has parallel failure
+    $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)' all-target-libstdc++-v3
     $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)'
     $(MAKE) -C '$(BUILD_DIR)' -j 1 $(INSTALL_STRIP_TOOLCHAIN)
 


### PR DESCRIPTION
From: https://github.com/gcc-mirror/gcc/commit/8e49ac832c6ef83afa52e59f0e7e0e6151f5bd3d

Fixes part of #1913
