### PR TITLE
Improve handling of virtual packages and build messages

### DIFF
--- a/docs/assets/build-matrix.css
+++ b/docs/assets/build-matrix.css
@@ -12,3 +12,7 @@ td.unsupported {
     background-color: #f99;
     text-align: center;
 }
+td.neutral {
+    background-color: #d1d1d1;
+    text-align: center;
+}

--- a/docs/build-matrix.html
+++ b/docs/build-matrix.html
@@ -38,4605 +38,4605 @@ feel free to submit a pull request.
 </thead>
 <tbody>
 <tr>
- <th class="row">a52dec</th>
- <td>0.7.4</td>
+ <th class="row" title=""> a52dec   </th>
+ <td>0.7.4 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">agg</th>
- <td>2.5</td>
+ <th class="row" title=""> agg   </th>
+ <td>2.5 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-   <td class="unsupported">&#x2717;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">alure</th>
- <td>1.2</td>
+ <th class="row" title=""> alure   </th>
+ <td>1.2 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">apr</th>
- <td>1.5.2</td>
+ <th class="row" title=""> apr   </th>
+ <td>1.5.2 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">apr-util</th>
- <td>1.5.4</td>
+ <th class="row" title=""> apr-util   </th>
+ <td>1.5.4 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">armadillo</th>
- <td>8.200.2</td>
+ <th class="row" title=""> armadillo   </th>
+ <td>8.200.2 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">aspell</th>
- <td>0.60.6.1</td>
+ <th class="row" title=""> aspell   </th>
+ <td>0.60.6.1 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">assimp</th>
- <td>3.2</td>
+ <th class="row" title=""> assimp   </th>
+ <td>3.2 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">atk</th>
- <td>2.16.0</td>
+ <th class="row" title=""> atk   </th>
+ <td>2.16.0 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">atkmm</th>
- <td>2.22.7</td>
+ <th class="row" title=""> atkmm   </th>
+ <td>2.22.7 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">aubio</th>
- <td>0.4.2</td>
+ <th class="row" title=""> aubio   </th>
+ <td>0.4.2 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">autotools</th>
- <td>1</td>
-   <td class="unsupported">&#x2717;</td>
-   <td class="unsupported">&#x2717;</td>
-   <td class="unsupported">&#x2717;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+ <th class="row" title=""> autotools  [meta-pkg]  </th>
+ <td>1 </td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td class="neutral">&bull;</td>
  </tr>
 
 <tr>
- <th class="row">bfd</th>
- <td>2.28</td>
+ <th class="row" title=""> bfd   </th>
+ <td>2.28 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">binutils</th>
- <td>2.28</td>
+ <th class="row" title=""> binutils   </th>
+ <td>2.28 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">blas</th>
- <td>3.5.0</td>
-   <td class="unsupported">&#x2717;</td>
-   <td class="unsupported">&#x2717;</td>
-   <td class="unsupported">&#x2717;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+ <th class="row" title="*** blas has been replaced by openblas ***"> blas   ** </th>
+ <td>3.5.0 </td>
+     <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">boost</th>
- <td>1.60.0</td>
+ <th class="row" title=""> boost   </th>
+ <td>1.60.0 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">box2d</th>
- <td>2.3.1</td>
+ <th class="row" title=""> box2d   </th>
+ <td>2.3.1 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">bullet</th>
- <td>2.82-r2704</td>
+ <th class="row" title=""> bullet   </th>
+ <td>2.82-r2704 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">bzip2</th>
- <td>1.0.6</td>
+ <th class="row" title=""> bzip2   </th>
+ <td>1.0.6 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">cairo</th>
- <td>1.15.4</td>
+ <th class="row" title=""> cairo   </th>
+ <td>1.15.4 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">cairomm</th>
- <td>1.11.2</td>
+ <th class="row" title=""> cairomm   </th>
+ <td>1.11.2 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">cblas</th>
- <td>1</td>
-   <td class="unsupported">&#x2717;</td>
-   <td class="unsupported">&#x2717;</td>
-   <td class="unsupported">&#x2717;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+ <th class="row" title="*** cblas has been replaced by openblas ***"> cblas   ** </th>
+ <td>1 </td>
+     <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">ccfits</th>
- <td>2.5</td>
+ <th class="row" title=""> ccfits   </th>
+ <td>2.5 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">cegui</th>
- <td>9726a2b505fb</td>
+ <th class="row" title=""> cegui   </th>
+ <td>9726a2b505fb </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">cfitsio</th>
- <td>3410</td>
+ <th class="row" title=""> cfitsio   </th>
+ <td>3410 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">cgal</th>
- <td>4.11</td>
+ <th class="row" title=""> cgal   </th>
+ <td>4.11 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">check</th>
- <td>0.10.0</td>
+ <th class="row" title=""> check   </th>
+ <td>0.10.0 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">chipmunk</th>
- <td>6.2.2</td>
+ <th class="row" title=""> chipmunk   </th>
+ <td>6.2.2 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">chromaprint</th>
- <td>1.1</td>
+ <th class="row" title=""> chromaprint   </th>
+ <td>1.1 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">cimg</th>
- <td>1.6.3</td>
+ <th class="row" title=""> cimg   </th>
+ <td>1.6.3 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">cloog</th>
- <td>0.18.4</td>
+ <th class="row" title=""> cloog   </th>
+ <td>0.18.4 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">cmake</th>
- <td>3.8.2</td>
-   <td class="unsupported">&#x2717;</td>
-   <td class="unsupported">&#x2717;</td>
-   <td class="unsupported">&#x2717;</td>
-   <td class="unsupported">&#x2717;</td>
-   <td class="supported">&#x2713;</td>
+ <th class="row" title=""> cmake   </th>
+ <td>3.8.2 </td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td class="supported">&#x2713;</td>
  </tr>
 
 <tr>
- <th class="row">cmake-conf</th>
- <td>1</td>
+ <th class="row" title=""> cmake-conf   </th>
+ <td>1 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-   <td class="supported">&#x2713;</td>
+    <td class="supported">&#x2713;</td>
  </tr>
 
 <tr>
- <th class="row">cminpack</th>
- <td>1.3.4</td>
+ <th class="row" title=""> cminpack   </th>
+ <td>1.3.4 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">coda</th>
- <td>2.15.1</td>
+ <th class="row" title=""> coda   </th>
+ <td>2.15.1 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">coin</th>
- <td>3.1.3</td>
+ <th class="row" title=""> coin   </th>
+ <td>3.1.3 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">cpp-netlib</th>
- <td>0.11.2</td>
+ <th class="row" title=""> cpp-netlib   </th>
+ <td>0.11.2 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">cppunit</th>
- <td>1.13.2</td>
+ <th class="row" title=""> cppunit   </th>
+ <td>1.13.2 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">cryptopp</th>
- <td>5.6.3</td>
+ <th class="row" title=""> cryptopp   </th>
+ <td>5.6.3 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">crystalhd</th>
- <td>1</td>
+ <th class="row" title=""> crystalhd   </th>
+ <td>1 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">cunit</th>
- <td>2.1-3</td>
+ <th class="row" title=""> cunit   </th>
+ <td>2.1-3 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">curl</th>
- <td>7.56.1</td>
+ <th class="row" title=""> curl   </th>
+ <td>7.56.1 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">db</th>
- <td>6.1.26</td>
+ <th class="row" title=""> db   </th>
+ <td>6.1.26 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">dbus</th>
- <td>1.12.2</td>
+ <th class="row" title=""> dbus   </th>
+ <td>1.12.2 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">dcmtk</th>
- <td>3.6.0</td>
+ <th class="row" title=""> dcmtk   </th>
+ <td>3.6.0 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">devil</th>
- <td>cba359b</td>
+ <th class="row" title=""> devil   </th>
+ <td>cba359b </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">djvulibre</th>
- <td>3.5.27</td>
+ <th class="row" title=""> djvulibre   </th>
+ <td>3.5.27 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">dlfcn-win32</th>
- <td>e19bf07</td>
+ <th class="row" title=""> dlfcn-win32   </th>
+ <td>e19bf07 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">eigen</th>
- <td>3.2.5</td>
+ <th class="row" title=""> eigen   </th>
+ <td>3.2.5 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">exiv2</th>
- <td>0.25</td>
+ <th class="row" title=""> exiv2   </th>
+ <td>0.25 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">expat</th>
- <td>2.2.5</td>
+ <th class="row" title=""> expat   </th>
+ <td>2.2.5 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">faad2</th>
- <td>2.7</td>
+ <th class="row" title=""> faad2   </th>
+ <td>2.7 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">fdk-aac</th>
- <td>0.1.4</td>
+ <th class="row" title=""> fdk-aac   </th>
+ <td>0.1.4 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">ffmpeg</th>
- <td>3.4</td>
+ <th class="row" title=""> ffmpeg   </th>
+ <td>3.4 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">fftw</th>
- <td>3.3.6-pl1</td>
+ <th class="row" title=""> fftw   </th>
+ <td>3.3.6-pl1 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">file</th>
- <td>5.24</td>
+ <th class="row" title=""> file   </th>
+ <td>5.24 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">flac</th>
- <td>1.3.1</td>
+ <th class="row" title=""> flac   </th>
+ <td>1.3.1 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">flann</th>
- <td>1.8.4</td>
+ <th class="row" title=""> flann   </th>
+ <td>1.8.4 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">fltk</th>
- <td>1.3.3</td>
+ <th class="row" title=""> fltk   </th>
+ <td>1.3.3 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">fontconfig</th>
- <td>2.12.6</td>
+ <th class="row" title=""> fontconfig   </th>
+ <td>2.12.6 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">freeglut</th>
- <td>3.0.0</td>
+ <th class="row" title=""> freeglut   </th>
+ <td>3.0.0 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">freeimage</th>
- <td>3.15.4</td>
+ <th class="row" title=""> freeimage   </th>
+ <td>3.15.4 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">freetds</th>
- <td>1.00.70</td>
+ <th class="row" title=""> freetds   </th>
+ <td>1.00.70 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">freetype</th>
- <td>2.8.1</td>
+ <th class="row" title=""> freetype   </th>
+ <td>2.8.1 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">freetype-bootstrap</th>
- <td>2.8.1</td>
+ <th class="row" title=""> freetype-bootstrap   </th>
+ <td>2.8.1 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">freexl</th>
- <td>1.0.3</td>
+ <th class="row" title=""> freexl   </th>
+ <td>1.0.3 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">fribidi</th>
- <td>0.19.6</td>
+ <th class="row" title=""> fribidi   </th>
+ <td>0.19.6 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">ftgl</th>
- <td>2.1.3~rc5</td>
+ <th class="row" title=""> ftgl   </th>
+ <td>2.1.3~rc5 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">gc</th>
- <td>7.4.6</td>
+ <th class="row" title=""> gc   </th>
+ <td>7.4.6 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">gcc</th>
- <td>5.4.0</td>
+ <th class="row" title=""> gcc   </th>
+ <td>5.4.0 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">gd</th>
- <td>2.1.0</td>
+ <th class="row" title=""> gd   </th>
+ <td>2.1.0 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">gdal</th>
- <td>2.2.2</td>
+ <th class="row" title=""> gdal   </th>
+ <td>2.2.2 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">gdb</th>
- <td>8.0.1</td>
+ <th class="row" title=""> gdb   </th>
+ <td>8.0.1 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">gdk-pixbuf</th>
- <td>2.32.3</td>
+ <th class="row" title=""> gdk-pixbuf   </th>
+ <td>2.32.3 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">gendef</th>
- <td>5.0.3</td>
+ <th class="row" title=""> gendef   </th>
+ <td>5.0.3 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">geoip-database</th>
- <td>20150317-1</td>
-   <td class="unsupported">&#x2717;</td>
-   <td class="unsupported">&#x2717;</td>
-   <td class="unsupported">&#x2717;</td>
-   <td class="unsupported">&#x2717;</td>
-   <td class="supported">&#x2713;</td>
+ <th class="row" title=""> geoip-database   </th>
+ <td>20150317-1 </td>
+     <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+    <td class="supported">&#x2713;</td>
  </tr>
 
 <tr>
