### PR TITLE
gcc plugins: use plugin-specific patches

### DIFF
--- a/plugins/gcc6/gcc6-overlay.mk
+++ b/plugins/gcc6/gcc6-overlay.mk
@@ -22,3 +22,4 @@ $(PKG)_CHECKSUM := 850bf21eafdfe5cd5f6827148184c08c4a0852a37ccf36ce69855334d2c91
 $(PKG)_SUBDIR   := gcc-$($(PKG)_VERSION)
 $(PKG)_FILE     := gcc-$($(PKG)_VERSION).tar.xz
 $(PKG)_URL      := https://ftp.gnu.org/gnu/gcc/gcc-$($(PKG)_VERSION)/$($(PKG)_FILE)
+$(PKG)_PATCHES  := $(dir $(lastword $(MAKEFILE_LIST)))/gcc6.patch

--- a/plugins/gcc6/gcc6.patch
+++ b/plugins/gcc6/gcc6.patch
@@ -1,0 +1,27 @@
+This file is part of MXE. See LICENSE.md for licensing information.
+
+Contains ad hoc patches for cross building.
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tony Theodore <tonyt@logyst.com>
+Date: Thu, 2 Feb 2017 02:05:50 +1100
+Subject: [PATCH] allow native cpu detection when building with clang
+
+function was disabled for non-gcc5 in:
+https://gcc.gnu.org/git/?p=gcc.git;a=commitdiff;h=b587c12551143c14f023860a1dbdf7316ae71f27;hp=43096b526a9f23008b9769372f11475ae63487bc
+
+clang can build it correctly and this should probably be a feature test
+
+diff --git a/gcc/config/i386/driver-i386.c b/gcc/config/i386/driver-i386.c
+index 1111111..2222222 100644
+--- a/gcc/config/i386/driver-i386.c
++++ b/gcc/config/i386/driver-i386.c
+@@ -24,7 +24,7 @@ along with GCC; see the file COPYING3.  If not see
+ 
+ const char *host_detect_local_cpu (int argc, const char **argv);
+ 
+-#if defined(__GNUC__) && (__GNUC__ >= 5 || !defined(__PIC__))
++#if defined(__GNUC__) && (__GNUC__ >= 5 || !defined(__PIC__)) || defined(__clang__)
+ #include "cpuid.h"
+ 
+ struct cache_desc

--- a/plugins/gcc7/gcc7-overlay.mk
+++ b/plugins/gcc7/gcc7-overlay.mk
@@ -22,3 +22,4 @@ $(PKG)_CHECKSUM := 1cf7adf8ff4b5aa49041c8734bbcf1ad18cc4c94d0029aae0f4e488410884
 $(PKG)_SUBDIR   := gcc-$($(PKG)_VERSION)
 $(PKG)_FILE     := gcc-$($(PKG)_VERSION).tar.xz
 $(PKG)_URL      := https://ftp.gnu.org/gnu/gcc/gcc-$($(PKG)_VERSION)/$($(PKG)_FILE)
+$(PKG)_PATCHES  := $(dir $(lastword $(MAKEFILE_LIST)))/gcc7.patch

--- a/plugins/gcc7/gcc7.patch
+++ b/plugins/gcc7/gcc7.patch
@@ -1,0 +1,27 @@
+This file is part of MXE. See LICENSE.md for licensing information.
+
+Contains ad hoc patches for cross building.
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tony Theodore <tonyt@logyst.com>
+Date: Thu, 2 Feb 2017 02:05:50 +1100
+Subject: [PATCH] allow native cpu detection when building with clang
+
+function was disabled for non-gcc5 in:
+https://gcc.gnu.org/git/?p=gcc.git;a=commitdiff;h=b587c12551143c14f023860a1dbdf7316ae71f27;hp=43096b526a9f23008b9769372f11475ae63487bc
+
+clang can build it correctly and this should probably be a feature test
+
+diff --git a/gcc/config/i386/driver-i386.c b/gcc/config/i386/driver-i386.c
+index 1111111..2222222 100644
+--- a/gcc/config/i386/driver-i386.c
++++ b/gcc/config/i386/driver-i386.c
+@@ -24,7 +24,7 @@ along with GCC; see the file COPYING3.  If not see
+ 
+ const char *host_detect_local_cpu (int argc, const char **argv);
+ 
+-#if defined(__GNUC__) && (__GNUC__ >= 5 || !defined(__PIC__))
++#if defined(__GNUC__) && (__GNUC__ >= 5 || !defined(__PIC__)) || defined(__clang__)
+ #include "cpuid.h"
+ 
+ struct cache_desc


### PR DESCRIPTION
From https://github.com/mxe/mxe/commit/9eb13fc4b8ae7a97f3d3b11ddc2f58a79994dd54#commitcomment-24681487,
the patch in #1915 is a backport and doesn't apply to gcc > 5.
