### PR TITLE
[plugin] Meson build system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,7 @@ TIMESTAMP  := $(shell date +%Y%m%d_%H%M%S)
 PKG_DIR    := $(PWD)/pkg
 TMP_DIR     = $(MXE_TMP)/tmp-$(1)
 BUILD      := $(shell '$(EXT_DIR)/config.guess')
+ORIG_PATH  := $(call merge,:,$(filter-out $(PREFIX)/$(BUILD)/bin $(PREFIX)/bin,$(call split,:,$(PATH))))
 PATH       := $(PREFIX)/$(BUILD)/bin:$(PREFIX)/bin:$(shell echo $$PATH | $(SED) -e 's,:\.$$,,' -e 's,\.:,,g')
 
 # set to empty or $(false) to disable stripping

--- a/plugins/meson/conf/mxe-crossfile.meson.in
+++ b/plugins/meson/conf/mxe-crossfile.meson.in
@@ -1,0 +1,23 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+[binaries]
+c = '@PREFIX@/bin/@TARGET@-gcc'
+cpp = '@PREFIX@/bin/@TARGET@-g++'
+ar = '@PREFIX@/bin/@TARGET@-ar'
+ranlib = '@PREFIX@/bin/@TARGET@-ranlib'
+ld = '@PREFIX@/bin/@TARGET@-ld'
+strip = '@PREFIX@/bin/@TARGET@-strip'
+windres = '@PREFIX@/bin/@TARGET@-windres'
+windmc = '@PREFIX@/bin/@TARGET@-windmc'
+pkgconfig = '@PREFIX@/bin/@TARGET@-pkg-config'
+# MXE forbids this
+# exe_wrapper = 'wine'
+
+[properties]
+needs_exe_wrapper = true
+
+[host_machine]
+system = 'windows'
+cpu_family = '@CPU_FAMILY@'
+cpu = '@CPU@'
+endian = 'little'

--- a/plugins/meson/conf/target-meson.in
+++ b/plugins/meson/conf/target-meson.in
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+echo "== Using MXE wrapper: @PREFIX@/bin/@TARGET@-meson"
+
+export PATH="@PATH@:$PATH"
+
+unset NO_MESON_CROSSFILE
+if echo -- "$@" | grep -Ewq "configure"; then
+    NO_MESON_CROSSFILE=1
+fi
+
+if [[ "$NO_MESON_CROSSFILE" == "1" ]]; then
+    echo "== Skip using Meson cross file: @MESON_CROSS_FILE@"
+    exec "@PREFIX@/@BUILD@/bin/meson" "$@"
+else
+    echo "== Using Meson cross file: @MESON_CROSS_FILE@"
+    exec "@PREFIX@/@BUILD@/bin/meson" \
+              --cross-file "@MESON_CROSS_FILE@" \
+              --default-library "@LIBTYPE@" \
+              --prefix "@PREFIX@/@TARGET@" \
+              "$@"
+fi

--- a/plugins/meson/meson-1-fixes.patch
+++ b/plugins/meson/meson-1-fixes.patch
@@ -1,0 +1,33 @@
+This file is part of MXE. See LICENSE.md for licensing information.
+
+Contains ad hoc patches for cross building.
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Andrei Alexeyev <0x416b617269@gmail.com>
+Date: Wed, 29 Nov 2017 20:36:44 +0200
+Subject: [PATCH 1/1] Use only distutils for consistency
+
+
+diff --git a/setup.py b/setup.py
+index 1111111..2222222 100644
+--- a/setup.py
++++ b/setup.py
+@@ -23,15 +23,9 @@ if sys.version_info[0] < 3:
+     print('Tried to install with Python 2, Meson only supports Python 3.')
+     sys.exit(1)
+ 
+-# We need to support Python installations that have nothing but the basic
+-# Python installation. Use setuptools when possible and fall back to
+-# plain distutils when setuptools is not available.
+-try:
+-    from setuptools import setup
+-    from setuptools.command.install_scripts import install_scripts as orig
+-except ImportError:
+-    from distutils.core import setup
+-    from distutils.command.install_scripts import install_scripts as orig
++# Use only distutils for consistency
++from distutils.core import setup
++from distutils.command.install_scripts import install_scripts as orig
+ 
+ class install_scripts(orig):
+     def run(self):

--- a/plugins/meson/meson.mk
+++ b/plugins/meson/meson.mk
@@ -46,7 +46,26 @@ endef
 
 define $(PKG)_BUILD_$(BUILD)
     cd '$(SOURCE_DIR)' && python3 setup.py install \