- <th class="row">geos</th>
- <td>3.6.2</td>
+ <th class="row" title=""> geos   </th>
+ <td>3.6.2 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">gettext</th>
- <td>0.19.8.1</td>
+ <th class="row" title=""> gettext   </th>
+ <td>0.19.8.1 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-   <td class="supported">&#x2713;</td>
+    <td class="supported">&#x2713;</td>
  </tr>
 
 <tr>
- <th class="row">ghostscript</th>
- <td>9.19</td>
+ <th class="row" title=""> ghostscript   </th>
+ <td>9.19 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">giflib</th>
- <td>5.1.4</td>
+ <th class="row" title=""> giflib   </th>
+ <td>5.1.4 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">glew</th>
- <td>1.12.0</td>
+ <th class="row" title=""> glew   </th>
+ <td>1.12.0 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">glfw2</th>
- <td>2.7.9</td>
+ <th class="row" title=""> glfw2   </th>
+ <td>2.7.9 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">glfw3</th>
- <td>3.1.2</td>
+ <th class="row" title=""> glfw3   </th>
+ <td>3.1.2 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">glib</th>
- <td>2.50.2</td>
+ <th class="row" title=""> glib   </th>
+ <td>2.50.2 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-   <td class="supported">&#x2713;</td>
+    <td class="supported">&#x2713;</td>
  </tr>
 
 <tr>
- <th class="row">glibmm</th>
- <td>2.42.0</td>
+ <th class="row" title=""> glibmm   </th>
+ <td>2.42.0 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">glm</th>
- <td>0.9.7.6</td>
+ <th class="row" title=""> glm   </th>
+ <td>0.9.7.6 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">glpk</th>
- <td>4.60</td>
+ <th class="row" title=""> glpk   </th>
+ <td>4.60 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">gmp</th>
- <td>6.1.2</td>
+ <th class="row" title=""> gmp   </th>
+ <td>6.1.2 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-   <td class="supported">&#x2713;</td>
+    <td class="supported">&#x2713;</td>
  </tr>
 
 <tr>
- <th class="row">gnutls</th>
- <td>3.5.16</td>
+ <th class="row" title=""> gnutls   </th>
+ <td>3.5.16 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">googlemock</th>
- <td>1.7.0</td>
-   <td class="unsupported">&#x2717;</td>
-   <td class="unsupported">&#x2717;</td>
-   <td class="unsupported">&#x2717;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+ <th class="row" title=""> googlemock  [archive-pkg]  </th>
+ <td>1.7.0 </td>
+    <td class="neutral">&bull;</td>
+    <td class="neutral">&bull;</td>
+    <td class="neutral">&bull;</td>
+    <td class="neutral">&bull;</td>
+    <td class="neutral">&bull;</td>
  </tr>
 
 <tr>
- <th class="row">googletest</th>
- <td>1.7.0</td>
-   <td class="unsupported">&#x2717;</td>
-   <td class="unsupported">&#x2717;</td>
-   <td class="unsupported">&#x2717;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+ <th class="row" title=""> googletest  [archive-pkg]  </th>
+ <td>1.7.0 </td>
+    <td class="neutral">&bull;</td>
+    <td class="neutral">&bull;</td>
+    <td class="neutral">&bull;</td>
+    <td class="neutral">&bull;</td>
+    <td class="neutral">&bull;</td>
  </tr>
 
 <tr>
- <th class="row">graphicsmagick</th>
- <td>1.3.21</td>
+ <th class="row" title=""> graphicsmagick   </th>
+ <td>1.3.21 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">gsl</th>
- <td>2.3</td>
+ <th class="row" title=""> gsl   </th>
+ <td>2.3 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">gsoap</th>
- <td>2.8.22</td>
+ <th class="row" title=""> gsoap   </th>
+ <td>2.8.22 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">gst-libav</th>
- <td>1.12.3</td>
+ <th class="row" title=""> gst-libav   </th>
+ <td>1.12.3 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">gst-plugins-bad</th>
- <td>1.12.3</td>
+ <th class="row" title=""> gst-plugins-bad   </th>
+ <td>1.12.3 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">gst-plugins-base</th>
- <td>1.12.3</td>
+ <th class="row" title=""> gst-plugins-base   </th>
+ <td>1.12.3 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">gst-plugins-good</th>
- <td>1.12.3</td>
+ <th class="row" title=""> gst-plugins-good   </th>
+ <td>1.12.3 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">gst-plugins-ugly</th>
- <td>1.12.3</td>
+ <th class="row" title=""> gst-plugins-ugly   </th>
+ <td>1.12.3 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">gstreamer</th>
- <td>1.12.3</td>
+ <th class="row" title=""> gstreamer   </th>
+ <td>1.12.3 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">gta</th>
- <td>1.0.8</td>
+ <th class="row" title=""> gta   </th>
+ <td>1.0.8 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">gtk2</th>
- <td>2.24.29</td>
+ <th class="row" title=""> gtk2   </th>
+ <td>2.24.29 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">gtk3</th>
- <td>3.22.7</td>
+ <th class="row" title=""> gtk3   </th>
+ <td>3.22.7 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">gtkglarea</th>
- <td>2.0.1</td>
+ <th class="row" title=""> gtkglarea   </th>
+ <td>2.0.1 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">gtkglext</th>
- <td>1.2.0</td>
+ <th class="row" title=""> gtkglext   </th>
+ <td>1.2.0 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">gtkglextmm</th>
- <td>1.2.0</td>
+ <th class="row" title=""> gtkglextmm   </th>
+ <td>1.2.0 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">gtkimageview</th>
- <td>1.6.4</td>
+ <th class="row" title=""> gtkimageview   </th>
+ <td>1.6.4 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">gtkmm2</th>
- <td>2.24.4</td>
+ <th class="row" title=""> gtkmm2   </th>
+ <td>2.24.4 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">gtkmm3</th>
- <td>3.14.0</td>
+ <th class="row" title=""> gtkmm3   </th>
+ <td>3.14.0 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">gtksourceview</th>
- <td>2.10.5</td>
+ <th class="row" title=""> gtksourceview   </th>
+ <td>2.10.5 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">gtksourceviewmm2</th>
- <td>2.10.3</td>
+ <th class="row" title=""> gtksourceviewmm2   </th>
+ <td>2.10.3 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">guile</th>
- <td>1.8.8</td>
+ <th class="row" title=""> guile   </th>
+ <td>1.8.8 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-   <td class="unsupported">&#x2717;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">gumbo</th>
- <td>0.10.1</td>
+ <th class="row" title=""> gumbo   </th>
+ <td>0.10.1 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">hamlib</th>
- <td>3.1</td>
+ <th class="row" title=""> hamlib   </th>
+ <td>3.1 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">harfbuzz</th>
- <td>1.7.1</td>
+ <th class="row" title=""> harfbuzz   </th>
+ <td>1.7.1 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">hdf-eos2</th>
- <td>19v1.00</td>
+ <th class="row" title=""> hdf-eos2   </th>
+ <td>19v1.00 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">hdf-eos5</th>
- <td>1.15</td>
+ <th class="row" title=""> hdf-eos5   </th>
+ <td>1.15 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">hdf4</th>
- <td>4.2.10</td>
+ <th class="row" title=""> hdf4   </th>
+ <td>4.2.10 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">hdf5</th>
- <td>1.8.12</td>
+ <th class="row" title=""> hdf5   </th>
+ <td>1.8.12 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">hunspell</th>
- <td>1.6.1</td>
+ <th class="row" title=""> hunspell   </th>
+ <td>1.6.1 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">hyperscan</th>
- <td>4.3.2</td>
+ <th class="row" title=""> hyperscan   </th>
+ <td>4.3.2 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">icu4c</th>
- <td>56.1</td>
+ <th class="row" title=""> icu4c   </th>
+ <td>56.1 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">id3lib</th>
- <td>3.8.3</td>
+ <th class="row" title=""> id3lib   </th>
+ <td>3.8.3 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">ilmbase</th>
- <td>2.2.0</td>
+ <th class="row" title=""> ilmbase   </th>
+ <td>2.2.0 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">imagemagick</th>
- <td>6.9.0-0</td>
+ <th class="row" title=""> imagemagick   </th>
+ <td>6.9.0-0 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">intel-tbb</th>
- <td>c28c8be</td>
+ <th class="row" title=""> intel-tbb   </th>
+ <td>c28c8be </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">isl</th>
- <td>0.15</td>
+ <th class="row" title=""> isl   </th>
+ <td>0.15 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-   <td class="supported">&#x2713;</td>
+    <td class="supported">&#x2713;</td>
  </tr>
 
 <tr>
