### PR TITLE
libssh: use libgcrypt instead of openssl

### DIFF
--- a/src/libssh.mk
+++ b/src/libssh.mk
@@ -9,7 +9,7 @@ $(PKG)_CHECKSUM := d275b1b3622c36efacfac748d5eecaf0e80349a551f72abb6ce5afa8c2e6b
 $(PKG)_SUBDIR   := libssh-$($(PKG)_VERSION)
 $(PKG)_FILE     := libssh-$($(PKG)_VERSION).tar.gz
 $(PKG)_URL      := https://git.libssh.org/projects/libssh.git/snapshot/libssh-$($(PKG)_VERSION).tar.gz
-$(PKG)_DEPS     := gcc openssl zlib
+$(PKG)_DEPS     := gcc libgcrypt zlib
 
 define $(PKG)_UPDATE
     $(WGET) -q -O- 'https://git.libssh.org/projects/libssh.git/refs/tags' | \
@@ -28,7 +28,7 @@ define $(PKG)_BUILD
         -DWITH_DEBUG_CALLTRACE=OFF \
         -DWITH_DEBUG_CRYPTO=OFF \
         -DWITH_EXAMPLES=OFF \
-        -DWITH_GCRYPT=OFF \
+        -DWITH_GCRYPT=ON \
         -DWITH_GSSAPI=OFF \
         -DWITH_INTERNAL_DOC=OFF \
         -DWITH_NACL=OFF \
@@ -47,8 +47,9 @@ define $(PKG)_BUILD
     (echo 'Name: $(PKG)'; \
      echo 'Version: $($(PKG)_VERSION)'; \
      echo 'Description: libssh'; \
-     echo 'Requires: openssl'; \
+     echo 'Requires: libgcrypt zlib'; \
      echo 'Libs: -lssh'; \
+     echo 'Libs.private: -lws2_32'; \
      echo 'Cflags.private: -DLIBSSH_STATIC';) \
      > '$(PREFIX)/$(TARGET)/lib/pkgconfig/$(PKG).pc'
 


### PR DESCRIPTION
See GPL and OpenSSL in:
http://mxe.cc/#potential-legal-issues

and:
https://www.libssh.org/archive/libssh/2017-10/0000017.html