### PR TITLE
Makefile: speedup LOOKUP_PKG_RULE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -736,13 +736,13 @@ show-upstream-deps-%:
 # print first level pkg deps for use in build-pkg.lua
 .PHONY: print-deps-for-build-pkg
 print-deps-for-build-pkg:
-	$(foreach TARGET,$(MXE_TARGETS), \
+	$(foreach TARGET,$(sort $(MXE_TARGETS)), \
 	    $(foreach PKG,$(sort $($(TARGET)_PKGS)), \
-	        $(info for-build-pkg $(TARGET)~$(PKG) \
+	        $(info $(strip for-build-pkg $(TARGET)~$(PKG) \
 	        $(subst $(space),-,$($(PKG)_VERSION)) \
 	        $(addprefix $(TARGET)~,$(value $(call LOOKUP_PKG_RULE,$(PKG),DEPS,$(TARGET)))) \
 	        $(addprefix $(TARGET)~,$(if $(call set_is_not_member,$(PKG),$(MXE_CONF_PKGS)),$(MXE_CONF_PKGS))) \
-	        $(and $($(TARGET)_DEPS),$(addprefix $($(TARGET)_DEPS)~,$($($(TARGET)_DEPS)_PKGS))))))
+	        $(and $($(TARGET)_DEPS),$(addprefix $($(TARGET)_DEPS)~,$($($(TARGET)_DEPS)_PKGS)))))))
 	        @echo -n
 
 BUILD_PKG_TMP_FILES := *-*.list mxe-*.tar.xz mxe-*.deb* wheezy jessie


### PR DESCRIPTION
LOOKUP_PKG_RULE is called many times and spends a lot of time searching
for rules when the default rule is the most common. This simply
avoids exhaustive searching since we can determine beforehand if there
are multiple rules.

Also drops some of the gmsl functions if favour of normal make
variables.

First commit adds sort/strip so print-deps-for-build-pkg output can be
easily compared.

```
$ git checkout HEAD~1
$ time make print-deps-for-build-pkg \
      MXE_TARGETS="`echo {i686-w64-mingw32,x86_64-w64-mingw32}.{static,shared}`"> orig
real	0m17.564s
user	0m16.410s
sys	0m0.783s

$ git checkout speedup
$ time make print-deps-for-build-pkg \
      MXE_TARGETS="`echo {i686-w64-mingw32,x86_64-w64-mingw32}.{static,shared}`"> new
real	0m4.036s
user	0m3.624s
sys	0m0.326s

$ diff -u orig new
$
```