- <th class="row">itk</th>
- <td>4.10.1</td>
+ <th class="row" title=""> itk   </th>
+ <td>4.10.1 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">itpp</th>
- <td>4.3.1</td>
+ <th class="row" title=""> itpp   </th>
+ <td>4.3.1 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">jack</th>
- <td>1.9.10</td>
-   <td class="unsupported">&#x2717;</td>
+ <th class="row" title=""> jack   </th>
+ <td>1.9.10 </td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">jansson</th>
- <td>2.7</td>
+ <th class="row" title=""> jansson   </th>
+ <td>2.7 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">jasper</th>
- <td>2.0.14</td>
+ <th class="row" title=""> jasper   </th>
+ <td>2.0.14 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">jpeg</th>
- <td>9b</td>
+ <th class="row" title=""> jpeg   </th>
+ <td>9b </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">json-c</th>
- <td>0.12.1</td>
+ <th class="row" title=""> json-c   </th>
+ <td>0.12.1 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">json-glib</th>
- <td>1.0.4</td>
+ <th class="row" title=""> json-glib   </th>
+ <td>1.0.4 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">json_spirit</th>
- <td>4.08</td>
+ <th class="row" title=""> json_spirit   </th>
+ <td>4.08 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">jsoncpp</th>
- <td>1.8.0</td>
+ <th class="row" title=""> jsoncpp   </th>
+ <td>1.8.0 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">lame</th>
- <td>3.99.5</td>
+ <th class="row" title=""> lame   </th>
+ <td>3.99.5 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">lapack</th>
- <td>3.6.0</td>
-   <td class="unsupported">&#x2717;</td>
-   <td class="unsupported">&#x2717;</td>
-   <td class="unsupported">&#x2717;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+ <th class="row" title="*** lapack has been replaced by openblas ***"> lapack   ** </th>
+ <td>3.6.0 </td>
+     <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">lcms</th>
- <td>2.9</td>
+ <th class="row" title=""> lcms   </th>
+ <td>2.9 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">lcms1</th>
- <td>1.19</td>
+ <th class="row" title=""> lcms1   </th>
+ <td>1.19 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">lensfun</th>
- <td>0.3.2</td>
+ <th class="row" title=""> lensfun   </th>
+ <td>0.3.2 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">levmar</th>
- <td>2.6</td>
+ <th class="row" title=""> levmar   </th>
+ <td>2.6 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libaacs</th>
- <td>0.8.1</td>
+ <th class="row" title=""> libaacs   </th>
+ <td>0.8.1 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libarchive</th>
- <td>3.3.2</td>
+ <th class="row" title=""> libarchive   </th>
+ <td>3.3.2 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libass</th>
- <td>0.14.0</td>
+ <th class="row" title=""> libass   </th>
+ <td>0.14.0 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libatomic_ops</th>
- <td>7.4.8</td>
+ <th class="row" title=""> libatomic_ops   </th>
+ <td>7.4.8 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libbluray</th>
- <td>0.9.2</td>
+ <th class="row" title=""> libbluray   </th>
+ <td>0.9.2 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libbs2b</th>
- <td>3.1.0</td>
+ <th class="row" title=""> libbs2b   </th>
+ <td>3.1.0 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libcaca</th>
- <td>0.99.beta19</td>
+ <th class="row" title=""> libcaca   </th>
+ <td>0.99.beta19 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libcddb</th>
- <td>1.3.2</td>
+ <th class="row" title=""> libcddb   </th>
+ <td>1.3.2 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libcdio</th>
- <td>0.93</td>
+ <th class="row" title=""> libcdio   </th>
+ <td>0.93 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libcdio-paranoia</th>
- <td>10.2+0.93+1</td>
+ <th class="row" title=""> libcdio-paranoia   </th>
+ <td>10.2+0.93+1 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libcomm14cux</th>
- <td>2.1.1</td>
+ <th class="row" title=""> libcomm14cux   </th>
+ <td>2.1.1 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libcroco</th>
- <td>0.6.2</td>
+ <th class="row" title=""> libcroco   </th>
+ <td>0.6.2 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libdnet</th>
- <td>1.11</td>
+ <th class="row" title=""> libdnet   </th>
+ <td>1.11 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libdvbpsi</th>
- <td>1.2.0</td>
+ <th class="row" title=""> libdvbpsi   </th>
+ <td>1.2.0 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libdvdcss</th>
- <td>1.3.0</td>
+ <th class="row" title=""> libdvdcss   </th>
+ <td>1.3.0 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libdvdetect</th>
- <td>0.71.0</td>
+ <th class="row" title=""> libdvdetect   </th>
+ <td>0.71.0 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libdvdnav</th>
- <td>5.0.1</td>
+ <th class="row" title=""> libdvdnav   </th>
+ <td>5.0.1 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libdvdread</th>
- <td>5.0.0</td>
+ <th class="row" title=""> libdvdread   </th>
+ <td>5.0.0 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libechonest</th>
- <td>2.3.1</td>
-   <td class="unsupported">&#x2717;</td>
+ <th class="row" title=""> libechonest   </th>
+ <td>2.3.1 </td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libepoxy</th>
- <td>1.3.1</td>
+ <th class="row" title=""> libepoxy   </th>
+ <td>1.3.1 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libevent</th>
- <td>2.0.21</td>
+ <th class="row" title=""> libevent   </th>
+ <td>2.0.21 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libf2c</th>
- <td>1</td>
+ <th class="row" title=""> libf2c   </th>
+ <td>1 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libffi</th>
- <td>3.2.1</td>
+ <th class="row" title=""> libffi   </th>
+ <td>3.2.1 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libftdi</th>
- <td>0.20</td>
-   <td class="unsupported">&#x2717;</td>
-   <td class="unsupported">&#x2717;</td>
-   <td class="unsupported">&#x2717;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+ <th class="row" title="*** libftdi is deprecated - please use libftdi1 ***"> libftdi   ** </th>
+ <td>0.20 </td>
+     <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libftdi1</th>
- <td>1.2</td>
+ <th class="row" title=""> libftdi1   </th>
+ <td>1.2 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libgcrypt</th>
- <td>1.8.1</td>
+ <th class="row" title=""> libgcrypt   </th>
+ <td>1.8.1 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libgda</th>
- <td>4.2.13</td>
+ <th class="row" title=""> libgda   </th>
+ <td>4.2.13 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libgdamm</th>
- <td>4.1.3</td>
+ <th class="row" title=""> libgdamm   </th>
+ <td>4.1.3 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libgee</th>
- <td>0.5.0</td>
+ <th class="row" title=""> libgee   </th>
+ <td>0.5.0 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libgeotiff</th>
- <td>1.4.2</td>
+ <th class="row" title=""> libgeotiff   </th>
+ <td>1.4.2 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libgit2</th>
- <td>0.23.2</td>
+ <th class="row" title=""> libgit2   </th>
+ <td>0.23.2 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libglade</th>
- <td>2.6.4</td>
+ <th class="row" title=""> libglade   </th>
+ <td>2.6.4 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libgnurx</th>
- <td>2.6.1</td>
+ <th class="row" title=""> libgnurx   </th>
+ <td>2.6.1 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libgpg_error</th>
- <td>1.27</td>
+ <th class="row" title=""> libgpg_error   </th>
+ <td>1.27 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libgsasl</th>
- <td>1.8.0</td>
+ <th class="row" title=""> libgsasl   </th>
+ <td>1.8.0 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libgsf</th>
- <td>1.14.30</td>
+ <th class="row" title=""> libgsf   </th>
+ <td>1.14.30 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libharu</th>
- <td>2.3.0</td>
+ <th class="row" title=""> libharu   </th>
+ <td>2.3.0 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libiberty</th>
- <td>2.28</td>
+ <th class="row" title=""> libiberty   </th>
+ <td>2.28 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libical</th>
- <td>2.0.0</td>
+ <th class="row" title=""> libical   </th>
+ <td>2.0.0 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libiconv</th>
- <td>1.15</td>
+ <th class="row" title=""> libiconv   </th>
+ <td>1.15 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-   <td class="supported">&#x2713;</td>
+    <td class="supported">&#x2713;</td>
  </tr>
 
 <tr>
