### PR TITLE
gdal: add support for openjpeg 2.3

### DIFF
--- a/src/gdal-1-fixes.patch
+++ b/src/gdal-1-fixes.patch
@@ -5,7 +5,7 @@ Contains ad hoc patches for cross building.
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Luke Potgieter <fried.roadkill+ght@gmail.com>
 Date: Tue, 29 Aug 2017 16:31:09 +0200
-Subject: [PATCH 1/2] Detect spatialite more effectively than just checking for
+Subject: [PATCH 1/3] Detect spatialite more effectively than just checking for
  headers in the system paths. PostgreSQL detection requires -lpthread when
  building statically.
 
@@ -74,7 +74,7 @@ index 1111111..2222222 100644
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Luke Potgieter <fried.roadkill+ght@gmail.com>
 Date: Tue, 26 Sep 2017 14:56:19 +0200
-Subject: [PATCH 2/2] Use the new proj dll version number for the latest proj.
+Subject: [PATCH 2/3] Use the new proj dll version number for the latest proj.
 
 
 diff --git a/ogr/ogrct.cpp b/ogr/ogrct.cpp
@@ -93,3 +93,277 @@ index 1111111..2222222 100644
  #elif defined(__APPLE__)
  #  define LIBNAME "libproj.dylib"
  #else
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tony Theodore <tonyt@logyst.com>
+Date: Sun, 19 Nov 2017 12:01:30 +1100
+Subject: [PATCH 3/3] Add support for openjpeg 2.3
+
+taken from:
+https://trac.osgeo.org/gdal/changeset/40330
+
+diff --git a/configure b/configure
+index 1111111..2222222 100755
+--- a/configure
++++ b/configure
+@@ -25116,19 +25116,20 @@ $as_echo "$as_me: OpenJPEG (JPEG2000) support disabled." >&6;}
+ 
+ elif test "$with_openjpeg" = "yes" -o "$with_openjpeg" = "" ; then
+ 
+-  for ac_header in openjpeg-2.2/openjpeg.h
++
++  for ac_header in openjpeg-2.3/openjpeg.h
+ do :
+-  ac_fn_c_check_header_mongrel "$LINENO" "openjpeg-2.2/openjpeg.h" "ac_cv_header_openjpeg_2_2_openjpeg_h" "$ac_includes_default"
+-if test "x$ac_cv_header_openjpeg_2_2_openjpeg_h" = xyes; then :
++  ac_fn_c_check_header_mongrel "$LINENO" "openjpeg-2.3/openjpeg.h" "ac_cv_header_openjpeg_2_3_openjpeg_h" "$ac_includes_default"
++if test "x$ac_cv_header_openjpeg_2_3_openjpeg_h" = xyes; then :
+   cat >>confdefs.h <<_ACEOF
+-#define HAVE_OPENJPEG_2_2_OPENJPEG_H 1
++#define HAVE_OPENJPEG_2_3_OPENJPEG_H 1
+ _ACEOF
+ 
+ fi
+ 
+ done
+ 
+-  if test "$ac_cv_header_openjpeg_2_2_openjpeg_h" = "yes"; then
++  if test "$ac_cv_header_openjpeg_2_3_openjpeg_h" = "yes"; then
+     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for opj_stream_set_user_data_length in -lopenjp2" >&5
+ $as_echo_n "checking for opj_stream_set_user_data_length in -lopenjp2... " >&6; }
+ if ${ac_cv_lib_openjp2_opj_stream_set_user_data_length+:} false; then :
+@@ -25172,23 +25173,23 @@ else
+ fi
+ 
+     if test "$HAVE_OPENJPEG" = "yes"; then
+-        OPENJPEG_VERSION=20200
++        OPENJPEG_VERSION=20300
+         LIBS="-lopenjp2 $LIBS"
+     fi
+   else
+-    for ac_header in openjpeg-2.1/openjpeg.h
++    for ac_header in openjpeg-2.2/openjpeg.h
+ do :
+-  ac_fn_c_check_header_mongrel "$LINENO" "openjpeg-2.1/openjpeg.h" "ac_cv_header_openjpeg_2_1_openjpeg_h" "$ac_includes_default"
+-if test "x$ac_cv_header_openjpeg_2_1_openjpeg_h" = xyes; then :
++  ac_fn_c_check_header_mongrel "$LINENO" "openjpeg-2.2/openjpeg.h" "ac_cv_header_openjpeg_2_2_openjpeg_h" "$ac_includes_default"
++if test "x$ac_cv_header_openjpeg_2_2_openjpeg_h" = xyes; then :
+   cat >>confdefs.h <<_ACEOF
+-#define HAVE_OPENJPEG_2_1_OPENJPEG_H 1
++#define HAVE_OPENJPEG_2_2_OPENJPEG_H 1
+ _ACEOF
+ 
+ fi
+ 
+ done
+ 
+-    if test "$ac_cv_header_openjpeg_2_1_openjpeg_h" = "yes"; then
++    if test "$ac_cv_header_openjpeg_2_2_openjpeg_h" = "yes"; then
+         { $as_echo "$as_me:${as_lineno-$LINENO}: checking for opj_stream_set_user_data_length in -lopenjp2" >&5
+ $as_echo_n "checking for opj_stream_set_user_data_length in -lopenjp2... " >&6; }
+ if ${ac_cv_lib_openjp2_opj_stream_set_user_data_length+:} false; then :
+@@ -25232,23 +25233,23 @@ else
+ fi
+ 
+         if test "$HAVE_OPENJPEG" = "yes"; then
+-            OPENJPEG_VERSION=20100
++            OPENJPEG_VERSION=20200
+             LIBS="-lopenjp2 $LIBS"
+         fi
+     else
+-        for ac_header in openjpeg-2.0/openjpeg.h
++        for ac_header in openjpeg-2.1/openjpeg.h
+ do :
+-  ac_fn_c_check_header_mongrel "$LINENO" "openjpeg-2.0/openjpeg.h" "ac_cv_header_openjpeg_2_0_openjpeg_h" "$ac_includes_default"
+-if test "x$ac_cv_header_openjpeg_2_0_openjpeg_h" = xyes; then :
++  ac_fn_c_check_header_mongrel "$LINENO" "openjpeg-2.1/openjpeg.h" "ac_cv_header_openjpeg_2_1_openjpeg_h" "$ac_includes_default"
++if test "x$ac_cv_header_openjpeg_2_1_openjpeg_h" = xyes; then :
+   cat >>confdefs.h <<_ACEOF
+-#define HAVE_OPENJPEG_2_0_OPENJPEG_H 1
++#define HAVE_OPENJPEG_2_1_OPENJPEG_H 1
+ _ACEOF
+ 
+ fi
+ 
+ done
+ 
+-        if test "$ac_cv_header_openjpeg_2_0_openjpeg_h" = "yes"; then
++        if test "$ac_cv_header_openjpeg_2_1_openjpeg_h" = "yes"; then
+             { $as_echo "$as_me:${as_lineno-$LINENO}: checking for opj_stream_set_user_data_length in -lopenjp2" >&5
+ $as_echo_n "checking for opj_stream_set_user_data_length in -lopenjp2... " >&6; }
+ if ${ac_cv_lib_openjp2_opj_stream_set_user_data_length+:} false; then :
+@@ -25292,8 +25293,69 @@ else
+ fi
+ 
+             if test "$HAVE_OPENJPEG" = "yes"; then
++                OPENJPEG_VERSION=20100
+                 LIBS="-lopenjp2 $LIBS"
+             fi
++        else
++            for ac_header in openjpeg-2.0/openjpeg.h
++do :
++  ac_fn_c_check_header_mongrel "$LINENO" "openjpeg-2.0/openjpeg.h" "ac_cv_header_openjpeg_2_0_openjpeg_h" "$ac_includes_default"
++if test "x$ac_cv_header_openjpeg_2_0_openjpeg_h" = xyes; then :
++  cat >>confdefs.h <<_ACEOF
++#define HAVE_OPENJPEG_2_0_OPENJPEG_H 1
++_ACEOF
++
++fi
++
++done
++
++            if test "$ac_cv_header_openjpeg_2_0_openjpeg_h" = "yes"; then
++                { $as_echo "$as_me:${as_lineno-$LINENO}: checking for opj_stream_set_user_data_length in -lopenjp2" >&5
++$as_echo_n "checking for opj_stream_set_user_data_length in -lopenjp2... " >&6; }
++if ${ac_cv_lib_openjp2_opj_stream_set_user_data_length+:} false; then :
++  $as_echo_n "(cached) " >&6
++else
++  ac_check_lib_save_LIBS=$LIBS
++LIBS="-lopenjp2  $LIBS"
++cat confdefs.h - <<_ACEOF >conftest.$ac_ext
++/* end confdefs.h.  */
++
++/* Override any GCC internal prototype to avoid an error.
++   Use char because int might match the return type of a GCC
++   builtin and then its argument prototype would still apply.  */
++#ifdef __cplusplus
++extern "C"
++#endif
++char opj_stream_set_user_data_length ();
++int
++main ()
++{
++return opj_stream_set_user_data_length ();
++  ;
++  return 0;
++}
++_ACEOF
++if ac_fn_c_try_link "$LINENO"; then :
++  ac_cv_lib_openjp2_opj_stream_set_user_data_length=yes
++else
++  ac_cv_lib_openjp2_opj_stream_set_user_data_length=no
++fi
++rm -f core conftest.err conftest.$ac_objext \
++    conftest$ac_exeext conftest.$ac_ext
++LIBS=$ac_check_lib_save_LIBS
++fi
++{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_openjp2_opj_stream_set_user_data_length" >&5
++$as_echo "$ac_cv_lib_openjp2_opj_stream_set_user_data_length" >&6; }
++if test "x$ac_cv_lib_openjp2_opj_stream_set_user_data_length" = xyes; then :
++  HAVE_OPENJPEG=yes
++else
++  HAVE_OPENJPEG=no
++fi
++
++                if test "$HAVE_OPENJPEG" = "yes"; then
++                    LIBS="-lopenjp2 $LIBS"
++                fi
++            fi
+         fi
+     fi
+   fi
+@@ -25308,8 +25370,11 @@ else
+   elif test -r $with_openjpeg/include/openjpeg-2.2/openjpeg.h ; then
+     OPENJPEG_VERSION=20200
+     EXTRA_INCLUDES="-I$with_openjpeg/include $EXTRA_INCLUDES"
++  elif test -r $with_openjpeg/include/openjpeg-2.3/openjpeg.h ; then
++    OPENJPEG_VERSION=20300
++    EXTRA_INCLUDES="-I$with_openjpeg/include $EXTRA_INCLUDES"
+   else
+-    as_fn_error $? "openjpeg.h not found in $with_openjpeg/include/openjpeg-2.0 or $with_openjpeg/include/openjpeg-2.1 or $with_openjpeg/include/openjpeg-2.2" "$LINENO" 5
++    as_fn_error $? "openjpeg.h not found in $with_openjpeg/include/openjpeg-2.0 or $with_openjpeg/include/openjpeg-2.1 or $with_openjpeg/include/openjpeg-2.2 or $with_openjpeg/include/openjpeg-2.3" "$LINENO" 5
+   fi
+ 
+   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for opj_stream_set_user_data_length in -lopenjp2" >&5
+diff --git a/configure.ac b/configure.ac
+index 1111111..2222222 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -2539,28 +2539,38 @@ if test "$with_openjpeg" = "no" ; then
+ 
+ elif test "$with_openjpeg" = "yes" -o "$with_openjpeg" = "" ; then
+ 
+-  AC_CHECK_HEADERS([openjpeg-2.2/openjpeg.h])
+-  if test "$ac_cv_header_openjpeg_2_2_openjpeg_h" = "yes"; then
++
++  AC_CHECK_HEADERS([openjpeg-2.3/openjpeg.h])
++  if test "$ac_cv_header_openjpeg_2_3_openjpeg_h" = "yes"; then
+     AC_CHECK_LIB(openjp2,opj_stream_set_user_data_length,HAVE_OPENJPEG=yes,HAVE_OPENJPEG=no,)
+     if test "$HAVE_OPENJPEG" = "yes"; then
+-        OPENJPEG_VERSION=20200
++        OPENJPEG_VERSION=20300
+         LIBS="-lopenjp2 $LIBS"
+     fi
+   else
+-    AC_CHECK_HEADERS([openjpeg-2.1/openjpeg.h])
+-    if test "$ac_cv_header_openjpeg_2_1_openjpeg_h" = "yes"; then
++    AC_CHECK_HEADERS([openjpeg-2.2/openjpeg.h])
++    if test "$ac_cv_header_openjpeg_2_2_openjpeg_h" = "yes"; then
+         AC_CHECK_LIB(openjp2,opj_stream_set_user_data_length,HAVE_OPENJPEG=yes,HAVE_OPENJPEG=no,)
+         if test "$HAVE_OPENJPEG" = "yes"; then
+-            OPENJPEG_VERSION=20100
++            OPENJPEG_VERSION=20200
+             LIBS="-lopenjp2 $LIBS"
+         fi
+     else
+-        AC_CHECK_HEADERS([openjpeg-2.0/openjpeg.h])
+-        if test "$ac_cv_header_openjpeg_2_0_openjpeg_h" = "yes"; then
++        AC_CHECK_HEADERS([openjpeg-2.1/openjpeg.h])
++        if test "$ac_cv_header_openjpeg_2_1_openjpeg_h" = "yes"; then
+             AC_CHECK_LIB(openjp2,opj_stream_set_user_data_length,HAVE_OPENJPEG=yes,HAVE_OPENJPEG=no,)
+             if test "$HAVE_OPENJPEG" = "yes"; then
++                OPENJPEG_VERSION=20100
+                 LIBS="-lopenjp2 $LIBS"
+             fi
++        else
++            AC_CHECK_HEADERS([openjpeg-2.0/openjpeg.h])
++            if test "$ac_cv_header_openjpeg_2_0_openjpeg_h" = "yes"; then
++                AC_CHECK_LIB(openjp2,opj_stream_set_user_data_length,HAVE_OPENJPEG=yes,HAVE_OPENJPEG=no,)
++                if test "$HAVE_OPENJPEG" = "yes"; then
++                    LIBS="-lopenjp2 $LIBS"
++                fi
++            fi
+         fi
+     fi
+   fi
+@@ -2575,8 +2585,11 @@ else
+   elif test -r $with_openjpeg/include/openjpeg-2.2/openjpeg.h ; then
+     OPENJPEG_VERSION=20200
+     EXTRA_INCLUDES="-I$with_openjpeg/include $EXTRA_INCLUDES"
++  elif test -r $with_openjpeg/include/openjpeg-2.3/openjpeg.h ; then
++    OPENJPEG_VERSION=20300
++    EXTRA_INCLUDES="-I$with_openjpeg/include $EXTRA_INCLUDES"
+   else
+-    AC_MSG_ERROR([openjpeg.h not found in $with_openjpeg/include/openjpeg-2.0 or $with_openjpeg/include/openjpeg-2.1 or $with_openjpeg/include/openjpeg-2.2])
++    AC_MSG_ERROR([openjpeg.h not found in $with_openjpeg/include/openjpeg-2.0 or $with_openjpeg/include/openjpeg-2.1 or $with_openjpeg/include/openjpeg-2.2 or $with_openjpeg/include/openjpeg-2.3])
+   fi
+ 
+   AC_CHECK_LIB(openjp2,opj_stream_set_user_data_length,HAVE_OPENJPEG=yes,HAVE_OPENJPEG=no,-L$with_openjpeg/lib)
+diff --git a/frmts/openjpeg/openjpegdataset.cpp b/frmts/openjpeg/openjpegdataset.cpp
+index 1111111..2222222 100644
+--- a/frmts/openjpeg/openjpegdataset.cpp
++++ b/frmts/openjpeg/openjpegdataset.cpp
+@@ -34,7 +34,9 @@
+ #pragma clang diagnostic ignored "-Wdocumentation"
+ #endif
+ 
+-#if defined(OPENJPEG_VERSION) && OPENJPEG_VERSION >= 20200
++#if defined(OPENJPEG_VERSION) && OPENJPEG_VERSION >= 20300
++#include <openjpeg-2.3/openjpeg.h>
++#elif defined(OPENJPEG_VERSION) && OPENJPEG_VERSION >= 20200
+ #include <openjpeg-2.2/openjpeg.h>
+ #elif defined(OPENJPEG_VERSION) && OPENJPEG_VERSION >= 20100
+ #include <openjpeg-2.1/openjpeg.h>
+diff --git a/nmake.opt b/nmake.opt
+index 1111111..2222222 100644
+--- a/nmake.opt
++++ b/nmake.opt
+@@ -611,6 +611,8 @@ OCI_INCLUDE =	-I$(ORACLE_HOME)\oci\include
+ #OPENJPEG_VERSION = 20100
+ # For OpenJpeg 2.2.x, uncomment
+ #OPENJPEG_VERSION = 20200
++# For OpenJpeg 2.3.x, uncomment
++#OPENJPEG_VERSION = 20300
+ 
+ #if using an external zlib uncomment the following lines
+ #ZLIB_EXTERNAL_LIB = 1


### PR DESCRIPTION
Nice:
```
make init-git-gdal
make import-patch-gdal
cd gits/gdal-2.2.2/
curl 'https://trac.osgeo.org/gdal/changeset/40330?format=diff' | patch -p4
git commit -a -m'Add support for openjpeg 2.3
>
> taken from:
> https://trac.osgeo.org/gdal/changeset/40330'
cd ../..
make export-patch-gdal
```