-        --prefix='$(PREFIX)/$(TARGET)' && \
-    $(SED) -i 's,^#!/usr/bin/python3,#!/usr/bin/env python3,' \
-        '$(PREFIX)/$(TARGET)/bin/meson'
+        --prefix='$(PREFIX)/$(TARGET)'
+
+    # Awful hacks: we must hijack the python entry points here to install our
+    # site-packages path. This is because Meson is going to put the path to the
+    # real python interpreter and script it's been invoked with into the build
+    # rules file, bypassing any of our shell wrappers. This causes automatic
+    # reconfiguration to fail.
+
+    for prog in meson{,conf,introspect,test} wraptool; do \
+        $(SED) '1d' '$(PREFIX)/$(TARGET)'/bin/$${prog} > '$(1)'/$${prog}.tail; \
+        echo "#!/usr/bin/env python3" > '$(PREFIX)/$(TARGET)'/bin/$${prog}; \
+        echo "__mxe_python_path = r'''" >> '$(PREFIX)/$(TARGET)'/bin/$${prog}; \
+        echo '$(PREFIX)/$(TARGET)/lib/python$(PY3_XY_VER)/site-packages' >> '$(PREFIX)/$(TARGET)'/bin/$${prog}; \
+        echo "'''[1:-1]" >> '$(PREFIX)/$(TARGET)'/bin/$${prog}; \
+        echo 'import sys; sys.path.insert(1, __mxe_python_path)' >> '$(PREFIX)/$(TARGET)'/bin/$${prog}; \
+        echo "__mxe_path = r'''" >> '$(PREFIX)/$(TARGET)'/bin/$${prog}; \
+        echo '$(PREFIX)/$(BUILD)/bin:$(PREFIX)/bin' >> '$(PREFIX)/$(TARGET)'/bin/$${prog}; \
+        echo "'''[1:-1]" >> '$(PREFIX)/$(TARGET)'/bin/$${prog}; \
+        echo 'import os; os.environ["PATH"] = "{0}:{1}".format(__mxe_path, os.environ["PATH"])' >> '$(PREFIX)/$(TARGET)'/bin/$${prog}; \
+        cat '$(1)'/$${prog}.tail >> '$(PREFIX)/$(TARGET)'/bin/$${prog}; \
+        cat '$(PREFIX)/$(TARGET)'/bin/$${prog}; \
+    done
 endef