- <th class="row">libid3tag</th>
- <td>0.15.1b</td>
+ <th class="row" title=""> libid3tag   </th>
+ <td>0.15.1b </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libidn</th>
- <td>1.33</td>
+ <th class="row" title=""> libidn   </th>
+ <td>1.33 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libidn2</th>
- <td>2.0.2</td>
+ <th class="row" title=""> libidn2   </th>
+ <td>2.0.2 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libieee1284</th>
- <td>0.2.11</td>
+ <th class="row" title=""> libieee1284   </th>
+ <td>0.2.11 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libircclient</th>
- <td>1.8</td>
+ <th class="row" title=""> libircclient   </th>
+ <td>1.8 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libjpeg-turbo</th>
- <td>1.5.2</td>
+ <th class="row" title=""> libjpeg-turbo   </th>
+ <td>1.5.2 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">liblastfm</th>
- <td>1.0.9</td>
-   <td class="unsupported">&#x2717;</td>
+ <th class="row" title=""> liblastfm   </th>
+ <td>1.0.9 </td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">liblastfm_qt4</th>
- <td>1.0.9</td>
-   <td class="unsupported">&#x2717;</td>
+ <th class="row" title=""> liblastfm_qt4   </th>
+ <td>1.0.9 </td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">liblaxjson</th>
- <td>1.0.5</td>
+ <th class="row" title=""> liblaxjson   </th>
+ <td>1.0.5 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">liblo</th>
- <td>0.28</td>
+ <th class="row" title=""> liblo   </th>
+ <td>0.28 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">liblqr-1</th>
- <td>0.4.2</td>
+ <th class="row" title=""> liblqr-1   </th>
+ <td>0.4.2 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">liblsmash</th>
- <td>2.9.1</td>
+ <th class="row" title=""> liblsmash   </th>
+ <td>2.9.1 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libltdl</th>
- <td>2.4.4</td>
+ <th class="row" title=""> libltdl   </th>
+ <td>2.4.4 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libmad</th>
- <td>0.15.1b</td>
+ <th class="row" title=""> libmad   </th>
+ <td>0.15.1b </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libmicrohttpd</th>
- <td>0.9.38</td>
+ <th class="row" title=""> libmicrohttpd   </th>
+ <td>0.9.38 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-   <td class="unsupported">&#x2717;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libmikmod</th>
- <td>3.3.7</td>
+ <th class="row" title=""> libmikmod   </th>
+ <td>3.3.7 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libmms</th>
- <td>0.6.4</td>
+ <th class="row" title=""> libmms   </th>
+ <td>0.6.4 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libmng</th>
- <td>2.0.3</td>
+ <th class="row" title=""> libmng   </th>
+ <td>2.0.3 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libmodplug</th>
- <td>0.8.8.4</td>
+ <th class="row" title=""> libmodplug   </th>
+ <td>0.8.8.4 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libmpcdec</th>
- <td>1.2.6</td>
+ <th class="row" title=""> libmpcdec   </th>
+ <td>1.2.6 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libmysqlclient</th>
- <td>6.1.6</td>
+ <th class="row" title=""> libmysqlclient   </th>
+ <td>6.1.6 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libnice</th>
- <td>0.1.13</td>
+ <th class="row" title=""> libnice   </th>
+ <td>0.1.13 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libntlm</th>
- <td>1.4</td>
+ <th class="row" title=""> libntlm   </th>
+ <td>1.4 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">liboauth</th>
- <td>1.0.3</td>
+ <th class="row" title=""> liboauth   </th>
+ <td>1.0.3 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libodbc++</th>
- <td>0.2.5</td>
+ <th class="row" title=""> libodbc++   </th>
+ <td>0.2.5 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">liboil</th>
- <td>0.3.17</td>
+ <th class="row" title=""> liboil   </th>
+ <td>0.3.17 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libomemo</th>
- <td>0.6.1</td>
+ <th class="row" title=""> libomemo   </th>
+ <td>0.6.1 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libotr</th>
- <td>4.1.1</td>
+ <th class="row" title=""> libotr   </th>
+ <td>4.1.1 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libpano13</th>
- <td>2.9.18</td>
+ <th class="row" title=""> libpano13   </th>
+ <td>2.9.18 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libpaper</th>
- <td>1.1.24+nmu4</td>
+ <th class="row" title=""> libpaper   </th>
+ <td>1.1.24+nmu4 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libplist</th>
- <td>1.12</td>
+ <th class="row" title=""> libplist   </th>
+ <td>1.12 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libpng</th>
- <td>1.6.34</td>
+ <th class="row" title=""> libpng   </th>
+ <td>1.6.34 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libqrencode</th>
- <td>4.0.0</td>
+ <th class="row" title=""> libqrencode   </th>
+ <td>4.0.0 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">librosco</th>
- <td>0.1.11</td>
+ <th class="row" title=""> librosco   </th>
+ <td>0.1.11 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">librsvg</th>
- <td>2.40.5</td>
+ <th class="row" title=""> librsvg   </th>
+ <td>2.40.5 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">librtmp</th>
- <td>a107cef</td>
+ <th class="row" title=""> librtmp   </th>
+ <td>a107cef </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libsamplerate</th>
- <td>0.1.9</td>
+ <th class="row" title=""> libsamplerate   </th>
+ <td>0.1.9 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libserialport</th>
- <td>0.1.1</td>
+ <th class="row" title=""> libserialport   </th>
+ <td>0.1.1 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libshout</th>
- <td>2.4.1</td>
+ <th class="row" title=""> libshout   </th>
+ <td>2.4.1 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libsigc++</th>
- <td>2.4.0</td>
+ <th class="row" title=""> libsigc++   </th>
+ <td>2.4.0 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libsigrok</th>
- <td>0.5.0</td>
+ <th class="row" title=""> libsigrok   </th>
+ <td>0.5.0 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libsndfile</th>
- <td>1.0.28</td>
+ <th class="row" title=""> libsndfile   </th>
+ <td>1.0.28 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libsodium</th>
- <td>1.0.6</td>
+ <th class="row" title=""> libsodium   </th>
+ <td>1.0.6 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libsoup</th>
- <td>2.57.1</td>
+ <th class="row" title=""> libsoup   </th>
+ <td>2.57.1 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libspatialindex</th>
- <td>1.8.5</td>
+ <th class="row" title=""> libspatialindex   </th>
+ <td>1.8.5 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libspectre</th>
- <td>0.2.8</td>
+ <th class="row" title=""> libspectre   </th>
+ <td>0.2.8 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libssh</th>
- <td>0.7.5</td>
+ <th class="row" title=""> libssh   </th>
+ <td>0.7.5 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libssh2</th>
- <td>1.8.0</td>
+ <th class="row" title=""> libssh2   </th>
+ <td>1.8.0 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libsvm</th>
- <td>3.22</td>
+ <th class="row" title=""> libsvm   </th>
+ <td>3.22 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libtool</th>
- <td>2.4.4</td>
-   <td class="unsupported">&#x2717;</td>
-   <td class="unsupported">&#x2717;</td>
-   <td class="unsupported">&#x2717;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+ <th class="row" title=""> libtool   </th>
+ <td>2.4.4 </td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td class="unsupported">&#x2717;</td>
  </tr>
 
 <tr>
- <th class="row">libtorrent-rasterbar</th>
- <td>1.1.0</td>
+ <th class="row" title=""> libtorrent-rasterbar   </th>
+ <td>1.1.0 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libunistring</th>
- <td>0.9.7</td>
+ <th class="row" title=""> libunistring   </th>
+ <td>0.9.7 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libusb</th>
- <td>1.2.6.0</td>
-   <td class="unsupported">&#x2717;</td>
-   <td class="unsupported">&#x2717;</td>
-   <td class="unsupported">&#x2717;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+ <th class="row" title="*** libusb is deprecated - please use libusb1 ***"> libusb   ** </th>
+ <td>1.2.6.0 </td>
+     <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libusb1</th>
- <td>1.0.21</td>
+ <th class="row" title=""> libusb1   </th>
+ <td>1.0.21 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libuv</th>
- <td>1.9.1</td>
+ <th class="row" title=""> libuv   </th>
+ <td>1.9.1 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libvpx</th>
- <td>1.5.0</td>
+ <th class="row" title=""> libvpx   </th>
+ <td>1.5.0 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libwebp</th>
- <td>0.4.4</td>
+ <th class="row" title=""> libwebp   </th>
+ <td>0.4.4 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libwebsockets</th>
- <td>1.4-chrome43&hellip;</td>
+ <th class="row" title=""> libwebsockets   </th>
+ <td>1.4-chrome43 &hellip;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libxml++</th>
- <td>2.40.1</td>
+ <th class="row" title=""> libxml++   </th>
+ <td>2.40.1 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libxml2</th>
- <td>2.9.4</td>
+ <th class="row" title=""> libxml2   </th>
+ <td>2.9.4 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libxslt</th>
- <td>1.1.29</td>
+ <th class="row" title=""> libxslt   </th>
+ <td>1.1.29 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">libzip</th>
- <td>1.1.3</td>
+ <th class="row" title=""> libzip   </th>
+ <td>1.1.3 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">llvm</th>
- <td>3.4</td>
+ <th class="row" title=""> llvm   </th>
+ <td>3.4 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">log4cxx</th>
- <td>0.10.0</td>
+ <th class="row" title=""> log4cxx   </th>
+ <td>0.10.0 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">lua</th>
- <td>5.3.3</td>
+ <th class="row" title=""> lua   </th>
+ <td>5.3.3 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">luabind</th>
- <td>0.9.1</td>
+ <th class="row" title=""> luabind   </th>
+ <td>0.9.1 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">luajit</th>
- <td>2.0.4</td>
+ <th class="row" title=""> luajit   </th>
+ <td>2.0.4 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">lz4</th>
- <td>1.8.0</td>
+ <th class="row" title=""> lz4   </th>
+ <td>1.8.0 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">lzma</th>
- <td>1701</td>
+ <th class="row" title=""> lzma   </th>
+ <td>1701 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+    <td class="unsupported">&#x2717;</td>
  </tr>
 
 <tr>
