### PR TITLE
Add meson-wrapper plugin

### DIFF
--- a/plugins/meson-wrapper/conf/mxe-crossfile.meson.in
+++ b/plugins/meson-wrapper/conf/mxe-crossfile.meson.in
@@ -1,0 +1,23 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+[binaries]
+c = '@PREFIX@/bin/@TARGET@-gcc'
+cpp = '@PREFIX@/bin/@TARGET@-g++'
+ar = '@PREFIX@/bin/@TARGET@-ar'
+ranlib = '@PREFIX@/bin/@TARGET@-ranlib'
+ld = '@PREFIX@/bin/@TARGET@-ld'
+strip = '@PREFIX@/bin/@TARGET@-strip'
+windres = '@PREFIX@/bin/@TARGET@-windres'
+windmc = '@PREFIX@/bin/@TARGET@-windmc'
+pkgconfig = '@PREFIX@/bin/@TARGET@-pkg-config'
+# MXE forbids this
+# exe_wrapper = 'wine'
+
+[properties]
+needs_exe_wrapper = true
+
+[host_machine]
+system = 'windows'
+cpu_family = '@CPU_FAMILY@'
+cpu = '@CPU@'
+endian = 'little'

--- a/plugins/meson-wrapper/conf/target-meson.in
+++ b/plugins/meson-wrapper/conf/target-meson.in
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+echo "== Using MXE wrapper: @PREFIX@/bin/@TARGET@-meson"
+
+unset NO_MESON_CROSSFILE
+if echo -- "$@" | grep -Ewq "configure"; then
+    NO_MESON_CROSSFILE=1
+fi
+
+if [[ "$NO_MESON_CROSSFILE" == "1" ]]; then
+    echo "== Skip using Meson cross file: @MESON_CROSS_FILE@"
+    exec meson "$@"
+else
+    echo "== Using Meson cross file: @MESON_CROSS_FILE@"
+    exec meson \
+              --cross-file "@MESON_CROSS_FILE@" \
+              --default-library "@LIBTYPE@" \
+              --prefix "@PREFIX@/@TARGET@" \
+              "$@"
+fi

--- a/plugins/meson-wrapper/meson-wrapper.mk
+++ b/plugins/meson-wrapper/meson-wrapper.mk
@@ -1,0 +1,36 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+PKG            := meson-wrapper
+$(PKG)_VERSION := 1
+$(PKG)_UPDATE  := echo 1
+$(PKG)_TARGETS := $(MXE_TARGETS)
+$(PKG)_FILE_DEPS := $(wildcard $(PWD)/plugins/meson-wrapper/conf/*)
+
+define $(PKG)_BUILD
+    # create the Meson cross file
+    mkdir -p '$(PREFIX)/$(TARGET)/share/meson/mxe-conf.d'
+    cmake-configure-file \
+        -DLIBTYPE=$(if $(BUILD_SHARED),shared,static) \
+        -DPREFIX=$(PREFIX) \
+        -DTARGET=$(TARGET) \
+        -DBUILD=$(BUILD) \
+        -DCPU_FAMILY=$(strip \
+             $(if $(findstring x86_64,$(TARGET)),x86_64,\
+             $(if $(findstring i686,$(TARGET)),x86))) \
+        -DCPU=$(strip \
+             $(if $(findstring x86_64,$(TARGET)),x86_64,\
+             $(if $(findstring i686,$(TARGET)),i686))) \
+        -DINPUT='$(PWD)/plugins/meson-wrapper/conf/mxe-crossfile.meson.in' \
+        -DOUTPUT='$(PREFIX)/$(TARGET)/share/meson/mxe-crossfile.meson'
+
+    # create the prefixed Meson wrapper script
+    cmake-configure-file \
+        -DLIBTYPE=$(if $(BUILD_SHARED),shared,static) \
+        -DPREFIX=$(PREFIX) \
+        -DTARGET=$(TARGET) \
+        -DBUILD=$(BUILD) \
+        -DMESON_CROSS_FILE='$(PREFIX)/$(TARGET)/share/meson/mxe-crossfile.meson' \
+        -DINPUT='$(PWD)/plugins/meson-wrapper/conf/target-meson.in' \
+        -DOUTPUT='$(PREFIX)/bin/$(TARGET)-meson'
+    chmod 0755 '$(PREFIX)/bin/$(TARGET)-meson'
+endef


### PR DESCRIPTION
This plugin adds a "meson-wrapper" package, which installs Meson cross files and wrapper scripts for each target, similar to "cmake-conf". This allows Meson projects to seamlessly integrate with MXE.

The wrapper scripts require Meson to be installed on the host system.

Example usage:

```sh
x86_64-w64-mingw32.static-meson sourcedir destdir
# you can now use 'meson configure', 'ninja', etc. in destdir as normal
```
