### PR TITLE
hyperscan: fix build where native SSSE3 detection fails

### DIFF
--- a/src/hyperscan.mk
+++ b/src/hyperscan.mk
@@ -10,12 +10,22 @@ $(PKG)_GH_CONF  := 01org/hyperscan/tags, v
 $(PKG)_DEPS     := gcc boost
 # $(PKG)_NATIVE_DEPS := ragel
 
+# Add the following options to run on (virtual) machine without AVX2 or
+# build on machine where native detection of SSSE3 may fail
+# -DCMAKE_C_FLAGS="-march=core2" -DCMAKE_CXX_FLAGS="-march=core2"
+
+$(PKG)_ARCH_FLAGS = \
+    $(TARGET)-gcc -xc /dev/null -o- -S -fverbose-asm \
+        -march=native | \
+        grep mssse3 >/dev/null 2>&1 || \
+        echo -march=core2
+
 define $(PKG)_BUILD
-    # Add the following options to run on (virtual) machine without AVX2
-    # -DCMAKE_C_FLAGS="-march=core2" -DCMAKE_CXX_FLAGS="-march=core2"
     cd '$(BUILD_DIR)' && $(TARGET)-cmake \
         -DRAGEL='$(PREFIX)/$(BUILD)/bin/ragel' \
         -DMXE_DISABLE_INCLUDE_SYSTEM_FLAG=TRUE \
+        -DCMAKE_C_FLAGS="`$($(PKG)_ARCH_FLAGS)`" \
+        -DCMAKE_CXX_FLAGS="`$($(PKG)_ARCH_FLAGS)`" \
         '$(SOURCE_DIR)'
     $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)'
     $(MAKE) -C '$(BUILD_DIR)' -j 1 install


### PR DESCRIPTION
closes #1997
