### PR TITLE
Add plugin freetype-no-harfbuzz

### DIFF
--- a/plugins/freetype-no-harfbuzz/freetype-bootstrap.mk
+++ b/plugins/freetype-no-harfbuzz/freetype-bootstrap.mk
@@ -1,0 +1,5 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+PKG            := freetype-bootstrap
+$(PKG)_DEPS    := freetype
+$(PKG)_BUILD   :=

--- a/plugins/freetype-no-harfbuzz/freetype.mk
+++ b/plugins/freetype-no-harfbuzz/freetype.mk
@@ -1,0 +1,19 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+PKG             := freetype
+$(PKG)_DEPS     := gcc bzip2 libpng zlib
+
+define $(PKG)_BUILD_COMMON
+    cd '$(1)' && GNUMAKE=$(MAKE) ./configure --with-harfbuzz=no \
+        $(MXE_CONFIGURE_OPTS) \
+        LIBPNG_CFLAGS="`$(TARGET)-pkg-config libpng --cflags`" \
+        LIBPNG_LDFLAGS="`$(TARGET)-pkg-config libpng --libs`" \
+        FT2_EXTRA_LIBS="`$(TARGET)-pkg-config libpng --libs`"
+    $(MAKE) -C '$(1)' -j '$(JOBS)'
+    $(MAKE) -C '$(1)' -j 1 install
+    ln -sf '$(PREFIX)/$(TARGET)/bin/freetype-config' '$(PREFIX)/bin/$(TARGET)-freetype-config'
+endef
+
+define $(PKG)_BUILD
+    $($(PKG)_BUILD_COMMON)
+endef


### PR DESCRIPTION
This plugin modifies the `freetype` package to build without `harfbuzz` support. `harfbuzz` pulls in a lot of dependencies itself, which may be undesirable for some projects. Since there is no circular dependency in this case, `freetype-bootstrap` becomes a dummy no-op package that just depends on `freetype`.