### PR TITLE
qt5: read deps from files in current directory

### DIFF
--- a/plugins/examples/qt5-freeze/qt5.mk
+++ b/plugins/examples/qt5-freeze/qt5.mk
@@ -1,10 +1,10 @@
 # This file is part of MXE. See LICENSE.md for licensing information.
 
 PKG             := qt5
-$(PKG)_WEBSITE  := http://qt-project.org/
+$(PKG)_WEBSITE  := https://www.qt.io/
 $(PKG)_DESCR    := Qt
 $(PKG)_VERSION   = $(qtbase_VERSION)
-$(PKG)_DEPS     := $(patsubst $(TOP_DIR)/src/%.mk,%,\
-                        $(shell grep -l 'qtbase_VERSION' \
-                                $(TOP_DIR)/src/qt*.mk \
-                                --exclude '$(TOP_DIR)/src/qt5.mk'))
+$(PKG)_DEPS     := $(subst qt5, qtbase, \
+                      $(patsubst $(dir $(lastword $(MAKEFILE_LIST)))/%.mk,%,\
+                          $(shell grep -l 'qtbase_VERSION' \
+                              $(dir $(lastword $(MAKEFILE_LIST)))/qt*.mk)))

--- a/src/qt5.mk
+++ b/src/qt5.mk
@@ -4,7 +4,7 @@ PKG             := qt5
 $(PKG)_WEBSITE  := https://www.qt.io/
 $(PKG)_DESCR    := Qt
 $(PKG)_VERSION   = $(qtbase_VERSION)
-$(PKG)_DEPS     := $(patsubst $(TOP_DIR)/src/%.mk,%,\
-                        $(shell grep -l 'qtbase_VERSION' \
-                                $(TOP_DIR)/src/qt*.mk \
-                                --exclude '$(TOP_DIR)/src/qt5.mk'))
+$(PKG)_DEPS     := $(subst qt5, qtbase, \
+                      $(patsubst $(dir $(lastword $(MAKEFILE_LIST)))/%.mk,%,\
+                          $(shell grep -l 'qtbase_VERSION' \
+                              $(dir $(lastword $(MAKEFILE_LIST)))/qt*.mk)))


### PR DESCRIPTION
fixes #1901

```
$ make gmsl-print-qt5_DEPS
qt5_DEPS = qt3d qtbase qtactiveqt qtcanvas3d qtcharts qtconnectivity qtdatavis3d qtdeclarative qtgamepad qtgraphicaleffects qtimageformats qtlocation qtmultimedia qtpurchasing qtquickcontrols qtquickcontrols2 qtscript qtscxml qtsensors qtserialbus qtserialport qtspeech qtsvg qttools qttranslations qtvirtualkeyboard qtwebchannel qtwebkit qtwebsockets qtwebview qtwinextras qtxmlpatterns

$ make gmsl-print-qt5_DEPS MXE_PLUGIN_DIRS=plugins/examples/qt5-freeze/
qt5_DEPS = qt3d qtbase qtactiveqt qtcanvas3d qtcharts qtconnectivity qtdatavis3d qtdeclarative-render2d qtdeclarative qtgamepad qtgraphicaleffects qtimageformats qtlocation qtmultimedia qtpurchasing qtquickcontrols qtquickcontrols2 qtscript qtscxml qtsensors qtserialbus qtserialport qtsvg qttools qttranslations qtvirtualkeyboard qtwebchannel qtwebkit qtwebsockets qtwebview qtwinextras qtxmlpatterns
```

@uwehermann, this seems to work with the frozen version having `qtdeclarative-render2d` and missing `qtspeech `. Can you confirm?