- <th class="row">lzo</th>
- <td>2.09</td>
+ <th class="row" title=""> lzo   </th>
+ <td>2.09 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">matio</th>
- <td>1.5.2</td>
+ <th class="row" title=""> matio   </th>
+ <td>1.5.2 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">mdbtools</th>
- <td>0.7.1</td>
+ <th class="row" title=""> mdbtools   </th>
+ <td>0.7.1 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">metis</th>
- <td>5.1.0</td>
+ <th class="row" title=""> metis   </th>
+ <td>5.1.0 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">mingw-w64</th>
- <td>5.0.3</td>
-   <td class="unsupported">&#x2717;</td>
-   <td class="unsupported">&#x2717;</td>
-   <td class="unsupported">&#x2717;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+ <th class="row" title=""> mingw-w64  [archive-pkg]  </th>
+ <td>5.0.3 </td>
+    <td class="neutral">&bull;</td>
+    <td class="neutral">&bull;</td>
+    <td class="neutral">&bull;</td>
+    <td class="neutral">&bull;</td>
+    <td></td>
  </tr>
 
 <tr>
- <th class="row">miniupnpc</th>
- <td>1.9</td>
+ <th class="row" title=""> miniupnpc   </th>
+ <td>1.9 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">minizip</th>
- <td>0b46a2b</td>
+ <th class="row" title=""> minizip   </th>
+ <td>0b46a2b </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">mman-win32</th>
- <td>b7ec370</td>
+ <th class="row" title=""> mman-win32   </th>
+ <td>b7ec370 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">mpc</th>
- <td>1.0.2</td>
+ <th class="row" title=""> mpc   </th>
+ <td>1.0.2 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-   <td class="supported">&#x2713;</td>
+    <td class="supported">&#x2713;</td>
  </tr>
 
 <tr>
- <th class="row">mpfr</th>
- <td>3.1.5</td>
+ <th class="row" title=""> mpfr   </th>
+ <td>3.1.5 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-   <td class="supported">&#x2713;</td>
+    <td class="supported">&#x2713;</td>
  </tr>
 
 <tr>
- <th class="row">mpg123</th>
- <td>1.22.4</td>
+ <th class="row" title=""> mpg123   </th>
+ <td>1.22.4 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">muparser</th>
- <td>2.2.5</td>
+ <th class="row" title=""> muparser   </th>
+ <td>2.2.5 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">muparserx</th>
- <td>4.0.4</td>
+ <th class="row" title=""> muparserx   </th>
+ <td>4.0.4 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">mxe-conf</th>
- <td>1</td>
+ <th class="row" title=""> mxe-conf   </th>
+ <td>1 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-   <td class="supported">&#x2713;</td>
+    <td class="supported">&#x2713;</td>
  </tr>
 
 <tr>
- <th class="row">mxml</th>
- <td>2.11</td>
+ <th class="row" title=""> mxml   </th>
+ <td>2.11 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">nasm</th>
- <td>2.13.01</td>
-   <td class="unsupported">&#x2717;</td>
-   <td class="unsupported">&#x2717;</td>
-   <td class="unsupported">&#x2717;</td>
-   <td class="unsupported">&#x2717;</td>
-   <td class="supported">&#x2713;</td>
+ <th class="row" title=""> nasm   </th>
+ <td>2.13.01 </td>
+     <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+    <td class="supported">&#x2713;</td>
  </tr>
 
 <tr>
- <th class="row">ncurses</th>
- <td>e14300b</td>
+ <th class="row" title=""> ncurses   </th>
+ <td>e14300b </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">neon</th>
- <td>0.30.2</td>
+ <th class="row" title=""> neon   </th>
+ <td>0.30.2 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">netcdf</th>
- <td>4.3.0</td>
+ <th class="row" title=""> netcdf   </th>
+ <td>4.3.0 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">netpbm</th>
- <td>10.35.96</td>
+ <th class="row" title=""> netpbm   </th>
+ <td>10.35.96 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">nettle</th>
- <td>3.3</td>
+ <th class="row" title=""> nettle   </th>
+ <td>3.3 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">nlopt</th>
- <td>2.4.2</td>
+ <th class="row" title=""> nlopt   </th>
+ <td>2.4.2 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">nsis</th>
- <td>3.01</td>
+ <th class="row" title=""> nsis   </th>
+ <td>3.01 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">ocaml-cairo</th>
- <td>1.2.0</td>
+ <th class="row" title=""> ocaml-cairo   </th>
+ <td>1.2.0 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-   <td class="unsupported">&#x2717;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">ocaml-camlimages</th>
- <td>4.0.1</td>
+ <th class="row" title=""> ocaml-camlimages   </th>
+ <td>4.0.1 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-   <td class="unsupported">&#x2717;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">ocaml-core</th>
- <td>4.00.1</td>
+ <th class="row" title=""> ocaml-core   </th>
+ <td>4.00.1 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-   <td class="unsupported">&#x2717;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">ocaml-findlib</th>
- <td>1.4</td>
+ <th class="row" title=""> ocaml-findlib   </th>
+ <td>1.4 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-   <td class="unsupported">&#x2717;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">ocaml-flexdll</th>
- <td>0.31</td>
+ <th class="row" title=""> ocaml-flexdll   </th>
+ <td>0.31 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-   <td class="unsupported">&#x2717;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">ocaml-lablgl</th>
- <td>1.05</td>
+ <th class="row" title=""> ocaml-lablgl   </th>
+ <td>1.05 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-   <td class="unsupported">&#x2717;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">ocaml-lablgtk2</th>
- <td>2.16.0</td>
+ <th class="row" title=""> ocaml-lablgtk2   </th>
+ <td>2.16.0 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-   <td class="unsupported">&#x2717;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">ocaml-native</th>
- <td>4.00.1</td>
+ <th class="row" title=""> ocaml-native   </th>
+ <td>4.00.1 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-   <td class="unsupported">&#x2717;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">ocaml-xml-light</th>
- <td>2.2</td>
+ <th class="row" title=""> ocaml-xml-light   </th>
+ <td>2.2 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-   <td class="unsupported">&#x2717;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">oce</th>
- <td>0.18.2</td>
+ <th class="row" title=""> oce   </th>
+ <td>0.18.2 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">ogg</th>
- <td>1.3.2</td>
+ <th class="row" title=""> ogg   </th>
+ <td>1.3.2 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">old</th>
- <td>0.17</td>
+ <th class="row" title=""> old   </th>
+ <td>0.17 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">openal</th>
- <td>1.16.0</td>
+ <th class="row" title=""> openal   </th>
+ <td>1.16.0 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">openblas</th>
- <td>0.2.20</td>
+ <th class="row" title=""> openblas   </th>
+ <td>0.2.20 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">opencore-amr</th>
- <td>0.1.3</td>
+ <th class="row" title=""> opencore-amr   </th>
+ <td>0.1.3 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">opencsg</th>
- <td>1.4.1</td>
+ <th class="row" title=""> opencsg   </th>
+ <td>1.4.1 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">opencv</th>
- <td>3.3.0</td>
+ <th class="row" title=""> opencv   </th>
+ <td>3.3.0 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">openexr</th>
- <td>2.2.0</td>
+ <th class="row" title=""> openexr   </th>
+ <td>2.2.0 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">openjpeg</th>
- <td>2.3.0</td>
+ <th class="row" title=""> openjpeg   </th>
+ <td>2.3.0 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">openmp-validation</th>
- <td>ff8cf0c</td>
+ <th class="row" title=""> openmp-validation   </th>
+ <td>ff8cf0c </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">openscenegraph</th>
- <td>3.4.0</td>
+ <th class="row" title=""> openscenegraph   </th>
+ <td>3.4.0 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">openssl</th>
- <td>1.0.2m</td>
+ <th class="row" title=""> openssl   </th>
+ <td>1.0.2m </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">openthreads</th>
- <td>3.4.0</td>
+ <th class="row" title=""> openthreads   </th>
+ <td>3.4.0 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">opus</th>
- <td>1.1.1</td>
+ <th class="row" title=""> opus   </th>
+ <td>1.1.1 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">opusfile</th>
- <td>0.6</td>
+ <th class="row" title=""> opusfile   </th>
+ <td>0.6 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">ossim</th>
- <td>43a071a</td>
+ <th class="row" title=""> ossim   </th>
+ <td>43a071a </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">pango</th>
- <td>1.37.4</td>
+ <th class="row" title=""> pango   </th>
+ <td>1.37.4 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">pangomm</th>
- <td>2.34.0</td>
+ <th class="row" title=""> pangomm   </th>
+ <td>2.34.0 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">pcl</th>
- <td>1.8.0</td>
+ <th class="row" title=""> pcl   </th>
+ <td>1.8.0 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">pcre</th>
- <td>8.41</td>
+ <th class="row" title=""> pcre   </th>
+ <td>8.41 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">pcre2</th>
- <td>10.30</td>
+ <th class="row" title=""> pcre2   </th>
+ <td>10.30 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">pdcurses</th>
- <td>3.4</td>
+ <th class="row" title=""> pdcurses   </th>
+ <td>3.4 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">pdflib_lite</th>
- <td>7.0.5p3</td>
+ <th class="row" title=""> pdflib_lite   </th>
+ <td>7.0.5p3 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">pfstools</th>
- <td>2.0.4</td>
+ <th class="row" title=""> pfstools   </th>
+ <td>2.0.4 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">physfs</th>
- <td>2.0.3</td>
+ <th class="row" title=""> physfs   </th>
+ <td>2.0.3 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">picomodel</th>
- <td>1142ad8</td>
+ <th class="row" title=""> picomodel   </th>
+ <td>1142ad8 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">pire</th>
- <td>0.0.5</td>
+ <th class="row" title=""> pire   </th>
+ <td>0.0.5 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">pixman</th>
- <td>0.33.6</td>
+ <th class="row" title=""> pixman   </th>
+ <td>0.33.6 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">pkgconf</th>
- <td>da179fd</td>
+ <th class="row" title=""> pkgconf   </th>
+ <td>da179fd </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-   <td class="supported">&#x2713;</td>
+    <td class="supported">&#x2713;</td>
  </tr>
 
 <tr>
