### PR TITLE
Add package sqlcipher

### DIFF
--- a/plugins/tcl.tk/tcl.mk
+++ b/plugins/tcl.tk/tcl.mk
@@ -1,30 +1,5 @@
 # This file is part of MXE. See LICENSE.md for licensing information.
 
 PKG             := tcl
-$(PKG)_WEBSITE  := https://tcl.tk/
-$(PKG)_OWNER    := https://github.com/highperformancecoder
-$(PKG)_IGNORE   :=
-$(PKG)_VERSION  := 8.6.4
-$(PKG)_CHECKSUM := 9e6ed94c981c1d0c5f5fefb8112d06c6bf4d050a7327e95e71d417c416519c8d
-$(PKG)_SUBDIR   := tcl$($(PKG)_VERSION)
-$(PKG)_FILE     := tcl$($(PKG)_VERSION)-src.tar.gz
-$(PKG)_URL      := https://$(SOURCEFORGE_MIRROR)/project/tcl/Tcl/$($(PKG)_VERSION)/$($(PKG)_FILE)
+$(PKG)_TARGETS  := $(BUILD) $(MXE_TARGETS)
 $(PKG)_DEPS     := gcc zlib
-
-define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://sourceforge.net/projects/tcl/files/Tcl/' | \
-    $(SED) -n 's,.*/\([0-9][^"]*\)/".*,\1,p' | \
-    head -1
-endef
-
-define $(PKG)_BUILD
-    # autoreconf to treat unrecognized options as warnings
-    cd '$(SOURCE_DIR)/win' && autoreconf -fi
-    cd '$(BUILD_DIR)' && '$(SOURCE_DIR)/win/configure' \
-        $(MXE_CONFIGURE_OPTS) \
-        --enable-threads \
-        $(if $(findstring x86_64,$(TARGET)), --enable-64bit) \
-        CFLAGS='-D__MINGW_EXCPT_DEFINE_PSDK'
-    $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)'
-    $(MAKE) -C '$(BUILD_DIR)' -j 1 install install-private-headers
-endef

--- a/src/sqlcipher-1-fixes.patch
+++ b/src/sqlcipher-1-fixes.patch
@@ -1,0 +1,25 @@
+This file is part of MXE. See LICENSE.md for licensing information.
+
+Contains ad hoc patches for cross building.
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Your Name <you@example.com>
+Date: Wed, 27 Sep 2017 15:26:44 +0000
+Subject: [PATCH] fix dependency
+
+Source:
+https://github.com/Alexpux/MINGW-packages/blob/f083f27fb163b68673d5ac649fae353f44b49c7d/mingw-w64-sqlcipher/01-fix_dep.diff
+
+diff --git a/Makefile.in b/Makefile.in
+index 1111111..2222222 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -1074,7 +1074,7 @@ FTS5_SRC = \
+    $(TOP)/ext/fts5/fts5_varint.c \
+    $(TOP)/ext/fts5/fts5_vocab.c  \
+ 
+-fts5parse.c:	$(TOP)/ext/fts5/fts5parse.y lemon 
++fts5parse.c:	$(TOP)/ext/fts5/fts5parse.y lemon$(BEXE)
+ 	cp $(TOP)/ext/fts5/fts5parse.y .
+ 	rm -f fts5parse.h
+ 	./lemon$(BEXE) $(OPTS) fts5parse.y

--- a/src/sqlcipher.mk
+++ b/src/sqlcipher.mk
@@ -1,0 +1,39 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+PKG             := sqlcipher
+$(PKG)_WEBSITE  := https://www.zetetic.net/sqlcipher/
+$(PKG)_DESCR    := SQLite extension that provides 256 bit AES encryption of database files
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 3.4.1
+$(PKG)_CHECKSUM := 4172cc6e5a79d36e178d36bd5cc467a938e08368952659bcd95eccbaf0fa4ad4
+$(PKG)_GH_CONF  := sqlcipher/sqlcipher, v
+$(PKG)_DEPS     := gcc openssl readline
+
+define $(PKG)_BUILD
+    # build and install the library
+    cd '$(BUILD_DIR)' && $(SOURCE_DIR)/configure \
+        "LIBS=$$($(TARGET)-pkg-config --libs libcrypto)" \
+        "CFLAGS=-DSQLITE_HAS_CODEC" \
+        --enable-tempstore=yes \
+        --disable-tcl \
+        --disable-editline \
+        --enable-readline \
+        --with-readline \
+        $(MXE_CONFIGURE_OPTS)
+    $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)'
+    $(MAKE) -C '$(BUILD_DIR)' -j 1 install $(MXE_DISABLE_CRUFT)
+
+#    # create pkg-config files
+#    $(INSTALL) -d '$(PREFIX)/$(TARGET)/lib/pkgconfig'
+#    (echo 'Name: $(PKG)'; \
+#     echo 'Version: $($(PKG)_VERSION)'; \
+#     echo 'Description: SQLite extension that provides 256 bit AES encryption of database files'; \
+#     echo 'Libs: -lsqlcipher';) \
+#     > '$(PREFIX)/$(TARGET)/lib/pkgconfig/$(PKG).pc'
+#
+#    # compile test
+#    '$(TARGET)-gcc' \
+#        -W -Wall -Werror -ansi -pedantic \
+#        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-$(PKG).exe' \
+#        `'$(TARGET)-pkg-config' $(PKG) --cflags --libs`
+endef

