### PR TITLE
winpcap: Fix installation of header files

### DIFF
--- a/src/winpcap.mk
+++ b/src/winpcap.mk
@@ -22,8 +22,6 @@ define $(PKG)_BUILD
     cd '$(1)' && $(TARGET)-gcc -ICommon -IpacketNtx/Dll -O -c '$(1)/packetNtx/Dll/Packet32.c'
     $(TARGET)-ar rc '$(1)/libpacket.a' '$(1)/Packet32.o'
     $(TARGET)-ranlib '$(1)/libpacket.a'
-    $(INSTALL) -d '$(PREFIX)/$(TARGET)/include'
-    $(INSTALL) -m644 '$(1)/Common'/*.h '$(PREFIX)/$(TARGET)/include/'
     $(INSTALL) -d '$(PREFIX)/$(TARGET)/lib'
     $(INSTALL) -m644 '$(1)/libpacket.a' '$(PREFIX)/$(TARGET)/lib/'
 
@@ -34,7 +32,31 @@ define $(PKG)_BUILD
     AR='$(TARGET)-ar' \
     RANLIB='$(TARGET)-ranlib' \
     $(MAKE) -C '$(1)/wpcap/PRJ' -j 1 libwpcap.a
-    $(INSTALL) -m644 '$(1)/wpcap/libpcap/'*.h '$(1)/wpcap/Win32-Extensions/'*.h '$(PREFIX)/$(TARGET)/include/'
+
+    $(INSTALL) -d '$(PREFIX)/$(TARGET)/include'
+    $(INSTALL) -m644 \
+         $(1)/wpcap/libpcap/Win32/Include/IP6_misc.h \
+         $(1)/wpcap/libpcap/pcap-namedb.h \
+         $(1)/wpcap/libpcap/pcap-bpf.h \
+         $(1)/wpcap/libpcap/remote-ext.h \
+         $(1)/Common/Packet32.h \
+         $(1)/wpcap/Win32-Extensions/Win32-Extensions.h \
+         $(1)/wpcap/libpcap/Win32/Include/bittypes.h \
+         $(1)/wpcap/libpcap/pcap-stdinc.h \
+         $(1)/wpcap/libpcap/pcap.h \
+        '$(PREFIX)/$(TARGET)/include/'
+
+    $(INSTALL) -d '$(PREFIX)/$(TARGET)/include/pcap'
+    $(INSTALL) -m644 \
+        $(1)/wpcap/libpcap/pcap/namedb.h \
+        $(1)/wpcap/libpcap/pcap/sll.h \
+        $(1)/wpcap/libpcap/pcap/bpf.h \
+        $(1)/wpcap/libpcap/pcap/usb.h \
+        $(1)/wpcap/libpcap/pcap/pcap.h \
+        $(1)/wpcap/libpcap/pcap/bluetooth.h \
+        $(1)/wpcap/libpcap/pcap/vlan.h \
+        '$(PREFIX)/$(TARGET)/include/pcap/'
+
     $(INSTALL) -m644 '$(1)/wpcap/PRJ/libwpcap.a' '$(PREFIX)/$(TARGET)/lib/'
 endef
 

--- a/src/winpcap.mk
+++ b/src/winpcap.mk
@@ -20,7 +20,9 @@ endef
 define $(PKG)_BUILD
     # build
     cd '$(1)' && $(TARGET)-gcc -ICommon -IpacketNtx/Dll -O -c '$(1)/packetNtx/Dll/Packet32.c'
-    $(TARGET)-ar rc '$(1)/libpacket.a' '$(1)/Packet32.o'
+    cd '$(1)' && $(TARGET)-gcc -ICommon -IpacketNtx/Dll -O -c '$(1)/packetNtx/Dll/AdInfo.c'
+    cd '$(1)' && $(TARGET)-gcc -ICommon -IpacketNtx/Dll -O -c '$(1)/packetNtx/Dll/NpfImExt.c'
+    $(TARGET)-ar rc '$(1)/libpacket.a' '$(1)/Packet32.o' '$(1)/AdInfo.o' '$(1)/NpfImExt.o'
     $(TARGET)-ranlib '$(1)/libpacket.a'
     $(INSTALL) -d '$(PREFIX)/$(TARGET)/lib'
     $(INSTALL) -m644 '$(1)/libpacket.a' '$(PREFIX)/$(TARGET)/lib/'


### PR DESCRIPTION
Not all files mentioned in create_include.bat were installed. This caused build errors in basically all programs which were using winpcap.

Fixes #1389
Fixes #2004