- <th class="row">plib</th>
- <td>1.8.5-rc1</td>
+ <th class="row" title=""> plib   </th>
+ <td>1.8.5-rc1 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">plibc</th>
- <td>cd7ed09</td>
+ <th class="row" title=""> plibc   </th>
+ <td>cd7ed09 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-   <td class="unsupported">&#x2717;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">plotmm</th>
- <td>0.1.2</td>
+ <th class="row" title=""> plotmm   </th>
+ <td>0.1.2 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">plotutils</th>
- <td>2.6</td>
+ <th class="row" title=""> plotutils   </th>
+ <td>2.6 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">poco</th>
- <td>1.4.7p1</td>
+ <th class="row" title=""> poco   </th>
+ <td>1.4.7p1 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">polarssl</th>
- <td>1.3.9</td>
+ <th class="row" title=""> polarssl   </th>
+ <td>1.3.9 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">poppler</th>
- <td>0.51.0</td>
+ <th class="row" title=""> poppler   </th>
+ <td>0.51.0 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">popt</th>
- <td>1.16</td>
+ <th class="row" title=""> popt   </th>
+ <td>1.16 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">portablexdr</th>
- <td>4.9.1</td>
+ <th class="row" title=""> portablexdr   </th>
+ <td>4.9.1 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">portaudio</th>
- <td>190600_20161&hellip;</td>
+ <th class="row" title=""> portaudio   </th>
+ <td>190600_20161 &hellip;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">portmidi</th>
- <td>217</td>
+ <th class="row" title=""> portmidi   </th>
+ <td>217 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">postgresql</th>
- <td>9.2.4</td>
+ <th class="row" title=""> postgresql   </th>
+ <td>9.2.4 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">primesieve</th>
- <td>5.5.0</td>
+ <th class="row" title=""> primesieve   </th>
+ <td>5.5.0 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">proj</th>
- <td>4.9.3</td>
+ <th class="row" title=""> proj   </th>
+ <td>4.9.3 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">protobuf</th>
- <td>3.4.0</td>
+ <th class="row" title=""> protobuf   </th>
+ <td>3.4.0 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-   <td class="supported">&#x2713;</td>
+    <td class="supported">&#x2713;</td>
  </tr>
 
 <tr>
- <th class="row">pthreads</th>
- <td>POSIX 1003.1&hellip;</td>
+ <th class="row" title=""> pthreads   </th>
+ <td>POSIX 1003.1 &hellip;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">pugixml</th>
- <td>1.8</td>
+ <th class="row" title=""> pugixml   </th>
+ <td>1.8 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">qca</th>
- <td>2.1.3</td>
-   <td class="unsupported">&#x2717;</td>
+ <th class="row" title=""> qca   </th>
+ <td>2.1.3 </td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">qdbm</th>
- <td>1.8.78</td>
+ <th class="row" title=""> qdbm   </th>
+ <td>1.8.78 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">qhttpengine</th>
- <td>0.1.0</td>
+ <th class="row" title=""> qhttpengine   </th>
+ <td>0.1.0 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">qjson</th>
- <td>0.8.1</td>
+ <th class="row" title=""> qjson   </th>
+ <td>0.8.1 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">qscintilla2</th>
- <td>2.10.1</td>
+ <th class="row" title=""> qscintilla2   </th>
+ <td>2.10.1 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">qt</th>
- <td>4.8.7</td>
+ <th class="row" title=""> qt   </th>
+ <td>4.8.7 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">qt3d</th>
- <td>5.9.3</td>
+ <th class="row" title=""> qt3d   </th>
+ <td>5.9.3 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">qt5</th>
- <td>5.9.3</td>
-   <td class="unsupported">&#x2717;</td>
-   <td class="unsupported">&#x2717;</td>
-   <td class="unsupported">&#x2717;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+ <th class="row" title=""> qt5  [meta-pkg]  </th>
+ <td>5.9.3 </td>
+    <td class="neutral">&bull;</td>
+    <td class="neutral">&bull;</td>
+    <td class="neutral">&bull;</td>
+    <td class="neutral">&bull;</td>
+    <td></td>
  </tr>
 
 <tr>
- <th class="row">qtactiveqt</th>
- <td>5.9.3</td>
+ <th class="row" title=""> qtactiveqt   </th>
+ <td>5.9.3 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">qtbase</th>
- <td>5.9.3</td>
+ <th class="row" title=""> qtbase   </th>
+ <td>5.9.3 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">qtcanvas3d</th>
- <td>5.9.3</td>
+ <th class="row" title=""> qtcanvas3d   </th>
+ <td>5.9.3 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">qtcharts</th>
- <td>5.9.3</td>
+ <th class="row" title=""> qtcharts   </th>
+ <td>5.9.3 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">qtconnectivity</th>
- <td>5.9.3</td>
+ <th class="row" title=""> qtconnectivity   </th>
+ <td>5.9.3 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">qtdatavis3d</th>
- <td>5.9.3</td>
+ <th class="row" title=""> qtdatavis3d   </th>
+ <td>5.9.3 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">qtdeclarative</th>
- <td>5.9.3</td>
+ <th class="row" title=""> qtdeclarative   </th>
+ <td>5.9.3 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">qtgamepad</th>
- <td>5.9.3</td>
+ <th class="row" title=""> qtgamepad   </th>
+ <td>5.9.3 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">qtgraphicaleffects</th>
- <td>5.9.3</td>
+ <th class="row" title=""> qtgraphicaleffects   </th>
+ <td>5.9.3 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">qtimageformats</th>
- <td>5.9.3</td>
+ <th class="row" title=""> qtimageformats   </th>
+ <td>5.9.3 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">qtkeychain</th>
- <td>0.8.0</td>
+ <th class="row" title=""> qtkeychain   </th>
+ <td>0.8.0 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">qtlocation</th>
- <td>5.9.3</td>
+ <th class="row" title=""> qtlocation   </th>
+ <td>5.9.3 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">qtmultimedia</th>
- <td>5.9.3</td>
+ <th class="row" title=""> qtmultimedia   </th>
+ <td>5.9.3 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">qtofficeopenxml</th>
- <td>02dda4a46f92&hellip;</td>
+ <th class="row" title=""> qtofficeopenxml   </th>
+ <td>02dda4a46f92 &hellip;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">qtpurchasing</th>
- <td>5.9.3</td>
+ <th class="row" title=""> qtpurchasing   </th>
+ <td>5.9.3 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">qtquickcontrols</th>
- <td>5.9.3</td>
+ <th class="row" title=""> qtquickcontrols   </th>
+ <td>5.9.3 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">qtquickcontrols2</th>
- <td>5.9.3</td>
+ <th class="row" title=""> qtquickcontrols2   </th>
+ <td>5.9.3 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">qtscript</th>
- <td>5.9.3</td>
+ <th class="row" title=""> qtscript   </th>
+ <td>5.9.3 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">qtscxml</th>
- <td>5.9.3</td>
+ <th class="row" title=""> qtscxml   </th>
+ <td>5.9.3 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">qtsensors</th>
- <td>5.9.3</td>
+ <th class="row" title=""> qtsensors   </th>
+ <td>5.9.3 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">qtserialbus</th>
- <td>5.9.3</td>
+ <th class="row" title=""> qtserialbus   </th>
+ <td>5.9.3 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">qtserialport</th>
- <td>5.9.3</td>
+ <th class="row" title=""> qtserialport   </th>
+ <td>5.9.3 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">qtserialport_qt4</th>
- <td>5c3b6cc</td>
+ <th class="row" title=""> qtserialport_qt4   </th>
+ <td>5c3b6cc </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">qtservice</th>
- <td>ad9bc46</td>
+ <th class="row" title=""> qtservice   </th>
+ <td>ad9bc46 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">qtsparkle</th>
- <td>4c852e57061d&hellip;</td>
+ <th class="row" title=""> qtsparkle   </th>
+ <td>4c852e57061d &hellip;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">qtsparkle_qt4</th>
- <td>4c852e57061d&hellip;</td>
+ <th class="row" title=""> qtsparkle_qt4   </th>
+ <td>4c852e57061d &hellip;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">qtspeech</th>
- <td>5.9.3</td>
+ <th class="row" title=""> qtspeech   </th>
+ <td>5.9.3 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">qtsvg</th>
- <td>5.9.3</td>
+ <th class="row" title=""> qtsvg   </th>
+ <td>5.9.3 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">qtsystems</th>
- <td>4e3a7ed</td>
+ <th class="row" title=""> qtsystems   </th>
+ <td>4e3a7ed </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">qttools</th>
- <td>5.9.3</td>
+ <th class="row" title=""> qttools   </th>
+ <td>5.9.3 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">qttranslations</th>
- <td>5.9.3</td>
+ <th class="row" title=""> qttranslations   </th>
+ <td>5.9.3 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">qtvirtualkeyboard</th>
- <td>5.9.3</td>
+ <th class="row" title=""> qtvirtualkeyboard   </th>
+ <td>5.9.3 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">qtwebchannel</th>
- <td>5.9.3</td>
+ <th class="row" title=""> qtwebchannel   </th>
+ <td>5.9.3 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">qtwebkit</th>
- <td>5.9.1</td>
-   <td class="unsupported">&#x2717;</td>
+ <th class="row" title=""> qtwebkit   </th>
+ <td>5.9.1 </td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">qtwebsockets</th>
- <td>5.9.3</td>
+ <th class="row" title=""> qtwebsockets   </th>
+ <td>5.9.3 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">qtwebview</th>
- <td>5.9.3</td>
+ <th class="row" title=""> qtwebview   </th>
+ <td>5.9.3 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">qtwinextras</th>
- <td>5.9.3</td>
+ <th class="row" title=""> qtwinextras   </th>
+ <td>5.9.3 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">qtxlsxwriter</th>
- <td>6895d8ba6c3a&hellip;</td>
+ <th class="row" title=""> qtxlsxwriter   </th>
+ <td>6895d8ba6c3a &hellip;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">qtxmlpatterns</th>
- <td>5.9.3</td>
+ <th class="row" title=""> qtxmlpatterns   </th>
+ <td>5.9.3 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">quazip</th>
- <td>0.7.3</td>
+ <th class="row" title=""> quazip   </th>
+ <td>0.7.3 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">qwt</th>
- <td>6.1.3</td>
+ <th class="row" title=""> qwt   </th>
+ <td>6.1.3 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">qwtplot3d</th>
- <td>0.2.7</td>
+ <th class="row" title=""> qwtplot3d   </th>
+ <td>0.2.7 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">ragel</th>
- <td>6.9</td>
-   <td class="unsupported">&#x2717;</td>
-   <td class="unsupported">&#x2717;</td>
-   <td class="unsupported">&#x2717;</td>
-   <td class="unsupported">&#x2717;</td>
-   <td class="supported">&#x2713;</td>
+ <th class="row" title=""> ragel   </th>
+ <td>6.9 </td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td class="supported">&#x2713;</td>
  </tr>
 
 <tr>