--- a/src/sqlcipher.mk
+++ b/src/sqlcipher.mk
@@ -14,6 +14,8 @@ define $(PKG)_BUILD
     cd '$(BUILD_DIR)' && $(SOURCE_DIR)/configure \
         "LIBS=$$($(TARGET)-pkg-config --libs libcrypto)" \
         "CFLAGS=-DSQLITE_HAS_CODEC" \
+        config_BUILD_EXEEXT='' \
+        config_TARGET_EXEEXT='.exe' \
         --enable-tempstore=yes \
         --disable-tcl \
         --disable-editline \
@@ -21,19 +23,11 @@ define $(PKG)_BUILD
         --with-readline \
         $(MXE_CONFIGURE_OPTS)
     $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)'
-    $(MAKE) -C '$(BUILD_DIR)' -j 1 install $(MXE_DISABLE_CRUFT)
+    $(MAKE) -C '$(BUILD_DIR)' -j 1 install
 
-#    # create pkg-config files
-#    $(INSTALL) -d '$(PREFIX)/$(TARGET)/lib/pkgconfig'
-#    (echo 'Name: $(PKG)'; \
-#     echo 'Version: $($(PKG)_VERSION)'; \
-#     echo 'Description: SQLite extension that provides 256 bit AES encryption of database files'; \
-#     echo 'Libs: -lsqlcipher';) \
-#     > '$(PREFIX)/$(TARGET)/lib/pkgconfig/$(PKG).pc'
-#
-#    # compile test
-#    '$(TARGET)-gcc' \
-#        -W -Wall -Werror -ansi -pedantic \
-#        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-$(PKG).exe' \
-#        `'$(TARGET)-pkg-config' $(PKG) --cflags --libs`
+    # compile test
+    '$(TARGET)-gcc' \
+        -W -Wall -Werror \
+        '$(SOURCE_DIR)/mptest/mptest.c' -o '$(PREFIX)/$(TARGET)/bin/test-$(PKG).exe' \
+        `'$(TARGET)-pkg-config' $(PKG) --cflags --libs`
 endef

--- a/src/tcl.mk
+++ b/src/tcl.mk
@@ -1,0 +1,34 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+PKG             := tcl
+$(PKG)_WEBSITE  := https://tcl.tk/
+$(PKG)_OWNER    := https://github.com/highperformancecoder
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 8.6.4
+$(PKG)_CHECKSUM := 9e6ed94c981c1d0c5f5fefb8112d06c6bf4d050a7327e95e71d417c416519c8d
+$(PKG)_SUBDIR   := tcl$($(PKG)_VERSION)
+$(PKG)_FILE     := tcl$($(PKG)_VERSION)-src.tar.gz
+$(PKG)_URL      := https://$(SOURCEFORGE_MIRROR)/project/tcl/Tcl/$($(PKG)_VERSION)/$($(PKG)_FILE)
+$(PKG)_TARGETS  := $(BUILD)
+$(PKG)_DEPS_$(BUILD) := zlib
+
+$(PKG)_SOURCE_SUBDIR  = $(if $(findstring mingw,$(TARGET)),win,unix)
+$(PKG)_CONFIGURE_OPTS = $(if $(findstring mingw,$(TARGET)),CFLAGS=-D__MINGW_EXCPT_DEFINE_PSDK)
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- 'https://sourceforge.net/projects/tcl/files/Tcl/' | \
+    $(SED) -n 's,.*/\([0-9][^"]*\)/".*,\1,p' | \
+    head -1
+endef
+
+define $(PKG)_BUILD
+    # autoreconf to treat unrecognized options as warnings
+    cd '$(SOURCE_DIR)/$($(PKG)_SOURCE_SUBDIR)' && autoreconf -fi
+    cd '$(BUILD_DIR)' && '$(SOURCE_DIR)/$($(PKG)_SOURCE_SUBDIR)/configure' \
+        $(MXE_CONFIGURE_OPTS) \
+        --enable-threads \
+        $(if $(findstring x86_64,$(TARGET)), --enable-64bit) \
+        $($(PKG)_CONFIGURE_OPTS)
+    $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)' PKGS_DIR=
+    $(MAKE) -C '$(BUILD_DIR)' -j 1 install install-private-headers PKGS_DIR=
+endef


### PR DESCRIPTION
Closes #1911.

Installs the executable since that falls into the (small) class of utilities that help developers. The `tcl` bindings can remain disabled until someone investigates what's needed.

@aquiles2k @starius, open issues:
 - requires `tcl` to build - should we do a native build or add it to requirements?
 - test program appears to be simply an `sqlite` test - I couldn't find any minimal examples of usage for a test case.