--- a/plugins/meson/meson.mk
+++ b/plugins/meson/meson.mk
@@ -1,0 +1,52 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+PKG              := meson
+$(PKG)_WEBSITE   := https://mesonbuild.com/
+$(PKG)_DESCR     := An open source build system meant to be extremely fast and as user friendly as possible.
+$(PKG)_IGNORE    :=
+$(PKG)_VERSION   := 0.43.0
+$(PKG)_CHECKSUM  := 324894427dcd29f6156fe06b046c6ad1b998470714debd7c5705902f21aaaa73
+$(PKG)_GH_CONF   := mesonbuild/meson/releases/latest
+$(PKG)_SUBDIR    := $(PKG)-$($(PKG)_VERSION)
+$(PKG)_FILE      := $($(PKG)_SUBDIR).tar.gz
+$(PKG)_URL       := https://github.com/mesonbuild/meson/archive/$($(PKG)_VERSION).tar.gz
+$(PKG)_FILE_DEPS := $(wildcard $(PWD)/plugins/meson/conf/*)
+$(PKG)_DEPS      := python3-conf ninja
+$(PKG)_TARGETS   := $(BUILD) $(MXE_TARGETS)
+
+define $(PKG)_BUILD
+    # create the Meson cross file
+    mkdir -p '$(PREFIX)/$(TARGET)/share/meson'
+    cmake-configure-file \
+        -DLIBTYPE=$(if $(BUILD_SHARED),shared,static) \
+        -DPREFIX=$(PREFIX) \
+        -DTARGET=$(TARGET) \
+        -DBUILD=$(BUILD) \
+        -DCPU_FAMILY=$(strip \
+             $(if $(findstring x86_64,$(TARGET)),x86_64,\
+             $(if $(findstring i686,$(TARGET)),x86))) \
+        -DCPU=$(strip \
+             $(if $(findstring x86_64,$(TARGET)),x86_64,\
+             $(if $(findstring i686,$(TARGET)),i686))) \
+        -DINPUT='$(PWD)/plugins/meson/conf/mxe-crossfile.meson.in' \
+        -DOUTPUT='$(PREFIX)/$(TARGET)/share/meson/mxe-crossfile.meson'
+
+    # create the prefixed Meson wrapper script
+    cmake-configure-file \
+        -DPATH='$(PREFIX)/$(BUILD)/bin:$(PREFIX)/bin' \
+        -DLIBTYPE=$(if $(BUILD_SHARED),shared,static) \
+        -DPREFIX=$(PREFIX) \
+        -DTARGET=$(TARGET) \
+        -DBUILD=$(BUILD) \
+        -DMESON_CROSS_FILE='$(PREFIX)/$(TARGET)/share/meson/mxe-crossfile.meson' \
+        -DINPUT='$(PWD)/plugins/meson/conf/target-meson.in' \
+        -DOUTPUT='$(PREFIX)/bin/$(TARGET)-meson'
+    chmod 0755 '$(PREFIX)/bin/$(TARGET)-meson'
+endef
+
+define $(PKG)_BUILD_$(BUILD)
+    cd '$(SOURCE_DIR)' && python3 setup.py install \
+        --prefix='$(PREFIX)/$(TARGET)' && \
+    $(SED) -i 's,^#!/usr/bin/python3,#!/usr/bin/env python3,' \
+        '$(PREFIX)/$(TARGET)/bin/meson'
+endef

--- a/plugins/meson/ninja.mk
+++ b/plugins/meson/ninja.mk
@@ -1,0 +1,24 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+PKG             := ninja
+$(PKG)_WEBSITE  := https://ninja-build.org/
+$(PKG)_DESCR    := A small build system with a focus on speed
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 1.8.2
+$(PKG)_CHECKSUM := 86b8700c3d0880c2b44c2ff67ce42774aaf8c28cbf57725cb881569288c1c6f4
+$(PKG)_GH_CONF  := ninja-build/ninja/releases/latest,v
+$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
+$(PKG)_FILE     := $($(PKG)_SUBDIR).tar.gz
+$(PKG)_URL      := https://github.com/ninja-build/ninja/archive/v$($(PKG)_VERSION).tar.gz
+$(PKG)_DEPS     :=
+$(PKG)_TARGETS  := $(BUILD) $(MXE_TARGETS)
+
+define $(PKG)_BUILD
+    ln -sf '$(PREFIX)/$(BUILD)/bin/ninja' '$(PREFIX)/bin/$(TARGET)-ninja'
+endef
+
+define $(PKG)_BUILD_$(BUILD)
+    cd '$(SOURCE_DIR)' && python2 ./configure.py --bootstrap \
+        --with-python="`which python2`" && \
+    $(INSTALL) -m755 -D ninja "$(PREFIX)/$(TARGET)/bin/ninja"
+endef

--- a/src/python3-conf.mk
+++ b/src/python3-conf.mk
@@ -1,0 +1,24 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+PKG            := python3-conf
+$(PKG)_VERSION := 1
+$(PKG)_UPDATE  := echo 1
+$(PKG)_TARGETS := $(BUILD) $(MXE_TARGETS)
+SYS_PYTHON3    := $(shell PATH="$(ORIG_PATH)" which python3)
+PY3_XY_VER     := $(shell $(SYS_PYTHON3) -c "import sys; print('{0[0]}.{0[1]}'.format(sys.version_info))")
+
+define $(PKG)_BUILD
+    ln -sf '$(PREFIX)/$(BUILD)/bin/python3' '$(PREFIX)/bin/$(TARGET)-python3'
+endef
+
+define $(PKG)_BUILD_$(BUILD)
+    #create python3 wrapper in a directory which is in PATH
+    echo $(SYS_PYTHON3)
+    (echo '#!/bin/sh'; \
+     echo 'PYTHONPATH="$(PREFIX)/$(TARGET)/lib/python$(PY3_XY_VER)/site-packages" \
+           exec $(SYS_PYTHON3) "$$@"';) \
+             > '$(PREFIX)/$(TARGET)/bin/python3'
+    chmod 0755 '$(PREFIX)/$(TARGET)/bin/python3'
+
+    mkdir -p "$(PREFIX)/$(TARGET)/lib/python$(PY3_XY_VER)/site-packages"
+endef


### PR DESCRIPTION
This plugin adds support for the Meson build system (as well as Ninja, Meson's default backend). Cross files and wrappers are installed for each target, similar to `cmake-conf`. This allows Meson projects to seamlessly integrate with MXE.

Example usage:

```sh
make MXE_PLUGIN_DIRS=plugins/meson MXE_TARGETS=x86_64-w64-mingw32.static meson
cd $destdir
x86_64-w64-mingw32.static-meson $sourcedir
x86_64-w64-mingw32.static-meson configure -Dfoo=bar
x86_64-w64-mingw32.static-ninja
```

The host's `meson` and `ninja` executables can also be used after the initial configuration step, given their versions are compatible.

Python 3.4 or later is required to be installed on the host system. A `python3-conf` package, based on @tonytheodore's [`python-conf`](https://github.com/tonytheodore/mxe/commit/3ee5c108c8fb206f6e66ae29fa4d24d2171769fd), has been added to `src` to make this work.

This PR supersedes #1995.