- <th class="row">readline</th>
- <td>6.3</td>
+ <th class="row" title=""> readline   </th>
+ <td>6.3 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">rubberband</th>
- <td>1.8.1</td>
+ <th class="row" title=""> rubberband   </th>
+ <td>1.8.1 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">rucksack</th>
- <td>3.1.0</td>
+ <th class="row" title=""> rucksack   </th>
+ <td>3.1.0 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">sdl</th>
- <td>1.2.15</td>
+ <th class="row" title=""> sdl   </th>
+ <td>1.2.15 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">sdl2</th>
- <td>2.0.7</td>
+ <th class="row" title=""> sdl2   </th>
+ <td>2.0.7 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">sdl2_gfx</th>
- <td>1.0.3</td>
+ <th class="row" title=""> sdl2_gfx   </th>
+ <td>1.0.3 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">sdl2_image</th>
- <td>2.0.1</td>
+ <th class="row" title=""> sdl2_image   </th>
+ <td>2.0.1 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">sdl2_mixer</th>
- <td>2.0.1</td>
+ <th class="row" title=""> sdl2_mixer   </th>
+ <td>2.0.1 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">sdl2_net</th>
- <td>2.0.0</td>
+ <th class="row" title=""> sdl2_net   </th>
+ <td>2.0.0 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">sdl2_ttf</th>
- <td>2.0.14</td>
+ <th class="row" title=""> sdl2_ttf   </th>
+ <td>2.0.14 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">sdl_gfx</th>
- <td>2.0.25</td>
+ <th class="row" title=""> sdl_gfx   </th>
+ <td>2.0.25 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">sdl_image</th>
- <td>1.2.12</td>
+ <th class="row" title=""> sdl_image   </th>
+ <td>1.2.12 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">sdl_mixer</th>
- <td>1.2.12</td>
+ <th class="row" title=""> sdl_mixer   </th>
+ <td>1.2.12 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">sdl_net</th>
- <td>1.2.8</td>
+ <th class="row" title=""> sdl_net   </th>
+ <td>1.2.8 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">sdl_pango</th>
- <td>0.1.2</td>
+ <th class="row" title=""> sdl_pango   </th>
+ <td>0.1.2 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">sdl_rwhttp</th>
- <td>0.2.0</td>
+ <th class="row" title=""> sdl_rwhttp   </th>
+ <td>0.2.0 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">sdl_sound</th>
- <td>1.0.3</td>
+ <th class="row" title=""> sdl_sound   </th>
+ <td>1.0.3 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">sdl_ttf</th>
- <td>2.0.11</td>
+ <th class="row" title=""> sdl_ttf   </th>
+ <td>2.0.11 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">sfml</th>
- <td>2.4.2</td>
+ <th class="row" title=""> sfml   </th>
+ <td>2.4.2 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">smpeg</th>
- <td>0.4.5+cvs200&hellip;</td>
+ <th class="row" title=""> smpeg   </th>
+ <td>0.4.5+cvs200 &hellip;</td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">smpeg2</th>
- <td>2.0.0</td>
+ <th class="row" title=""> smpeg2   </th>
+ <td>2.0.0 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">sox</th>
- <td>14.4.2</td>
+ <th class="row" title=""> sox   </th>
+ <td>14.4.2 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">sparsehash</th>
- <td>2.0.3</td>
+ <th class="row" title=""> sparsehash   </th>
+ <td>2.0.3 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">spatialite</th>
- <td>4.4.0-RC1</td>
+ <th class="row" title=""> spatialite   </th>
+ <td>4.4.0-RC1 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">speex</th>
- <td>1.2rc2</td>
+ <th class="row" title=""> speex   </th>
+ <td>1.2rc2 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">speexdsp</th>
- <td>1.2rc3</td>
+ <th class="row" title=""> speexdsp   </th>
+ <td>1.2rc3 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">sqlcipher</th>
- <td>3.4.1</td>
+ <th class="row" title=""> sqlcipher   </th>
+ <td>3.4.1 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">sqlite</th>
- <td>3210000</td>
+ <th class="row" title=""> sqlite   </th>
+ <td>3210000 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">subversion</th>
- <td>1.9.4</td>
+ <th class="row" title=""> subversion   </th>
+ <td>1.9.4 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">suitesparse</th>
- <td>4.5.6</td>
+ <th class="row" title=""> suitesparse   </th>
+ <td>4.5.6 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">t4k_common</th>
- <td>0.1.1</td>
+ <th class="row" title=""> t4k_common   </th>
+ <td>0.1.1 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">taglib</th>
- <td>1.10</td>
+ <th class="row" title=""> taglib   </th>
+ <td>1.10 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">tcl</th>
- <td>8.6.4</td>
-      <td class="supported">&#x2713;</td>
-      <td class="supported">&#x2713;</td>
-      <td class="supported">&#x2713;</td>
-      <td class="supported">&#x2713;</td>
-   <td class="supported">&#x2713;</td>
+ <th class="row" title=""> tcl   </th>
+ <td>8.6.4 </td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td class="supported">&#x2713;</td>
  </tr>
 
 <tr>
- <th class="row">tclap</th>
- <td>1.2.1</td>
+ <th class="row" title=""> tclap   </th>
+ <td>1.2.1 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">teem</th>
- <td>1.11.0</td>
+ <th class="row" title=""> teem   </th>
+ <td>1.11.0 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">termcap</th>
- <td>1.3.1</td>
+ <th class="row" title=""> termcap   </th>
+ <td>1.3.1 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">theora</th>
- <td>1.1.1</td>
+ <th class="row" title=""> theora   </th>
+ <td>1.1.1 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">tidy-html5</th>
- <td>5.4.0</td>
+ <th class="row" title=""> tidy-html5   </th>
+ <td>5.4.0 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">tiff</th>
- <td>4.0.8</td>
+ <th class="row" title=""> tiff   </th>
+ <td>4.0.8 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">tinyxml</th>
- <td>2.6.2</td>
+ <th class="row" title="*** tinyxml is deprecated - please use tinyxml2 ***"> tinyxml   ** </th>
+ <td>2.6.2 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">tinyxml2</th>
- <td>4.0.1</td>
+ <th class="row" title=""> tinyxml2   </th>
+ <td>4.0.1 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">tre</th>
- <td>0.8.0</td>
+ <th class="row" title=""> tre   </th>
+ <td>0.8.0 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">twolame</th>
- <td>0.3.13</td>
+ <th class="row" title=""> twolame   </th>
+ <td>0.3.13 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">ucl</th>
- <td>1.03</td>
+ <th class="row" title=""> ucl   </th>
+ <td>1.03 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-   <td class="supported">&#x2713;</td>
+    <td class="supported">&#x2713;</td>
  </tr>
 
 <tr>
- <th class="row">unrtf</th>
- <td>0.21.9</td>
+ <th class="row" title=""> unrtf   </th>
+ <td>0.21.9 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">upx</th>
- <td>3.91</td>
+ <th class="row" title=""> upx   </th>
+ <td>3.91 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-   <td class="supported">&#x2713;</td>
+    <td class="supported">&#x2713;</td>
  </tr>
 
 <tr>
- <th class="row">vamp-plugin-sdk</th>
- <td>2.5</td>
+ <th class="row" title=""> vamp-plugin-sdk   </th>
+ <td>2.5 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">vcdimager</th>
- <td>0.7.24</td>
+ <th class="row" title=""> vcdimager   </th>
+ <td>0.7.24 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">vidstab</th>
- <td>0.98b</td>
+ <th class="row" title=""> vidstab   </th>
+ <td>0.98b </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">vigra</th>
- <td>1.9.0</td>
+ <th class="row" title=""> vigra   </th>
+ <td>1.9.0 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-   <td class="unsupported">&#x2717;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">vmime</th>
- <td>eb5d9db</td>
+ <th class="row" title=""> vmime   </th>
+ <td>eb5d9db </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">vo-aacenc</th>
- <td>0.1.3</td>
+ <th class="row" title=""> vo-aacenc   </th>
+ <td>0.1.3 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">vo-amrwbenc</th>
- <td>0.1.3</td>
+ <th class="row" title=""> vo-amrwbenc   </th>
+ <td>0.1.3 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">vorbis</th>
- <td>1.3.5</td>
+ <th class="row" title=""> vorbis   </th>
+ <td>1.3.5 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">vtk</th>
- <td>8.0.0</td>
+ <th class="row" title=""> vtk   </th>
+ <td>8.0.0 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">waf</th>
- <td>1.8.17</td>
-   <td class="unsupported">&#x2717;</td>
-   <td class="unsupported">&#x2717;</td>
-   <td class="unsupported">&#x2717;</td>
-   <td class="unsupported">&#x2717;</td>
-   <td class="supported">&#x2713;</td>
+ <th class="row" title=""> waf   </th>
+ <td>1.8.17 </td>
+     <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+    <td class="supported">&#x2713;</td>
  </tr>
 
 <tr>
- <th class="row">wavpack</th>
- <td>4.75.2</td>
+ <th class="row" title=""> wavpack   </th>
+ <td>4.75.2 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">wget</th>
- <td>1.19.2</td>
+ <th class="row" title=""> wget   </th>
+ <td>1.19.2 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">widl</th>
- <td>5.0.3</td>
+ <th class="row" title=""> widl   </th>
+ <td>5.0.3 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">winpcap</th>
- <td>4_1_3</td>
+ <th class="row" title=""> winpcap   </th>
+ <td>4_1_3 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">wt</th>
- <td>3.3.7</td>
+ <th class="row" title=""> wt   </th>
+ <td>3.3.7 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">wxwidgets</th>
- <td>3.0.2</td>
+ <th class="row" title=""> wxwidgets   </th>
+ <td>3.0.2 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">x264</th>
- <td>20170626-224&hellip;</td>
+ <th class="row" title=""> x264   </th>
+ <td>20170626-224 &hellip;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">x265</th>
- <td>2.4</td>
+ <th class="row" title=""> x265   </th>
+ <td>2.4 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">xapian-core</th>
- <td>1.2.21</td>
+ <th class="row" title=""> xapian-core   </th>
+ <td>1.2.21 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">xerces</th>
- <td>3.1.4</td>
+ <th class="row" title=""> xerces   </th>
+ <td>3.1.4 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">xmlrpc-c</th>
- <td>d4364f4</td>
+ <th class="row" title=""> xmlrpc-c   </th>
+ <td>d4364f4 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">xmlwrapp</th>
- <td>0.7.0</td>
+ <th class="row" title=""> xmlwrapp   </th>
+ <td>0.7.0 </td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
       <td class="supported">&#x2713;</td>
-   <td class="unsupported">&#x2717;</td>
-  <td class="unsupported">&#x2717;</td>
+     <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">xorg-macros</th>
- <td>1.19.0</td>
+ <th class="row" title=""> xorg-macros   </th>
+ <td>1.19.0 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">xvidcore</th>
- <td>1.3.4</td>
+ <th class="row" title=""> xvidcore   </th>
+ <td>1.3.4 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">xxhash</th>
- <td>0.6.1</td>
+ <th class="row" title=""> xxhash   </th>
+ <td>0.6.1 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">xz</th>
- <td>5.2.3</td>
+ <th class="row" title=""> xz   </th>
+ <td>5.2.3 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">yaml-cpp</th>
- <td>0.5.3</td>
+ <th class="row" title=""> yaml-cpp   </th>
+ <td>0.5.3 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">yasm</th>
- <td>1.3.0</td>
+ <th class="row" title=""> yasm   </th>
+ <td>1.3.0 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-   <td class="supported">&#x2713;</td>
+    <td class="supported">&#x2713;</td>
  </tr>
 
 <tr>
- <th class="row">zlib</th>
- <td>1.2.11</td>
+ <th class="row" title=""> zlib   </th>
+ <td>1.2.11 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-   <td class="supported">&#x2713;</td>
+    <td class="supported">&#x2713;</td>
  </tr>
 
 <tr>
- <th class="row">zstd</th>
- <td>1.3.2</td>
+ <th class="row" title=""> zstd   </th>
+ <td>1.3.2 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
- <th class="row">zziplib</th>
- <td>0.13.62</td>
+ <th class="row" title=""> zziplib   </th>
+ <td>0.13.62 </td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
       <td class="supported">&#x2713;</td>
-  <td class="unsupported">&#x2717;</td>
+   <td></td>
  </tr>
 
 <tr>
 <th class="row" colspan="2">
-Total: 443
-<br>(+11 virtual
+Total: 449
+<br>(+5 virtual
 +5 native-only)
 </th>
-<th>437</th>
-<th>357</th>
-<th>423</th>
-<th>357</th>
+<th>436</th>
+<th>356</th>
+<th>422</th>
+<th>356</th>
 <th>26</th>
 </tr>
 </tbody>

--- a/plugins/native/glib2-macports.mk
+++ b/plugins/native/glib2-macports.mk
@@ -11,6 +11,7 @@ $(PKG)_FILE     := glib2-$($(PKG)_VERSION)_0.darwin_16.x86_64.tbz2
 $(PKG)_URL      := https://packages.macports.org/glib2/glib2-$($(PKG)_VERSION)_0.darwin_16.x86_64.tbz2
 $(PKG)_DEPS     :=
 $(PKG)_TARGETS  := $(BUILD)
+$(PKG)_TYPE     := archive
 
 define $(PKG)_UPDATE
     echo 'manually update glib2-macports as necessary' >&2;

--- a/src/autotools.mk
+++ b/src/autotools.mk
@@ -6,3 +6,4 @@ $(PKG)_DESCR    := Dependency package to ensure the autotools work
 $(PKG)_VERSION  := 1
 $(PKG)_DEPS     := libtool pkgconf
 $(PKG)_TARGETS  := $(BUILD)
+$(PKG)_TYPE     := meta

--- a/src/googlemock.mk
+++ b/src/googlemock.mk
@@ -9,3 +9,4 @@ $(PKG)_CHECKSUM := 3f20b6acb37e5a98e8c4518165711e3e35d47deb6cdb5a4dd4566563b5efd
 $(PKG)_GH_CONF  := google/googlemock/tags, release-
 $(PKG)_DEPS     :=
 $(PKG)_TARGETS  := $(BUILD) $(MXE_TARGETS)
+$(PKG)_TYPE     := archive

--- a/src/googletest.mk
+++ b/src/googletest.mk
@@ -9,3 +9,4 @@ $(PKG)_CHECKSUM := f73a6546fdf9fce9ff93a5015e0333a8af3062a152a9ad6bcb772c9668701
 $(PKG)_GH_CONF  := google/googletest/tags, release-
 $(PKG)_DEPS     :=
 $(PKG)_TARGETS  := $(BUILD) $(MXE_TARGETS)
+$(PKG)_TYPE     := archive

--- a/src/mingw-w64.mk
+++ b/src/mingw-w64.mk
@@ -9,6 +9,7 @@ $(PKG)_CHECKSUM := 2a601db99ef579b9be69c775218ad956a24a09d7dabc9ff6c5bd60da9ccc9
 $(PKG)_SUBDIR   := $(PKG)-v$($(PKG)_VERSION)
 $(PKG)_FILE     := $(PKG)-v$($(PKG)_VERSION).tar.bz2
 $(PKG)_URL      := https://$(SOURCEFORGE_MIRROR)/project/$(PKG)/$(PKG)/$(PKG)-release/$($(PKG)_FILE)
+$(PKG)_TYPE     := archive
 $(PKG)_DEPS     :=
 
 define $(PKG)_UPDATE

--- a/src/qt5.mk
+++ b/src/qt5.mk
@@ -4,6 +4,7 @@ PKG             := qt5
 $(PKG)_WEBSITE  := https://www.qt.io/
 $(PKG)_DESCR    := Qt
 $(PKG)_VERSION   = $(qtbase_VERSION)
+$(PKG)_TYPE     := meta
 $(PKG)_DEPS     := $(subst qt5, qtbase, \
                       $(patsubst $(dir $(lastword $(MAKEFILE_LIST)))/%.mk,%,\
                           $(shell grep -l 'qtbase_VERSION' \


### PR DESCRIPTION
  - add metadata to distinguish virtual package types
  - improve build order and status messages for empty packages
        print pkg type or `disabled` instead of `no-build`
  - add BUILD_DRY_RUN option and fixup make -t
  - update build-matrix rule to identify virtual pkgs
