### PR TITLE
qtbase: add Qt's angle backend

### DIFF
--- a/src/mesa-1-fixes.patch
+++ b/src/mesa-1-fixes.patch
@@ -1,0 +1,25 @@
+This file is part of MXE. See LICENSE.md for licensing information.
+
+Contains ad hoc patches for cross building.
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Robert Manner <robert.manner@balabit.com>
+Date: Fri, 15 Dec 2017 16:40:18 +0100
+Subject: [PATCH] scons/crossmingw.py: compiler prefix can be customized
+ through environment
+
+
+diff --git a/scons/crossmingw.py b/scons/crossmingw.py
+index 1111111..2222222 100644
+--- a/scons/crossmingw.py
++++ b/scons/crossmingw.py
+@@ -51,6 +51,9 @@ prefixes64 = SCons.Util.Split("""
+ """)
+ 
+ def find(env):
++    if os.environ['MINGW_PREFIX']:
++        return os.environ['MINGW_PREFIX']
++
+     if env['machine'] == 'x86_64':
+         prefixes = prefixes64
+     else:

--- a/src/mesa.mk
+++ b/src/mesa.mk
@@ -1,0 +1,13 @@
+PKG             := mesa
+$(PKG)_VERSION  := 17.3.0
+$(PKG)_CHECKSUM := 29a0a3a6c39990d491a1a58ed5c692e596b3bfc6c01d0b45e0b787116c50c6d9
+$(PKG)_SUBDIR   := mesa-$($(PKG)_VERSION)
+$(PKG)_FILE     := mesa-$($(PKG)_VERSION).tar.xz
+$(PKG)_URL      := ftp://ftp.freedesktop.org/pub/mesa/$($(PKG)_FILE)
+$(PKG)_DEPS     := gcc
+
+define $(PKG)_BUILD
+    cd '$(1)' && \
+    MINGW_PREFIX='$(TARGET)-' scons platform=windows toolchain=crossmingw machine=x86_64 verbose=1 build=release libgl-gdi
+    $(INSTALL) -m 755 '$(1)/build/windows-x86_64/gallium/targets/libgl-gdi/opengl32.dll' '$(PREFIX)/$(TARGET)/bin/'
+endef

--- a/src/qtbase-1-fixes.patch
+++ b/src/qtbase-1-fixes.patch
@@ -5,7 +5,7 @@ Contains ad hoc patches for cross building.
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Wed, 26 Aug 2015 12:45:43 +0100
-Subject: [PATCH 1/7] cmake: Rearrange STATIC vs INTERFACE targets
+Subject: [PATCH 1/8] cmake: Rearrange STATIC vs INTERFACE targets
 
 Otherwise we attempt to add_library(Qt5::UiPlugin STATIC IMPORTED)
 for header-only modules when building Qt5 statically.
@@ -37,7 +37,7 @@ index 55c74aad..d7bcffeb 100644
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tony Theodore <tonyt@logyst.com>
 Date: Sat, 16 Jul 2016 20:31:07 +1000
-Subject: [PATCH 2/7] Fix pkgconfig file and library naming
+Subject: [PATCH 2/8] Fix pkgconfig file and library naming
 
 See: https://codereview.qt-project.org/#/c/165394/
      https://bugreports.qt.io/browse/QTBUG-30898
@@ -103,7 +103,7 @@ index c0a8dcc2..d5e24ac1 100644
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mark Brand <mabrand@mabrand.nl>
 Date: Sun, 29 Jan 2017 13:02:16 +0100
-Subject: [PATCH 3/7] reenable fontconfig for win32 (MXE-specific)
+Subject: [PATCH 3/8] reenable fontconfig for win32 (MXE-specific)
 
 Change-Id: I05b036366bd402e43309742412bcf8ca91fe125f
 
@@ -140,7 +140,7 @@ index ca33689c..194523ee 100644
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mark Brand <mabrand@mabrand.nl>
 Date: Sun, 29 Jan 2017 16:22:03 +0100
-Subject: [PATCH 4/7] fix treatment of SYBASE_LIBS
+Subject: [PATCH 4/8] fix treatment of SYBASE_LIBS
 
 Change-Id: I4c9914cf7ef9d91feb0718a57f2551c1eeed47e0
 
@@ -161,7 +161,7 @@ index b69b51b6..d37423ad 100644
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mark Brand <mabrand@mabrand.nl>
 Date: Sun, 11 Jun 2017 00:27:41 +0200
-Subject: [PATCH 5/7] use pkg-config for harfbuzz
+Subject: [PATCH 5/8] use pkg-config for harfbuzz
 
 Change-Id: Ia65cbb90fd180f1bc10ce077a9a8323a48e51421
 
@@ -183,7 +183,7 @@ index 4791b345..5f606217 100644
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mark Brand <mabrand@mabrand.nl>
 Date: Sat, 7 Oct 2017 11:39:29 +0200
-Subject: [PATCH 6/7] Revert "qmake: don't limit command line length when not
+Subject: [PATCH 6/8] Revert "qmake: don't limit command line length when not
  actually on windows"
 
 This breaks cross compiling for mingw.
@@ -225,7 +225,7 @@ index 792ffb19..33002326 100644
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tony Theodore <tonyt@logyst.com>
 Date: Wed, 20 Dec 2017 12:08:48 +1100
-Subject: [PATCH 7/7] qtbase: add workaround for internal compiler error
+Subject: [PATCH 7/8] qtbase: add workaround for internal compiler error
 
 taken from:
 https://codereview.qt-project.org/#/c/212360/
@@ -243,3 +243,162 @@ index 67691903..c1a775a5 100644
  static qsizetype qt_random_cpu(void *buffer, qsizetype count) Q_DECL_NOTHROW;
  
  #  ifdef Q_PROCESSOR_X86_64
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Robert Manner <robert.manner@balabit.com>
+Date: Tue, 12 Dec 2017 15:57:37 +0100
+Subject: [PATCH 8/8] angle: added crosscompile support
+
+
+diff --git a/config.tests/win/angle_d3d11_qdtd/angle_d3d11_qdtd.cpp b/config.tests/win/angle_d3d11_qdtd/angle_d3d11_qdtd.cpp
+index 2dde2914..da41a9b6 100644
+--- a/config.tests/win/angle_d3d11_qdtd/angle_d3d11_qdtd.cpp
++++ b/config.tests/win/angle_d3d11_qdtd/angle_d3d11_qdtd.cpp
+@@ -37,7 +37,7 @@
+ **
+ ****************************************************************************/
+ 
+-#include <D3D11.h>
++#include <d3d11.h>
+ 
+ int main(int, char**)
+ {
+diff --git a/mkspecs/features/qt_module.prf b/mkspecs/features/qt_module.prf
+index d5e24ac1..99f6ec2b 100644
+--- a/mkspecs/features/qt_module.prf
++++ b/mkspecs/features/qt_module.prf
+@@ -278,7 +278,7 @@ TARGET = $$qt5LibraryTarget($$TARGET$$QT_LIBINFIX)
+     else: \
+         QMAKE_PKGCONFIG_LIBDIR = $$[QT_INSTALL_LIBS/raw]
+     QMAKE_PKGCONFIG_INCDIR = $$[QT_INSTALL_HEADERS/raw]
+-    QMAKE_PKGCONFIG_CFLAGS = -I${includedir}/$$MODULE_INCNAME
++    QMAKE_PKGCONFIG_CFLAGS = -I${includedir}/$$MODULE_INCNAME -I${includedir}/QtANGLE
+     QMAKE_PKGCONFIG_NAME = $$replace(TARGET, ^Qt$$QT_MAJOR_VERSION, "Qt$$QT_MAJOR_VERSION ")
+     QMAKE_PKGCONFIG_FILE = $$TARGET
+     for(i, MODULE_DEPENDS): \
+diff --git a/src/3rdparty/angle/src/compiler/translator/glslang.l b/src/3rdparty/angle/src/compiler/translator/glslang.l
+index d09358dd..258d5403 100644
+--- a/src/3rdparty/angle/src/compiler/translator/glslang.l
++++ b/src/3rdparty/angle/src/compiler/translator/glslang.l
+@@ -516,6 +516,10 @@ void yyerror(YYLTYPE* lloc, TParseContext* context, void *scanner, const char* r
+     context->recover();
+ }
+ 
++void glslangerror(YYLTYPE* lloc, TParseContext* context, void *scanner, const char* reason) {
++    yyerror(lloc, context, scanner, reason);
++}
++
+ int int_constant(TParseContext *context) {
+     struct yyguts_t* yyg = (struct yyguts_t*) context->getScanner();
+ 
+diff --git a/src/3rdparty/angle/src/libANGLE/renderer/d3d/d3d11/Renderer11.cpp b/src/3rdparty/angle/src/libANGLE/renderer/d3d/d3d11/Renderer11.cpp
+index 0173311b..a0274219 100644
+--- a/src/3rdparty/angle/src/libANGLE/renderer/d3d/d3d11/Renderer11.cpp
++++ b/src/3rdparty/angle/src/libANGLE/renderer/d3d/d3d11/Renderer11.cpp
+@@ -11,7 +11,7 @@
+ #include <EGL/eglext.h>
+ #include <sstream>
+ #if !defined(ANGLE_MINGW32_COMPAT) && WINAPI_FAMILY != WINAPI_FAMILY_PHONE_APP
+-#include <VersionHelpers.h>
++#include <versionhelpers.h>
+ #endif
+ 
+ #include "common/tls.h"
+diff --git a/src/angle/src/common/common.pri b/src/angle/src/common/common.pri
+index c1fad149..67dc4008 100644
+--- a/src/angle/src/common/common.pri
++++ b/src/angle/src/common/common.pri
+@@ -21,10 +21,14 @@ lib_replace.replace = \$\$\$\$[QT_INSTALL_LIBS]
+ lib_replace.CONFIG = path
+ QMAKE_PRL_INSTALL_REPLACE += lib_replace
+ 
+-# DirectX is included in the Windows 8 Kit, but everything else requires the DX SDK.
+-winrt|msvc {
++!equals(QMAKE_HOST.os, Windows) {
++    # If doing crosscompile, we expect shader header files already compiled by some other way
++    FXC = echo
++} else:winrt|msvc {
++    # DirectX is included in the Windows 8 Kit
+     FXC = fxc.exe
+ } else {
++    # Everything else requires the DX SDK.
+     DX_DIR = $$(DXSDK_DIR)
+     isEmpty(DX_DIR) {
+         error("Cannot determine DirectX SDK location. Please set DXSDK_DIR environment variable.")
+diff --git a/src/angle/src/compiler/translator.pro b/src/angle/src/compiler/translator.pro
+index 398b9230..d0c04384 100644
+--- a/src/angle/src/compiler/translator.pro
++++ b/src/angle/src/compiler/translator.pro
+@@ -179,31 +179,10 @@ SOURCES += \
+ 
+ 
+ # NOTE: 'flex' and 'bison' can be found in qt5/gnuwin32/bin
+-flex.commands = $$addGnuPath(flex) --noline --nounistd --outfile=${QMAKE_FILE_OUT} ${QMAKE_FILE_NAME}
+-flex.output = $${BUILDSUBDIR}${QMAKE_FILE_BASE}_lex.cpp
+-flex.input = FLEX_SOURCES
+-flex.dependency_type = TYPE_C
+-flex.variable_out = GENERATED_SOURCES
+-QMAKE_EXTRA_COMPILERS += flex
++CONFIG += lex
++QMAKE_MOD_LEX = "_lex"
++LEXSOURCES = $$FLEX_SOURCES
+ 
+-defineReplace(myDirName) { return($$dirname(1)) }
+-bison.commands = $$addGnuPath(bison) --no-lines --skeleton=yacc.c --defines=${QMAKE_FILE_OUT} \
+-                --output=${QMAKE_FUNC_FILE_OUT_myDirName}$$QMAKE_DIR_SEP${QMAKE_FILE_OUT_BASE}.cpp \
+-                ${QMAKE_FILE_NAME}$$escape_expand(\\n\\t) \
+-                @echo // EOF>>${QMAKE_FUNC_FILE_OUT_myDirName}$$QMAKE_DIR_SEP${QMAKE_FILE_OUT_BASE}.cpp
+-bison.output = $${BUILDSUBDIR}${QMAKE_FILE_BASE}_tab.h
+-bison.input = BISON_SOURCES
+-bison.dependency_type = TYPE_C
+-bison.variable_out = GENERATED_SOURCES
+-QMAKE_EXTRA_COMPILERS += bison
+-
+-# This is a dummy compiler to work around the fact that an extra compiler can only
+-# have one output file even if the command generates two.
+-MAKEFILE_NOOP_COMMAND = @echo -n
+-msvc: MAKEFILE_NOOP_COMMAND = @echo >NUL
+-bison_impl.output = $${BUILDSUBDIR}${QMAKE_FILE_BASE}_tab.cpp
+-bison_impl.input = BISON_SOURCES
+-bison_impl.commands = $$MAKEFILE_NOOP_COMMAND
+-bison_impl.depends = $${BUILDSUBDIR}${QMAKE_FILE_BASE}_tab.h
+-bison_impl.variable_out = GENERATED_SOURCES
+-QMAKE_EXTRA_COMPILERS += bison_impl
++CONFIG += yacc
++QMAKE_MOD_YACC = "_tab"
++YACCSOURCES = $$BISON_SOURCES
+diff --git a/src/angle/src/config.pri b/src/angle/src/config.pri
+index 4beb0952..48d017ce 100644
+--- a/src/angle/src/config.pri
++++ b/src/angle/src/config.pri
+@@ -52,7 +52,7 @@ CONFIG(debug, debug|release) {
+     DEFINES += NDEBUG
+ }
+ 
+-!isEmpty(BUILD_PASS): BUILDSUBDIR = $$lower($$BUILD_PASS)/
++BUILDSUBDIR = $${_PRO_FILE_PWD_}/
+ 
+ # c++11 is needed by MinGW to get support for unordered_map.
+ CONFIG += stl exceptions c++11
+diff --git a/src/angle/src/libGLESv2/libANGLE b/src/angle/src/libGLESv2/libANGLE
+new file mode 120000
+index 00000000..bc79f1f9
+--- /dev/null
++++ b/src/angle/src/libGLESv2/libANGLE
+@@ -0,0 +1 @@
++../QtANGLE/libANGLE
+\ No newline at end of file
+diff --git a/src/gui/configure.json b/src/gui/configure.json
+index 5f606217..531e387e 100644
+--- a/src/gui/configure.json
++++ b/src/gui/configure.json
+@@ -634,8 +634,7 @@
+             "type": "directX",
+             "files": [
+                 "d3dcompiler.h",
+-                "d3d11.lib",
+-                "fxc.exe"
++                "libd3d11.a"
+             ]
+         },
+         "egl-x11": {

--- a/src/qtbase-2-fixes.patch
+++ b/src/qtbase-2-fixes.patch
@@ -1,0 +1,11366 @@
+This file is part of MXE. See LICENSE.md for licensing information.
+
+Contains ad hoc patches for cross building.
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Robert Manner <robert.manner@balabit.com>
+Date: Sun, 17 Dec 2017 20:12:15 +0100
+Subject: [PATCH 1/1] QtANGLE: added shader header files compiled with fxc.exe
+
+
+diff --git a/src/angle/src/QtANGLE/.def b/src/angle/src/QtANGLE/.def
+new file mode 100644
+index 00000000..8717f5f9
+--- /dev/null
++++ b/src/angle/src/QtANGLE/.def
+@@ -0,0 +1,374 @@
++LIBRARY 
++EXPORTS
++;
++;   Generated from:
++;   /home/manner/balabit/repos/mxe/gits/qtbase-everywhere-src-5.10.0/src/3rdparty/angle/src/libGLESv2/libGLESv2.def
++    glActiveTexture                 @1
++    glAttachShader                  @2
++    glBindAttribLocation            @3
++    glBindBuffer                    @4
++    glBindFramebuffer               @5
++    glBindRenderbuffer              @6
++    glBindTexture                   @7
++    glBlendColor                    @8
++    glBlendEquation                 @9
++    glBlendEquationSeparate         @10
++    glBlendFunc                     @11
++    glBlendFuncSeparate             @12
++    glBufferData                    @13
++    glBufferSubData                 @14
++    glCheckFramebufferStatus        @15
++    glClear                         @16
++    glClearColor                    @17
++    glClearDepthf                   @18
++    glClearStencil                  @19
++    glColorMask                     @20
++    glCompileShader                 @21
++    glCompressedTexImage2D          @22
++    glCompressedTexSubImage2D       @23
++    glCopyTexImage2D                @24
++    glCopyTexSubImage2D             @25
++    glCreateProgram                 @26
++    glCreateShader                  @27
++    glCullFace                      @28
++    glDeleteBuffers                 @29
++    glDeleteFramebuffers            @30
++    glDeleteProgram                 @32
++    glDeleteRenderbuffers           @33
++    glDeleteShader                  @34
++    glDeleteTextures                @31
++    glDepthFunc                     @36
++    glDepthMask                     @37
++    glDepthRangef                   @38
++    glDetachShader                  @35
++    glDisable                       @39
++    glDisableVertexAttribArray      @40
++    glDrawArrays                    @41
++    glDrawElements                  @42
++    glEnable                        @43
++    glEnableVertexAttribArray       @44
++    glFinish                        @45
++    glFlush                         @46
++    glFramebufferRenderbuffer       @47
++    glFramebufferTexture2D          @48
++    glFrontFace                     @49
++    glGenBuffers                    @50
++    glGenFramebuffers               @52
++    glGenRenderbuffers              @53
++    glGenTextures                   @54
++    glGenerateMipmap                @51
++    glGetActiveAttrib               @55
++    glGetActiveUniform              @56
++    glGetAttachedShaders            @57
++    glGetAttribLocation             @58
++    glGetBooleanv                   @59
++    glGetBufferParameteriv          @60
++    glGetError                      @61
++    glGetFloatv                     @62
++    glGetFramebufferAttachmentParameteriv   @63
++    glGetIntegerv                   @64
++    glGetProgramInfoLog             @66
++    glGetProgramiv                  @65
++    glGetRenderbufferParameteriv    @67
++    glGetShaderInfoLog              @69
++    glGetShaderPrecisionFormat      @70
++    glGetShaderSource               @71
++    glGetShaderiv                   @68
++    glGetString                     @72
++    glGetTexParameterfv             @73
++    glGetTexParameteriv             @74
++    glGetUniformLocation            @77
++    glGetUniformfv                  @75
++    glGetUniformiv                  @76
++    glGetVertexAttribPointerv       @80
++    glGetVertexAttribfv             @78
++    glGetVertexAttribiv             @79
++    glHint                          @81
++    glIsBuffer                      @82
++    glIsEnabled                     @83
++    glIsFramebuffer                 @84
++    glIsProgram                     @85
++    glIsRenderbuffer                @86
++    glIsShader                      @87
++    glIsTexture                     @88
++    glLineWidth                     @89
++    glLinkProgram                   @90
++    glPixelStorei                   @91
++    glPolygonOffset                 @92
++    glReadPixels                    @93
++    glReleaseShaderCompiler         @94
++    glRenderbufferStorage           @95
++    glSampleCoverage                @96
++    glScissor                       @97
++    glShaderBinary                  @98
++    glShaderSource                  @99
++    glStencilFunc                   @100
++    glStencilFuncSeparate           @101
++    glStencilMask                   @102
++    glStencilMaskSeparate           @103
++    glStencilOp                     @104
++    glStencilOpSeparate             @105
++    glTexImage2D                    @106
++    glTexParameterf                 @107
++    glTexParameterfv                @108
++    glTexParameteri                 @109
++    glTexParameteriv                @110
++    glTexSubImage2D                 @111
++    glUniform1f                     @112
++    glUniform1fv                    @113
++    glUniform1i                     @114
++    glUniform1iv                    @115
++    glUniform2f                     @116
++    glUniform2fv                    @117
++    glUniform2i                     @118
++    glUniform2iv                    @119
++    glUniform3f                     @120
++    glUniform3fv                    @121
++    glUniform3i                     @122
++    glUniform3iv                    @123
++    glUniform4f                     @124
++    glUniform4fv                    @125
++    glUniform4i                     @126
++    glUniform4iv                    @127
++    glUniformMatrix2fv              @128
++    glUniformMatrix3fv              @129
++    glUniformMatrix4fv              @130
++    glUseProgram                    @131
++    glValidateProgram               @132
++    glVertexAttrib1f                @133
++    glVertexAttrib1fv               @134
++    glVertexAttrib2f                @135
++    glVertexAttrib2fv               @136
++    glVertexAttrib3f                @137
++    glVertexAttrib3fv               @138
++    glVertexAttrib4f                @139
++    glVertexAttrib4fv               @140
++    glVertexAttribPointer           @141
++    glViewport                      @142
++    ; Extensions
++    glBlitFramebufferANGLE          @149
++    glRenderbufferStorageMultisampleANGLE @150
++    glDeleteFencesNV                @151
++    glFinishFenceNV                 @152
++    glGenFencesNV                   @153
++    glGetFenceivNV                  @154
++    glIsFenceNV                     @155
++    glSetFenceNV                    @156
++    glTestFenceNV                   @157
++    glGetTranslatedShaderSourceANGLE @159
++    glTexStorage2DEXT               @160
++    glGetGraphicsResetStatusEXT     @161
++    glReadnPixelsEXT                @162
++    glGetnUniformfvEXT              @163
++    glGetnUniformivEXT              @164
++    glGenQueriesEXT                 @165
++    glDeleteQueriesEXT              @166
++    glIsQueryEXT                    @167
++    glBeginQueryEXT                 @168
++    glEndQueryEXT                   @169
++    glGetQueryivEXT                 @170
++    glGetQueryObjectuivEXT          @171
++    glVertexAttribDivisorANGLE      @172
++    glDrawArraysInstancedANGLE      @173
++    glDrawElementsInstancedANGLE    @174
++    glProgramBinaryOES              @175
++    glGetProgramBinaryOES           @176
++    glDrawBuffersEXT                @179
++    glMapBufferOES                  @285
++    glUnmapBufferOES                @286
++    glGetBufferPointervOES          @287
++    glMapBufferRangeEXT             @288
++    glFlushMappedBufferRangeEXT     @289
++    glDiscardFramebufferEXT         @293
++    glInsertEventMarkerEXT          @294
++    glPushGroupMarkerEXT            @295
++    glPopGroupMarkerEXT             @296
++    glEGLImageTargetTexture2DOES    @297
++    glEGLImageTargetRenderbufferStorageOES @298
++    glBindVertexArrayOES            @299
++    glDeleteVertexArraysOES         @300
++    glGenVertexArraysOES            @301
++    glIsVertexArrayOES              @302
++    glDebugMessageControlKHR        @303
++    glDebugMessageInsertKHR         @304
++    glDebugMessageCallbackKHR       @305
++    glGetDebugMessageLogKHR         @306
++    glPushDebugGroupKHR             @307
++    glPopDebugGroupKHR              @308
++    glObjectLabelKHR                @309
++    glGetObjectLabelKHR             @310
++    glObjectPtrLabelKHR             @311
++    glGetObjectPtrLabelKHR          @312
++    glGetPointervKHR                @313
++    glQueryCounterEXT               @314
++    glGetQueryObjectivEXT           @315
++    glGetQueryObjecti64vEXT         @316
++    glGetQueryObjectui64vEXT        @317
++    ; GLES 3.0 Functions
++    glReadBuffer                    @180
++    glDrawRangeElements             @181
++    glTexImage3D                    @182
++    glTexSubImage3D                 @183
++    glCopyTexSubImage3D             @184
++    glCompressedTexImage3D          @185
++    glCompressedTexSubImage3D       @186
++    glGenQueries                    @187
++    glDeleteQueries                 @188
++    glIsQuery                       @189
++    glBeginQuery                    @190
++    glEndQuery                      @191
++    glGetQueryiv                    @192
++    glGetQueryObjectuiv             @193
++    glUnmapBuffer                   @194
++    glGetBufferPointerv             @195
++    glDrawBuffers                   @196
++    glUniformMatrix2x3fv            @197
++    glUniformMatrix3x2fv            @198
++    glUniformMatrix2x4fv            @199
++    glUniformMatrix4x2fv            @200
++    glUniformMatrix3x4fv            @201
++    glUniformMatrix4x3fv            @202
++    glBlitFramebuffer               @203
++    glRenderbufferStorageMultisample @204
++    glFramebufferTextureLayer       @205
++    glMapBufferRange                @206
++    glFlushMappedBufferRange        @207
++    glBindVertexArray               @208
++    glDeleteVertexArrays            @209
++    glGenVertexArrays               @210
++    glIsVertexArray                 @211
++    glGetIntegeri_v                 @212
++    glBeginTransformFeedback        @213
++    glEndTransformFeedback          @214
++    glBindBufferRange               @215
++    glBindBufferBase                @216
++    glTransformFeedbackVaryings     @217
++    glGetTransformFeedbackVarying   @218
++    glVertexAttribIPointer          @219
++    glGetVertexAttribIiv            @220
++    glGetVertexAttribIuiv           @221
++    glVertexAttribI4i               @222
++    glVertexAttribI4ui              @223
++    glVertexAttribI4iv              @224
++    glVertexAttribI4uiv             @225
++    glGetUniformuiv                 @226
++    glGetFragDataLocation           @227
++    glUniform1ui                    @228
++    glUniform2ui                    @229
++    glUniform3ui                    @230
++    glUniform4ui                    @231
++    glUniform1uiv                   @232
++    glUniform2uiv                   @233
++    glUniform3uiv                   @234
++    glUniform4uiv                   @235
++    glClearBufferiv                 @236
++    glClearBufferuiv                @237
++    glClearBufferfv                 @238
++    glClearBufferfi                 @239
++    glGetStringi                    @240
++    glCopyBufferSubData             @241
++    glGetUniformIndices             @242
++    glGetActiveUniformsiv           @243
++    glGetUniformBlockIndex          @244
++    glGetActiveUniformBlockiv       @245
++    glGetActiveUniformBlockName     @246
++    glUniformBlockBinding           @247
++    glDrawArraysInstanced           @248
++    glDrawElementsInstanced         @249
++    glFenceSync                     @250
++    glIsSync                        @251
++    glDeleteSync                    @252
++    glClientWaitSync                @253
++    glWaitSync                      @254
++    glGetInteger64v                 @255
++    glGetSynciv                     @256
++    glGetInteger64i_v               @257
++    glGetBufferParameteri64v        @258
++    glGenSamplers                   @259
++    glDeleteSamplers                @260
++    glIsSampler                     @261
++    glBindSampler                   @262
++    glSamplerParameteri             @263
++    glSamplerParameteriv            @264
++    glSamplerParameterf             @265
++    glSamplerParameterfv            @266
++    glGetSamplerParameteriv         @267
++    glGetSamplerParameterfv         @268
++    glVertexAttribDivisor           @269
++    glBindTransformFeedback         @270
++    glDeleteTransformFeedbacks      @271
++    glGenTransformFeedbacks         @272
++    glIsTransformFeedback           @273
++    glPauseTransformFeedback        @274
++    glResumeTransformFeedback       @275
++    glGetProgramBinary              @276
++    glProgramBinary                 @277
++    glProgramParameteri             @278
++    glInvalidateFramebuffer         @279
++    glInvalidateSubFramebuffer      @280
++    glTexStorage2D                  @281
++    glTexStorage3D                  @282
++    glGetInternalformativ           @283
++    ; ANGLE Platform Implementation
++    ANGLEPlatformCurrent            @290
++    ANGLEPlatformInitialize         @291
++    ANGLEPlatformShutdown           @292
++;
++;   Generated from:
++;   /home/manner/balabit/repos/mxe/gits/qtbase-everywhere-src-5.10.0/src/3rdparty/angle/src/libEGL/libEGL.def
++    eglBindAPI                       @318
++    eglBindTexImage                  @319
++    eglChooseConfig                  @320
++    eglCopyBuffers                   @321
++    eglCreateContext                 @322
++    eglCreatePbufferFromClientBuffer @323
++    eglCreatePbufferSurface          @324
++    eglCreatePixmapSurface           @325
++    eglCreateWindowSurface           @326
++    eglDestroyContext                @327
++    eglDestroySurface                @328
++    eglGetConfigAttrib               @329
++    eglGetConfigs                    @330
++    eglGetCurrentContext             @331
++    eglGetCurrentDisplay             @332
++    eglGetCurrentSurface             @333
++    eglGetDisplay                    @334
++    eglGetError                      @335
++    eglGetProcAddress                @336
++    eglInitialize                    @337
++    eglMakeCurrent                   @338
++    eglQueryAPI                      @339
++    eglQueryContext                  @340
++    eglQueryString                   @341
++    eglQuerySurface                  @342
++    eglReleaseTexImage               @343
++    eglReleaseThread                 @344
++    eglSurfaceAttrib                 @345
++    eglSwapBuffers                   @346
++    eglSwapInterval                  @347
++    eglTerminate                     @348
++    eglWaitClient                    @349
++    eglWaitGL                        @350
++    eglWaitNative                    @351
++    ; Extensions
++    eglGetPlatformDisplayEXT         @352
++    eglQuerySurfacePointerANGLE      @353
++    eglPostSubBufferNV               @354
++    eglQueryDisplayAttribEXT         @355
++    eglQueryDeviceAttribEXT          @356
++    eglQueryDeviceStringEXT          @357
++    eglCreateImageKHR                @358
++    eglDestroyImageKHR               @359
++    eglCreateDeviceANGLE             @360
++    eglReleaseDeviceANGLE            @361
++    ; 1.5 entry points
++    eglCreateSync                    @362
++    eglDestroySync                   @363
++    eglClientWaitSync                @364
++    eglGetSyncAttrib                 @365
++    eglCreateImage                   @366
++    eglDestroyImage                  @367
++    eglGetPlatformDisplay            @368
++    eglCreatePlatformWindowSurface   @369
++    eglCreatePlatformPixmapSurface   @370
++    eglWaitSync                      @371
+diff --git a/src/angle/src/QtANGLE/d.def b/src/angle/src/QtANGLE/d.def
+new file mode 100644
+index 00000000..005bd4d6
+--- /dev/null
++++ b/src/angle/src/QtANGLE/d.def
+@@ -0,0 +1,374 @@
++LIBRARY d
++EXPORTS
++;
++;   Generated from:
++;   /home/manner/balabit/repos/mxe/gits/qtbase-everywhere-src-5.10.0/src/3rdparty/angle/src/libGLESv2/libGLESv2d.def
++    glActiveTexture                 @1
++    glAttachShader                  @2
++    glBindAttribLocation            @3
++    glBindBuffer                    @4
++    glBindFramebuffer               @5
++    glBindRenderbuffer              @6
++    glBindTexture                   @7
++    glBlendColor                    @8
++    glBlendEquation                 @9
++    glBlendEquationSeparate         @10
++    glBlendFunc                     @11
++    glBlendFuncSeparate             @12
++    glBufferData                    @13
++    glBufferSubData                 @14
++    glCheckFramebufferStatus        @15
++    glClear                         @16
++    glClearColor                    @17
++    glClearDepthf                   @18
++    glClearStencil                  @19
++    glColorMask                     @20
++    glCompileShader                 @21
++    glCompressedTexImage2D          @22
++    glCompressedTexSubImage2D       @23
++    glCopyTexImage2D                @24
++    glCopyTexSubImage2D             @25
++    glCreateProgram                 @26
++    glCreateShader                  @27
++    glCullFace                      @28
++    glDeleteBuffers                 @29
++    glDeleteFramebuffers            @30
++    glDeleteProgram                 @32
++    glDeleteRenderbuffers           @33
++    glDeleteShader                  @34
++    glDeleteTextures                @31
++    glDepthFunc                     @36
++    glDepthMask                     @37
++    glDepthRangef                   @38
++    glDetachShader                  @35
++    glDisable                       @39
++    glDisableVertexAttribArray      @40
++    glDrawArrays                    @41
++    glDrawElements                  @42
++    glEnable                        @43
++    glEnableVertexAttribArray       @44
++    glFinish                        @45
++    glFlush                         @46
++    glFramebufferRenderbuffer       @47
++    glFramebufferTexture2D          @48
++    glFrontFace                     @49
++    glGenBuffers                    @50
++    glGenFramebuffers               @52
++    glGenRenderbuffers              @53
++    glGenTextures                   @54
++    glGenerateMipmap                @51
++    glGetActiveAttrib               @55
++    glGetActiveUniform              @56
++    glGetAttachedShaders            @57
++    glGetAttribLocation             @58
++    glGetBooleanv                   @59
++    glGetBufferParameteriv          @60
++    glGetError                      @61
++    glGetFloatv                     @62
++    glGetFramebufferAttachmentParameteriv   @63
++    glGetIntegerv                   @64
++    glGetProgramInfoLog             @66
++    glGetProgramiv                  @65
++    glGetRenderbufferParameteriv    @67
++    glGetShaderInfoLog              @69
++    glGetShaderPrecisionFormat      @70
++    glGetShaderSource               @71
++    glGetShaderiv                   @68
++    glGetString                     @72
++    glGetTexParameterfv             @73
++    glGetTexParameteriv             @74
++    glGetUniformLocation            @77
++    glGetUniformfv                  @75
++    glGetUniformiv                  @76
++    glGetVertexAttribPointerv       @80
++    glGetVertexAttribfv             @78
++    glGetVertexAttribiv             @79
++    glHint                          @81
++    glIsBuffer                      @82
++    glIsEnabled                     @83
++    glIsFramebuffer                 @84
++    glIsProgram                     @85
++    glIsRenderbuffer                @86
++    glIsShader                      @87
++    glIsTexture                     @88
++    glLineWidth                     @89
++    glLinkProgram                   @90
++    glPixelStorei                   @91
++    glPolygonOffset                 @92
++    glReadPixels                    @93
++    glReleaseShaderCompiler         @94
++    glRenderbufferStorage           @95
++    glSampleCoverage                @96
++    glScissor                       @97
++    glShaderBinary                  @98
++    glShaderSource                  @99
++    glStencilFunc                   @100
++    glStencilFuncSeparate           @101
++    glStencilMask                   @102
++    glStencilMaskSeparate           @103
++    glStencilOp                     @104
++    glStencilOpSeparate             @105
++    glTexImage2D                    @106
++    glTexParameterf                 @107
++    glTexParameterfv                @108
++    glTexParameteri                 @109
++    glTexParameteriv                @110
++    glTexSubImage2D                 @111
++    glUniform1f                     @112
++    glUniform1fv                    @113
++    glUniform1i                     @114
++    glUniform1iv                    @115
++    glUniform2f                     @116
++    glUniform2fv                    @117
++    glUniform2i                     @118
++    glUniform2iv                    @119
++    glUniform3f                     @120
++    glUniform3fv                    @121
++    glUniform3i                     @122
++    glUniform3iv                    @123
++    glUniform4f                     @124
++    glUniform4fv                    @125
++    glUniform4i                     @126
++    glUniform4iv                    @127
++    glUniformMatrix2fv              @128
++    glUniformMatrix3fv              @129
++    glUniformMatrix4fv              @130
++    glUseProgram                    @131
++    glValidateProgram               @132
++    glVertexAttrib1f                @133
++    glVertexAttrib1fv               @134
++    glVertexAttrib2f                @135
++    glVertexAttrib2fv               @136
++    glVertexAttrib3f                @137
++    glVertexAttrib3fv               @138
++    glVertexAttrib4f                @139
++    glVertexAttrib4fv               @140
++    glVertexAttribPointer           @141
++    glViewport                      @142
++    ; Extensions
++    glBlitFramebufferANGLE          @149
++    glRenderbufferStorageMultisampleANGLE @150
++    glDeleteFencesNV                @151
++    glFinishFenceNV                 @152
++    glGenFencesNV                   @153
++    glGetFenceivNV                  @154
++    glIsFenceNV                     @155
++    glSetFenceNV                    @156
++    glTestFenceNV                   @157
++    glGetTranslatedShaderSourceANGLE @159
++    glTexStorage2DEXT               @160
++    glGetGraphicsResetStatusEXT     @161
++    glReadnPixelsEXT                @162
++    glGetnUniformfvEXT              @163
++    glGetnUniformivEXT              @164
++    glGenQueriesEXT                 @165
++    glDeleteQueriesEXT              @166
++    glIsQueryEXT                    @167
++    glBeginQueryEXT                 @168
++    glEndQueryEXT                   @169
++    glGetQueryivEXT                 @170
++    glGetQueryObjectuivEXT          @171
++    glVertexAttribDivisorANGLE      @172
++    glDrawArraysInstancedANGLE      @173
++    glDrawElementsInstancedANGLE    @174
++    glProgramBinaryOES              @175
++    glGetProgramBinaryOES           @176
++    glDrawBuffersEXT                @179
++    glMapBufferOES                  @285
++    glUnmapBufferOES                @286
++    glGetBufferPointervOES          @287
++    glMapBufferRangeEXT             @288
++    glFlushMappedBufferRangeEXT     @289
++    glDiscardFramebufferEXT         @293
++    glInsertEventMarkerEXT          @294
++    glPushGroupMarkerEXT            @295
++    glPopGroupMarkerEXT             @296
++    glEGLImageTargetTexture2DOES    @297
++    glEGLImageTargetRenderbufferStorageOES @298
++    glBindVertexArrayOES            @299
++    glDeleteVertexArraysOES         @300
++    glGenVertexArraysOES            @301
++    glIsVertexArrayOES              @302
++    glDebugMessageControlKHR        @303
++    glDebugMessageInsertKHR         @304
++    glDebugMessageCallbackKHR       @305
++    glGetDebugMessageLogKHR         @306
++    glPushDebugGroupKHR             @307
++    glPopDebugGroupKHR              @308
++    glObjectLabelKHR                @309
++    glGetObjectLabelKHR             @310
++    glObjectPtrLabelKHR             @311
++    glGetObjectPtrLabelKHR          @312
++    glGetPointervKHR                @313
++    glQueryCounterEXT               @314
++    glGetQueryObjectivEXT           @315
++    glGetQueryObjecti64vEXT         @316
++    glGetQueryObjectui64vEXT        @317
++    ; GLES 3.0 Functions
++    glReadBuffer                    @180
++    glDrawRangeElements             @181
++    glTexImage3D                    @182
++    glTexSubImage3D                 @183
++    glCopyTexSubImage3D             @184
++    glCompressedTexImage3D          @185
++    glCompressedTexSubImage3D       @186
++    glGenQueries                    @187
++    glDeleteQueries                 @188
++    glIsQuery                       @189
++    glBeginQuery                    @190
++    glEndQuery                      @191
++    glGetQueryiv                    @192
++    glGetQueryObjectuiv             @193
++    glUnmapBuffer                   @194
++    glGetBufferPointerv             @195
++    glDrawBuffers                   @196
++    glUniformMatrix2x3fv            @197
++    glUniformMatrix3x2fv            @198
++    glUniformMatrix2x4fv            @199
++    glUniformMatrix4x2fv            @200
++    glUniformMatrix3x4fv            @201
++    glUniformMatrix4x3fv            @202
++    glBlitFramebuffer               @203
++    glRenderbufferStorageMultisample @204
++    glFramebufferTextureLayer       @205
++    glMapBufferRange                @206
++    glFlushMappedBufferRange        @207
++    glBindVertexArray               @208
++    glDeleteVertexArrays            @209
++    glGenVertexArrays               @210
++    glIsVertexArray                 @211
++    glGetIntegeri_v                 @212
++    glBeginTransformFeedback        @213
++    glEndTransformFeedback          @214
++    glBindBufferRange               @215
++    glBindBufferBase                @216
++    glTransformFeedbackVaryings     @217
++    glGetTransformFeedbackVarying   @218
++    glVertexAttribIPointer          @219
++    glGetVertexAttribIiv            @220
++    glGetVertexAttribIuiv           @221
++    glVertexAttribI4i               @222
++    glVertexAttribI4ui              @223
++    glVertexAttribI4iv              @224
++    glVertexAttribI4uiv             @225
++    glGetUniformuiv                 @226
++    glGetFragDataLocation           @227
++    glUniform1ui                    @228
++    glUniform2ui                    @229
++    glUniform3ui                    @230
++    glUniform4ui                    @231
++    glUniform1uiv                   @232
++    glUniform2uiv                   @233
++    glUniform3uiv                   @234
++    glUniform4uiv                   @235
++    glClearBufferiv                 @236
++    glClearBufferuiv                @237
++    glClearBufferfv                 @238
++    glClearBufferfi                 @239
++    glGetStringi                    @240
++    glCopyBufferSubData             @241
++    glGetUniformIndices             @242
++    glGetActiveUniformsiv           @243
++    glGetUniformBlockIndex          @244
++    glGetActiveUniformBlockiv       @245
++    glGetActiveUniformBlockName     @246
++    glUniformBlockBinding           @247
++    glDrawArraysInstanced           @248
++    glDrawElementsInstanced         @249
++    glFenceSync                     @250
++    glIsSync                        @251
++    glDeleteSync                    @252
++    glClientWaitSync                @253
++    glWaitSync                      @254
++    glGetInteger64v                 @255
++    glGetSynciv                     @256
++    glGetInteger64i_v               @257
++    glGetBufferParameteri64v        @258
++    glGenSamplers                   @259
++    glDeleteSamplers                @260
++    glIsSampler                     @261
++    glBindSampler                   @262
++    glSamplerParameteri             @263
++    glSamplerParameteriv            @264
++    glSamplerParameterf             @265
++    glSamplerParameterfv            @266
++    glGetSamplerParameteriv         @267
++    glGetSamplerParameterfv         @268
++    glVertexAttribDivisor           @269
++    glBindTransformFeedback         @270
++    glDeleteTransformFeedbacks      @271
++    glGenTransformFeedbacks         @272
++    glIsTransformFeedback           @273
++    glPauseTransformFeedback        @274
++    glResumeTransformFeedback       @275
++    glGetProgramBinary              @276
++    glProgramBinary                 @277
++    glProgramParameteri             @278
++    glInvalidateFramebuffer         @279
++    glInvalidateSubFramebuffer      @280
++    glTexStorage2D                  @281
++    glTexStorage3D                  @282
++    glGetInternalformativ           @283
++    ; ANGLE Platform Implementation
++    ANGLEPlatformCurrent            @290
++    ANGLEPlatformInitialize         @291
++    ANGLEPlatformShutdown           @292
++;
++;   Generated from:
++;   /home/manner/balabit/repos/mxe/gits/qtbase-everywhere-src-5.10.0/src/3rdparty/angle/src/libEGL/libEGLd.def
++    eglBindAPI                       @318
++    eglBindTexImage                  @319
++    eglChooseConfig                  @320
++    eglCopyBuffers                   @321
++    eglCreateContext                 @322
++    eglCreatePbufferFromClientBuffer @323
++    eglCreatePbufferSurface          @324
++    eglCreatePixmapSurface           @325
++    eglCreateWindowSurface           @326
++    eglDestroyContext                @327
++    eglDestroySurface                @328
++    eglGetConfigAttrib               @329
++    eglGetConfigs                    @330
++    eglGetCurrentContext             @331
++    eglGetCurrentDisplay             @332
++    eglGetCurrentSurface             @333
++    eglGetDisplay                    @334
++    eglGetError                      @335
++    eglGetProcAddress                @336
++    eglInitialize                    @337
++    eglMakeCurrent                   @338
++    eglQueryAPI                      @339
++    eglQueryContext                  @340
++    eglQueryString                   @341
++    eglQuerySurface                  @342
++    eglReleaseTexImage               @343
++    eglReleaseThread                 @344
++    eglSurfaceAttrib                 @345
++    eglSwapBuffers                   @346
++    eglSwapInterval                  @347
++    eglTerminate                     @348
++    eglWaitClient                    @349
++    eglWaitGL                        @350
++    eglWaitNative                    @351
++    ; Extensions
++    eglGetPlatformDisplayEXT         @352
++    eglQuerySurfacePointerANGLE      @353
++    eglPostSubBufferNV               @354
++    eglQueryDisplayAttribEXT         @355
++    eglQueryDeviceAttribEXT          @356
++    eglQueryDeviceStringEXT          @357
++    eglCreateImageKHR                @358
++    eglDestroyImageKHR               @359
++    eglCreateDeviceANGLE             @360
++    eglReleaseDeviceANGLE            @361
++    ; 1.5 entry points
++    eglCreateSync                    @362
++    eglDestroySync                   @363
++    eglClientWaitSync                @364
++    eglGetSyncAttrib                 @365
++    eglCreateImage                   @366
++    eglDestroyImage                  @367
++    eglGetPlatformDisplay            @368
++    eglCreatePlatformWindowSurface   @369
++    eglCreatePlatformPixmapSurface   @370
++    eglWaitSync                      @371
+diff --git a/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/buffertotexture11_gs.h b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/buffertotexture11_gs.h
+new file mode 100644
+index 00000000..5522b61f
+--- /dev/null
++++ b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/buffertotexture11_gs.h
+@@ -0,0 +1,163 @@
++#if 0
++//
++// Generated by Microsoft (R) HLSL Shader Compiler 10.1
++//
++//
++//
++// Input signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_Position              0   xyzw        0      POS   float   xyzw
++// TEXCOORD                 0   x           1     NONE    uint   x   
++// LAYER                    0    y          1     NONE    uint    y  
++//
++//
++// Output signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_Position              0   xyzw        0      POS   float   xyzw
++// TEXCOORD                 0   x           1     NONE    uint   x   
++// SV_RenderTargetArrayIndex     0    y          1  RTINDEX    uint    y  
++//
++gs_4_0
++dcl_input_siv v[1][0].xyzw, position
++dcl_input v[1][1].x
++dcl_input v[1][1].y
++dcl_inputprimitive point 
++dcl_outputtopology pointlist 
++dcl_output_siv o0.xyzw, position
++dcl_output o1.x
++dcl_output_siv o1.y, rendertarget_array_index
++dcl_maxout 1
++mov o0.xyzw, v[0][0].xyzw
++mov o1.x, v[0][1].x
++mov o1.y, v[0][1].y
++emit 
++ret 
++// Approximately 5 instruction slots used
++#endif
++
++const BYTE g_GS_BufferToTexture[] =
++{
++     68,  88,  66,  67, 181, 104, 
++     45,  14,  26, 142, 216, 235, 
++     63, 167, 110,   6,   1, 170, 
++    134, 100,   1,   0,   0,   0, 
++    200,   2,   0,   0,   5,   0, 
++      0,   0,  52,   0,   0,   0, 
++    128,   0,   0,   0, 244,   0, 
++      0,   0, 124,   1,   0,   0, 
++     76,   2,   0,   0,  82,  68, 
++     69,  70,  68,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++     28,   0,   0,   0,   0,   4, 
++     83,  71,   0,   1,   0,   0, 
++     28,   0,   0,   0,  77, 105, 
++     99, 114, 111, 115, 111, 102, 
++    116,  32,  40,  82,  41,  32, 
++     72,  76,  83,  76,  32,  83, 
++    104,  97, 100, 101, 114,  32, 
++     67, 111, 109, 112, 105, 108, 
++    101, 114,  32,  49,  48,  46, 
++     49,   0,  73,  83,  71,  78, 
++    108,   0,   0,   0,   3,   0, 
++      0,   0,   8,   0,   0,   0, 
++     80,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++      3,   0,   0,   0,   0,   0, 
++      0,   0,  15,  15,   0,   0, 
++     92,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0,   1,   0, 
++      0,   0,   1,   1,   0,   0, 
++    101,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0,   1,   0, 
++      0,   0,   2,   2,   0,   0, 
++     83,  86,  95,  80, 111, 115, 
++    105, 116, 105, 111, 110,   0, 
++     84,  69,  88,  67,  79,  79, 
++     82,  68,   0,  76,  65,  89, 
++     69,  82,   0, 171,  79,  83, 
++     71,  78, 128,   0,   0,   0, 
++      3,   0,   0,   0,   8,   0, 
++      0,   0,  80,   0,   0,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,   3,   0,   0,   0, 
++      0,   0,   0,   0,  15,   0, 
++      0,   0,  92,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++      1,   0,   0,   0,   1,  14, 
++      0,   0, 101,   0,   0,   0, 
++      0,   0,   0,   0,   4,   0, 
++      0,   0,   1,   0,   0,   0, 
++      1,   0,   0,   0,   2,  13, 
++      0,   0,  83,  86,  95,  80, 
++    111, 115, 105, 116, 105, 111, 
++    110,   0,  84,  69,  88,  67, 
++     79,  79,  82,  68,   0,  83, 
++     86,  95,  82, 101, 110, 100, 
++    101, 114,  84,  97, 114, 103, 
++    101, 116,  65, 114, 114,  97, 
++    121,  73, 110, 100, 101, 120, 
++      0, 171,  83,  72,  68,  82, 
++    200,   0,   0,   0,  64,   0, 
++      2,   0,  50,   0,   0,   0, 
++     97,   0,   0,   5, 242,  16, 
++     32,   0,   1,   0,   0,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,  95,   0,   0,   4, 
++     18,  16,  32,   0,   1,   0, 
++      0,   0,   1,   0,   0,   0, 
++     95,   0,   0,   4,  34,  16, 
++     32,   0,   1,   0,   0,   0, 
++      1,   0,   0,   0,  93,   8, 
++      0,   1,  92,   8,   0,   1, 
++    103,   0,   0,   4, 242,  32, 
++     16,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0, 101,   0, 
++      0,   3,  18,  32,  16,   0, 
++      1,   0,   0,   0, 103,   0, 
++      0,   4,  34,  32,  16,   0, 
++      1,   0,   0,   0,   4,   0, 
++      0,   0,  94,   0,   0,   2, 
++      1,   0,   0,   0,  54,   0, 
++      0,   6, 242,  32,  16,   0, 
++      0,   0,   0,   0,  70,  30, 
++     32,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   6,  18,  32,  16,   0, 
++      1,   0,   0,   0,  10,  16, 
++     32,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0,  54,   0, 
++      0,   6,  34,  32,  16,   0, 
++      1,   0,   0,   0,  26,  16, 
++     32,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0,  19,   0, 
++      0,   1,  62,   0,   0,   1, 
++     83,  84,  65,  84, 116,   0, 
++      0,   0,   5,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   6,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,   1,   0,   0,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0
++};
+diff --git a/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/buffertotexture11_ps_4f.h b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/buffertotexture11_ps_4f.h
+new file mode 100644
+index 00000000..e3887285
+--- /dev/null
++++ b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/buffertotexture11_ps_4f.h
+@@ -0,0 +1,127 @@
++#if 0
++//
++// Generated by Microsoft (R) HLSL Shader Compiler 10.1
++//
++//
++// Resource Bindings:
++//
++// Name                                 Type  Format         Dim      HLSL Bind  Count
++// ------------------------------ ---------- ------- ----------- -------------- ------
++// Buffer4F                          texture  float4         buf             t0      1 
++//
++//
++//
++// Input signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_Position              0   xyzw        0      POS   float       
++// TEXCOORD                 0   x           1     NONE    uint   x   
++//
++//
++// Output signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_Target                0   xyzw        0   TARGET   float   xyzw
++//
++ps_4_0
++dcl_resource_buffer (float,float,float,float) t0
++dcl_input_ps constant v1.x
++dcl_output o0.xyzw
++ld o0.xyzw, v1.xxxx, t0.xyzw
++ret 
++// Approximately 2 instruction slots used
++#endif
++
++const BYTE g_PS_BufferToTexture_4F[] =
++{
++     68,  88,  66,  67, 156,  38, 
++    137, 246,  11, 113,  21, 186, 
++     20, 101,  47,  15, 216, 211, 
++    176, 224,   1,   0,   0,   0, 
++     12,   2,   0,   0,   5,   0, 
++      0,   0,  52,   0,   0,   0, 
++    172,   0,   0,   0,   4,   1, 
++      0,   0,  56,   1,   0,   0, 
++    144,   1,   0,   0,  82,  68, 
++     69,  70, 112,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++     28,   0,   0,   0,   0,   4, 
++    255, 255,   0,   1,   0,   0, 
++     69,   0,   0,   0,  60,   0, 
++      0,   0,   2,   0,   0,   0, 
++      5,   0,   0,   0,   1,   0, 
++      0,   0, 255, 255, 255, 255, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,  13,   0,   0,   0, 
++     66, 117, 102, 102, 101, 114, 
++     52,  70,   0,  77, 105,  99, 
++    114, 111, 115, 111, 102, 116, 
++     32,  40,  82,  41,  32,  72, 
++     76,  83,  76,  32,  83, 104, 
++     97, 100, 101, 114,  32,  67, 
++    111, 109, 112, 105, 108, 101, 
++    114,  32,  49,  48,  46,  49, 
++      0, 171, 171, 171,  73,  83, 
++     71,  78,  80,   0,   0,   0, 
++      2,   0,   0,   0,   8,   0, 
++      0,   0,  56,   0,   0,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,   3,   0,   0,   0, 
++      0,   0,   0,   0,  15,   0, 
++      0,   0,  68,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++      1,   0,   0,   0,   1,   1, 
++      0,   0,  83,  86,  95,  80, 
++    111, 115, 105, 116, 105, 111, 
++    110,   0,  84,  69,  88,  67, 
++     79,  79,  82,  68,   0, 171, 
++    171, 171,  79,  83,  71,  78, 
++     44,   0,   0,   0,   1,   0, 
++      0,   0,   8,   0,   0,   0, 
++     32,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      3,   0,   0,   0,   0,   0, 
++      0,   0,  15,   0,   0,   0, 
++     83,  86,  95,  84,  97, 114, 
++    103, 101, 116,   0, 171, 171, 
++     83,  72,  68,  82,  80,   0, 
++      0,   0,  64,   0,   0,   0, 
++     20,   0,   0,   0,  88,   8, 
++      0,   4,   0, 112,  16,   0, 
++      0,   0,   0,   0,  85,  85, 
++      0,   0,  98,   8,   0,   3, 
++     18,  16,  16,   0,   1,   0, 
++      0,   0, 101,   0,   0,   3, 
++    242,  32,  16,   0,   0,   0, 
++      0,   0,  45,   0,   0,   7, 
++    242,  32,  16,   0,   0,   0, 
++      0,   0,   6,  16,  16,   0, 
++      1,   0,   0,   0,  70, 126, 
++     16,   0,   0,   0,   0,   0, 
++     62,   0,   0,   1,  83,  84, 
++     65,  84, 116,   0,   0,   0, 
++      2,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      2,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0
++};
+diff --git a/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/buffertotexture11_ps_4i.h b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/buffertotexture11_ps_4i.h
+new file mode 100644
+index 00000000..075207b2
+--- /dev/null
++++ b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/buffertotexture11_ps_4i.h
+@@ -0,0 +1,127 @@
++#if 0
++//
++// Generated by Microsoft (R) HLSL Shader Compiler 10.1
++//
++//
++// Resource Bindings:
++//
++// Name                                 Type  Format         Dim      HLSL Bind  Count
++// ------------------------------ ---------- ------- ----------- -------------- ------
++// Buffer4I                          texture   sint4         buf             t0      1 
++//
++//
++//
++// Input signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_Position              0   xyzw        0      POS   float       
++// TEXCOORD                 0   x           1     NONE    uint   x   
++//
++//
++// Output signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_Target                0   xyzw        0   TARGET     int   xyzw
++//
++ps_4_0
++dcl_resource_buffer (sint,sint,sint,sint) t0
++dcl_input_ps constant v1.x
++dcl_output o0.xyzw
++ld o0.xyzw, v1.xxxx, t0.xyzw
++ret 
++// Approximately 2 instruction slots used
++#endif
++
++const BYTE g_PS_BufferToTexture_4I[] =
++{
++     68,  88,  66,  67, 162, 203, 
++     46,   4, 155,  72, 142, 126, 
++    228,  80,  83, 117, 139,  11, 
++     48, 250,   1,   0,   0,   0, 
++     12,   2,   0,   0,   5,   0, 
++      0,   0,  52,   0,   0,   0, 
++    172,   0,   0,   0,   4,   1, 
++      0,   0,  56,   1,   0,   0, 
++    144,   1,   0,   0,  82,  68, 
++     69,  70, 112,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++     28,   0,   0,   0,   0,   4, 
++    255, 255,   0,   1,   0,   0, 
++     69,   0,   0,   0,  60,   0, 
++      0,   0,   2,   0,   0,   0, 
++      3,   0,   0,   0,   1,   0, 
++      0,   0, 255, 255, 255, 255, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,  13,   0,   0,   0, 
++     66, 117, 102, 102, 101, 114, 
++     52,  73,   0,  77, 105,  99, 
++    114, 111, 115, 111, 102, 116, 
++     32,  40,  82,  41,  32,  72, 
++     76,  83,  76,  32,  83, 104, 
++     97, 100, 101, 114,  32,  67, 
++    111, 109, 112, 105, 108, 101, 
++    114,  32,  49,  48,  46,  49, 
++      0, 171, 171, 171,  73,  83, 
++     71,  78,  80,   0,   0,   0, 
++      2,   0,   0,   0,   8,   0, 
++      0,   0,  56,   0,   0,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,   3,   0,   0,   0, 
++      0,   0,   0,   0,  15,   0, 
++      0,   0,  68,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++      1,   0,   0,   0,   1,   1, 
++      0,   0,  83,  86,  95,  80, 
++    111, 115, 105, 116, 105, 111, 
++    110,   0,  84,  69,  88,  67, 
++     79,  79,  82,  68,   0, 171, 
++    171, 171,  79,  83,  71,  78, 
++     44,   0,   0,   0,   1,   0, 
++      0,   0,   8,   0,   0,   0, 
++     32,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      2,   0,   0,   0,   0,   0, 
++      0,   0,  15,   0,   0,   0, 
++     83,  86,  95,  84,  97, 114, 
++    103, 101, 116,   0, 171, 171, 
++     83,  72,  68,  82,  80,   0, 
++      0,   0,  64,   0,   0,   0, 
++     20,   0,   0,   0,  88,   8, 
++      0,   4,   0, 112,  16,   0, 
++      0,   0,   0,   0,  51,  51, 
++      0,   0,  98,   8,   0,   3, 
++     18,  16,  16,   0,   1,   0, 
++      0,   0, 101,   0,   0,   3, 
++    242,  32,  16,   0,   0,   0, 
++      0,   0,  45,   0,   0,   7, 
++    242,  32,  16,   0,   0,   0, 
++      0,   0,   6,  16,  16,   0, 
++      1,   0,   0,   0,  70, 126, 
++     16,   0,   0,   0,   0,   0, 
++     62,   0,   0,   1,  83,  84, 
++     65,  84, 116,   0,   0,   0, 
++      2,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      2,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0
++};
+diff --git a/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/buffertotexture11_ps_4ui.h b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/buffertotexture11_ps_4ui.h
+new file mode 100644
+index 00000000..ec791099
+--- /dev/null
++++ b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/buffertotexture11_ps_4ui.h
+@@ -0,0 +1,127 @@
++#if 0
++//
++// Generated by Microsoft (R) HLSL Shader Compiler 10.1
++//
++//
++// Resource Bindings:
++//
++// Name                                 Type  Format         Dim      HLSL Bind  Count
++// ------------------------------ ---------- ------- ----------- -------------- ------
++// Buffer4UI                         texture   uint4         buf             t0      1 
++//
++//
++//
++// Input signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_Position              0   xyzw        0      POS   float       
++// TEXCOORD                 0   x           1     NONE    uint   x   
++//
++//
++// Output signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_Target                0   xyzw        0   TARGET    uint   xyzw
++//
++ps_4_0
++dcl_resource_buffer (uint,uint,uint,uint) t0
++dcl_input_ps constant v1.x
++dcl_output o0.xyzw
++ld o0.xyzw, v1.xxxx, t0.xyzw
++ret 
++// Approximately 2 instruction slots used
++#endif
++
++const BYTE g_PS_BufferToTexture_4UI[] =
++{
++     68,  88,  66,  67, 168,  39, 
++    110,   5, 143,   0,  75, 136, 
++    251,  25,  27,  24,  35, 191, 
++      3,  64,   1,   0,   0,   0, 
++     12,   2,   0,   0,   5,   0, 
++      0,   0,  52,   0,   0,   0, 
++    172,   0,   0,   0,   4,   1, 
++      0,   0,  56,   1,   0,   0, 
++    144,   1,   0,   0,  82,  68, 
++     69,  70, 112,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++     28,   0,   0,   0,   0,   4, 
++    255, 255,   0,   1,   0,   0, 
++     70,   0,   0,   0,  60,   0, 
++      0,   0,   2,   0,   0,   0, 
++      4,   0,   0,   0,   1,   0, 
++      0,   0, 255, 255, 255, 255, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,  13,   0,   0,   0, 
++     66, 117, 102, 102, 101, 114, 
++     52,  85,  73,   0,  77, 105, 
++     99, 114, 111, 115, 111, 102, 
++    116,  32,  40,  82,  41,  32, 
++     72,  76,  83,  76,  32,  83, 
++    104,  97, 100, 101, 114,  32, 
++     67, 111, 109, 112, 105, 108, 
++    101, 114,  32,  49,  48,  46, 
++     49,   0, 171, 171,  73,  83, 
++     71,  78,  80,   0,   0,   0, 
++      2,   0,   0,   0,   8,   0, 
++      0,   0,  56,   0,   0,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,   3,   0,   0,   0, 
++      0,   0,   0,   0,  15,   0, 
++      0,   0,  68,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++      1,   0,   0,   0,   1,   1, 
++      0,   0,  83,  86,  95,  80, 
++    111, 115, 105, 116, 105, 111, 
++    110,   0,  84,  69,  88,  67, 
++     79,  79,  82,  68,   0, 171, 
++    171, 171,  79,  83,  71,  78, 
++     44,   0,   0,   0,   1,   0, 
++      0,   0,   8,   0,   0,   0, 
++     32,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0,  15,   0,   0,   0, 
++     83,  86,  95,  84,  97, 114, 
++    103, 101, 116,   0, 171, 171, 
++     83,  72,  68,  82,  80,   0, 
++      0,   0,  64,   0,   0,   0, 
++     20,   0,   0,   0,  88,   8, 
++      0,   4,   0, 112,  16,   0, 
++      0,   0,   0,   0,  68,  68, 
++      0,   0,  98,   8,   0,   3, 
++     18,  16,  16,   0,   1,   0, 
++      0,   0, 101,   0,   0,   3, 
++    242,  32,  16,   0,   0,   0, 
++      0,   0,  45,   0,   0,   7, 
++    242,  32,  16,   0,   0,   0, 
++      0,   0,   6,  16,  16,   0, 
++      1,   0,   0,   0,  70, 126, 
++     16,   0,   0,   0,   0,   0, 
++     62,   0,   0,   1,  83,  84, 
++     65,  84, 116,   0,   0,   0, 
++      2,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      2,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0
++};
+diff --git a/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/buffertotexture11_vs.h b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/buffertotexture11_vs.h
+new file mode 100644
+index 00000000..758839b8
+--- /dev/null
++++ b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/buffertotexture11_vs.h
+@@ -0,0 +1,309 @@
++#if 0
++//
++// Generated by Microsoft (R) HLSL Shader Compiler 10.1
++//
++//
++// Buffer Definitions: 
++//
++// cbuffer BufferCopyParams
++// {
++//
++//   uint FirstPixelOffset;             // Offset:    0 Size:     4
++//   uint PixelsPerRow;                 // Offset:    4 Size:     4
++//   uint RowStride;                    // Offset:    8 Size:     4
++//   uint RowsPerSlice;                 // Offset:   12 Size:     4
++//   float2 PositionOffset;             // Offset:   16 Size:     8
++//   float2 PositionScale;              // Offset:   24 Size:     8
++//   int2 TexLocationOffset;            // Offset:   32 Size:     8 [unused]
++//   int2 TexLocationScale;             // Offset:   40 Size:     8 [unused]
++//   uint FirstSlice;                   // Offset:   48 Size:     4
++//
++// }
++//
++//
++// Resource Bindings:
++//
++// Name                                 Type  Format         Dim      HLSL Bind  Count
++// ------------------------------ ---------- ------- ----------- -------------- ------
++// BufferCopyParams                  cbuffer      NA          NA            cb0      1 
++//
++//
++//
++// Input signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_VertexID              0   x           0   VERTID    uint   x   
++//
++//
++// Output signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_Position              0   xyzw        0      POS   float   xyzw
++// TEXCOORD                 0   x           1     NONE    uint   x   
++// LAYER                    0    y          1     NONE    uint    y  
++//
++vs_4_0
++dcl_constantbuffer CB0[4], immediateIndexed
++dcl_input_sgv v0.x, vertex_id
++dcl_output_siv o0.xyzw, position
++dcl_output o1.x
++dcl_output o1.y
++dcl_temps 2
++mov o0.zw, l(0,0,0,1.000000)
++imul null, r0.xy, cb0[0].wwww, cb0[0].yzyy
++udiv r0.z, null, v0.x, r0.x
++imad r0.x, -r0.z, r0.x, v0.x
++imad r0.y, r0.z, r0.y, cb0[0].x
++iadd o1.y, r0.z, cb0[3].x
++udiv r0.z, null, r0.x, cb0[0].y
++imad r0.x, -r0.z, cb0[0].y, r0.x
++utof r1.xy, r0.xzxx
++imad r0.y, r0.z, cb0[0].z, r0.y
++iadd o1.x, r0.x, r0.y
++mad o0.xy, cb0[1].zwzz, r1.xyxx, cb0[1].xyxx
++ret 
++// Approximately 13 instruction slots used
++#endif
++
++const BYTE g_VS_BufferToTexture[] =
++{
++     68,  88,  66,  67, 153,  33, 
++    196,  57, 209, 115, 237,  17, 
++     59, 231, 206, 105,   1,  81, 
++    121,  39,   1,   0,   0,   0, 
++    140,   5,   0,   0,   5,   0, 
++      0,   0,  52,   0,   0,   0, 
++     88,   2,   0,   0, 140,   2, 
++      0,   0,   0,   3,   0,   0, 
++     16,   5,   0,   0,  82,  68, 
++     69,  70,  28,   2,   0,   0, 
++      1,   0,   0,   0,  80,   0, 
++      0,   0,   1,   0,   0,   0, 
++     28,   0,   0,   0,   0,   4, 
++    254, 255,   0,   1,   0,   0, 
++    244,   1,   0,   0,  60,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,   1,   0,   0,   0, 
++     66, 117, 102, 102, 101, 114, 
++     67, 111, 112, 121,  80,  97, 
++    114,  97, 109, 115,   0, 171, 
++    171, 171,  60,   0,   0,   0, 
++      9,   0,   0,   0, 104,   0, 
++      0,   0,  64,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,  64,   1,   0,   0, 
++      0,   0,   0,   0,   4,   0, 
++      0,   0,   2,   0,   0,   0, 
++     84,   1,   0,   0,   0,   0, 
++      0,   0, 100,   1,   0,   0, 
++      4,   0,   0,   0,   4,   0, 
++      0,   0,   2,   0,   0,   0, 
++     84,   1,   0,   0,   0,   0, 
++      0,   0, 113,   1,   0,   0, 
++      8,   0,   0,   0,   4,   0, 
++      0,   0,   2,   0,   0,   0, 
++     84,   1,   0,   0,   0,   0, 
++      0,   0, 123,   1,   0,   0, 
++     12,   0,   0,   0,   4,   0, 
++      0,   0,   2,   0,   0,   0, 
++     84,   1,   0,   0,   0,   0, 
++      0,   0, 136,   1,   0,   0, 
++     16,   0,   0,   0,   8,   0, 
++      0,   0,   2,   0,   0,   0, 
++    152,   1,   0,   0,   0,   0, 
++      0,   0, 168,   1,   0,   0, 
++     24,   0,   0,   0,   8,   0, 
++      0,   0,   2,   0,   0,   0, 
++    152,   1,   0,   0,   0,   0, 
++      0,   0, 182,   1,   0,   0, 
++     32,   0,   0,   0,   8,   0, 
++      0,   0,   0,   0,   0,   0, 
++    200,   1,   0,   0,   0,   0, 
++      0,   0, 216,   1,   0,   0, 
++     40,   0,   0,   0,   8,   0, 
++      0,   0,   0,   0,   0,   0, 
++    200,   1,   0,   0,   0,   0, 
++      0,   0, 233,   1,   0,   0, 
++     48,   0,   0,   0,   4,   0, 
++      0,   0,   2,   0,   0,   0, 
++     84,   1,   0,   0,   0,   0, 
++      0,   0,  70, 105, 114, 115, 
++    116,  80, 105, 120, 101, 108, 
++     79, 102, 102, 115, 101, 116, 
++      0, 171, 171, 171,   0,   0, 
++     19,   0,   1,   0,   1,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,  80, 105, 120, 101, 
++    108, 115,  80, 101, 114,  82, 
++    111, 119,   0,  82, 111, 119, 
++     83, 116, 114, 105, 100, 101, 
++      0,  82, 111, 119, 115,  80, 
++    101, 114,  83, 108, 105,  99, 
++    101,   0,  80, 111, 115, 105, 
++    116, 105, 111, 110,  79, 102, 
++    102, 115, 101, 116,   0, 171, 
++      1,   0,   3,   0,   1,   0, 
++      2,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,  80, 111, 
++    115, 105, 116, 105, 111, 110, 
++     83,  99,  97, 108, 101,   0, 
++     84, 101, 120,  76, 111,  99, 
++     97, 116, 105, 111, 110,  79, 
++    102, 102, 115, 101, 116,   0, 
++      1,   0,   2,   0,   1,   0, 
++      2,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,  84, 101, 
++    120,  76, 111,  99,  97, 116, 
++    105, 111, 110,  83,  99,  97, 
++    108, 101,   0,  70, 105, 114, 
++    115, 116,  83, 108, 105,  99, 
++    101,   0,  77, 105,  99, 114, 
++    111, 115, 111, 102, 116,  32, 
++     40,  82,  41,  32,  72,  76, 
++     83,  76,  32,  83, 104,  97, 
++    100, 101, 114,  32,  67, 111, 
++    109, 112, 105, 108, 101, 114, 
++     32,  49,  48,  46,  49,   0, 
++     73,  83,  71,  78,  44,   0, 
++      0,   0,   1,   0,   0,   0, 
++      8,   0,   0,   0,  32,   0, 
++      0,   0,   0,   0,   0,   0, 
++      6,   0,   0,   0,   1,   0, 
++      0,   0,   0,   0,   0,   0, 
++      1,   1,   0,   0,  83,  86, 
++     95,  86, 101, 114, 116, 101, 
++    120,  73,  68,   0,  79,  83, 
++     71,  78, 108,   0,   0,   0, 
++      3,   0,   0,   0,   8,   0, 
++      0,   0,  80,   0,   0,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,   3,   0,   0,   0, 
++      0,   0,   0,   0,  15,   0, 
++      0,   0,  92,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++      1,   0,   0,   0,   1,  14, 
++      0,   0, 101,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++      1,   0,   0,   0,   2,  13, 
++      0,   0,  83,  86,  95,  80, 
++    111, 115, 105, 116, 105, 111, 
++    110,   0,  84,  69,  88,  67, 
++     79,  79,  82,  68,   0,  76, 
++     65,  89,  69,  82,   0, 171, 
++     83,  72,  68,  82,   8,   2, 
++      0,   0,  64,   0,   1,   0, 
++    130,   0,   0,   0,  89,   0, 
++      0,   4,  70, 142,  32,   0, 
++      0,   0,   0,   0,   4,   0, 
++      0,   0,  96,   0,   0,   4, 
++     18,  16,  16,   0,   0,   0, 
++      0,   0,   6,   0,   0,   0, 
++    103,   0,   0,   4, 242,  32, 
++     16,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0, 101,   0, 
++      0,   3,  18,  32,  16,   0, 
++      1,   0,   0,   0, 101,   0, 
++      0,   3,  34,  32,  16,   0, 
++      1,   0,   0,   0, 104,   0, 
++      0,   2,   2,   0,   0,   0, 
++     54,   0,   0,   8, 194,  32, 
++     16,   0,   0,   0,   0,   0, 
++      2,  64,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++    128,  63,  38,   0,   0,  10, 
++      0, 208,   0,   0,  50,   0, 
++     16,   0,   0,   0,   0,   0, 
++    246, 143,  32,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++    150, 133,  32,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++     78,   0,   0,   8,  66,   0, 
++     16,   0,   0,   0,   0,   0, 
++      0, 208,   0,   0,  10,  16, 
++     16,   0,   0,   0,   0,   0, 
++     10,   0,  16,   0,   0,   0, 
++      0,   0,  35,   0,   0,  10, 
++     18,   0,  16,   0,   0,   0, 
++      0,   0,  42,   0,  16, 128, 
++     65,   0,   0,   0,   0,   0, 
++      0,   0,  10,   0,  16,   0, 
++      0,   0,   0,   0,  10,  16, 
++     16,   0,   0,   0,   0,   0, 
++     35,   0,   0,  10,  34,   0, 
++     16,   0,   0,   0,   0,   0, 
++     42,   0,  16,   0,   0,   0, 
++      0,   0,  26,   0,  16,   0, 
++      0,   0,   0,   0,  10, 128, 
++     32,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,  30,   0, 
++      0,   8,  34,  32,  16,   0, 
++      1,   0,   0,   0,  42,   0, 
++     16,   0,   0,   0,   0,   0, 
++     10, 128,  32,   0,   0,   0, 
++      0,   0,   3,   0,   0,   0, 
++     78,   0,   0,   9,  66,   0, 
++     16,   0,   0,   0,   0,   0, 
++      0, 208,   0,   0,  10,   0, 
++     16,   0,   0,   0,   0,   0, 
++     26, 128,  32,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++     35,   0,   0,  11,  18,   0, 
++     16,   0,   0,   0,   0,   0, 
++     42,   0,  16, 128,  65,   0, 
++      0,   0,   0,   0,   0,   0, 
++     26, 128,  32,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++     10,   0,  16,   0,   0,   0, 
++      0,   0,  86,   0,   0,   5, 
++     50,   0,  16,   0,   1,   0, 
++      0,   0, 134,   0,  16,   0, 
++      0,   0,   0,   0,  35,   0, 
++      0,  10,  34,   0,  16,   0, 
++      0,   0,   0,   0,  42,   0, 
++     16,   0,   0,   0,   0,   0, 
++     42, 128,  32,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++     26,   0,  16,   0,   0,   0, 
++      0,   0,  30,   0,   0,   7, 
++     18,  32,  16,   0,   1,   0, 
++      0,   0,  10,   0,  16,   0, 
++      0,   0,   0,   0,  26,   0, 
++     16,   0,   0,   0,   0,   0, 
++     50,   0,   0,  11,  50,  32, 
++     16,   0,   0,   0,   0,   0, 
++    230, 138,  32,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++     70,   0,  16,   0,   1,   0, 
++      0,   0,  70, 128,  32,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,  62,   0,   0,   1, 
++     83,  84,  65,  84, 116,   0, 
++      0,   0,  13,   0,   0,   0, 
++      2,   0,   0,   0,   0,   0, 
++      0,   0,   4,   0,   0,   0, 
++      1,   0,   0,   0,   7,   0, 
++      0,   0,   2,   0,   0,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0
++};
+diff --git a/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/clearfloat11_fl9ps.h b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/clearfloat11_fl9ps.h
+new file mode 100644
+index 00000000..dcd098d8
+--- /dev/null
++++ b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/clearfloat11_fl9ps.h
+@@ -0,0 +1,174 @@
++#if 0
++//
++// Generated by Microsoft (R) HLSL Shader Compiler 10.1
++//
++//
++//
++// Input signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_POSITION              0   xyzw        0      POS   float       
++// COLOR                    0   xyzw        1     NONE   float   xyzw
++//
++//
++// Output signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_TARGET                0   xyzw        0   TARGET   float   xyzw
++// SV_TARGET                1   xyzw        1   TARGET   float   xyzw
++// SV_TARGET                2   xyzw        2   TARGET   float   xyzw
++// SV_TARGET                3   xyzw        3   TARGET   float   xyzw
++//
++//
++// Level9 shader bytecode:
++//
++    ps_2_x
++    dcl t0
++    mov oC0, t0
++    mov oC1, t0
++    mov oC2, t0
++    mov oC3, t0
++
++// approximately 4 instruction slots used
++ps_4_0
++dcl_input_ps linear v1.xyzw
++dcl_output o0.xyzw
++dcl_output o1.xyzw
++dcl_output o2.xyzw
++dcl_output o3.xyzw
++mov o0.xyzw, v1.xyzw
++mov o1.xyzw, v1.xyzw
++mov o2.xyzw, v1.xyzw
++mov o3.xyzw, v1.xyzw
++ret 
++// Approximately 5 instruction slots used
++#endif
++
++const BYTE g_PS_ClearFloat_FL9[] =
++{
++     68,  88,  66,  67, 227, 166, 
++    131, 141,   3,  13,  88, 185, 
++    195, 127, 105, 202, 235,  43, 
++     90, 237,   1,   0,   0,   0, 
++    224,   2,   0,   0,   6,   0, 
++      0,   0,  56,   0,   0,   0, 
++    168,   0,   0,   0,  72,   1, 
++      0,   0, 196,   1,   0,   0, 
++     16,   2,   0,   0, 100,   2, 
++      0,   0,  65, 111, 110,  57, 
++    104,   0,   0,   0, 104,   0, 
++      0,   0,   0,   2, 255, 255, 
++     68,   0,   0,   0,  36,   0, 
++      0,   0,   0,   0,  36,   0, 
++      0,   0,  36,   0,   0,   0, 
++     36,   0,   0,   0,  36,   0, 
++      0,   0,  36,   0,   1,   2, 
++    255, 255,  31,   0,   0,   2, 
++      0,   0,   0, 128,   0,   0, 
++     15, 176,   1,   0,   0,   2, 
++      0,   8,  15, 128,   0,   0, 
++    228, 176,   1,   0,   0,   2, 
++      1,   8,  15, 128,   0,   0, 
++    228, 176,   1,   0,   0,   2, 
++      2,   8,  15, 128,   0,   0, 
++    228, 176,   1,   0,   0,   2, 
++      3,   8,  15, 128,   0,   0, 
++    228, 176, 255, 255,   0,   0, 
++     83,  72,  68,  82, 152,   0, 
++      0,   0,  64,   0,   0,   0, 
++     38,   0,   0,   0,  98,  16, 
++      0,   3, 242,  16,  16,   0, 
++      1,   0,   0,   0, 101,   0, 
++      0,   3, 242,  32,  16,   0, 
++      0,   0,   0,   0, 101,   0, 
++      0,   3, 242,  32,  16,   0, 
++      1,   0,   0,   0, 101,   0, 
++      0,   3, 242,  32,  16,   0, 
++      2,   0,   0,   0, 101,   0, 
++      0,   3, 242,  32,  16,   0, 
++      3,   0,   0,   0,  54,   0, 
++      0,   5, 242,  32,  16,   0, 
++      0,   0,   0,   0,  70,  30, 
++     16,   0,   1,   0,   0,   0, 
++     54,   0,   0,   5, 242,  32, 
++     16,   0,   1,   0,   0,   0, 
++     70,  30,  16,   0,   1,   0, 
++      0,   0,  54,   0,   0,   5, 
++    242,  32,  16,   0,   2,   0, 
++      0,   0,  70,  30,  16,   0, 
++      1,   0,   0,   0,  54,   0, 
++      0,   5, 242,  32,  16,   0, 
++      3,   0,   0,   0,  70,  30, 
++     16,   0,   1,   0,   0,   0, 
++     62,   0,   0,   1,  83,  84, 
++     65,  84, 116,   0,   0,   0, 
++      5,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      5,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   4,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,  82,  68,  69,  70, 
++     68,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,  28,   0, 
++      0,   0,   0,   4, 255, 255, 
++      0,   1,   0,   0,  28,   0, 
++      0,   0,  77, 105,  99, 114, 
++    111, 115, 111, 102, 116,  32, 
++     40,  82,  41,  32,  72,  76, 
++     83,  76,  32,  83, 104,  97, 
++    100, 101, 114,  32,  67, 111, 
++    109, 112, 105, 108, 101, 114, 
++     32,  49,  48,  46,  49,   0, 
++     73,  83,  71,  78,  76,   0, 
++      0,   0,   2,   0,   0,   0, 
++      8,   0,   0,   0,  56,   0, 
++      0,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0,   3,   0, 
++      0,   0,   0,   0,   0,   0, 
++     15,   0,   0,   0,  68,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   3,   0, 
++      0,   0,   1,   0,   0,   0, 
++     15,  15,   0,   0,  83,  86, 
++     95,  80,  79,  83,  73,  84, 
++     73,  79,  78,   0,  67,  79, 
++     76,  79,  82,   0, 171, 171, 
++     79,  83,  71,  78, 116,   0, 
++      0,   0,   4,   0,   0,   0, 
++      8,   0,   0,   0, 104,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   3,   0, 
++      0,   0,   0,   0,   0,   0, 
++     15,   0,   0,   0, 104,   0, 
++      0,   0,   1,   0,   0,   0, 
++      0,   0,   0,   0,   3,   0, 
++      0,   0,   1,   0,   0,   0, 
++     15,   0,   0,   0, 104,   0, 
++      0,   0,   2,   0,   0,   0, 
++      0,   0,   0,   0,   3,   0, 
++      0,   0,   2,   0,   0,   0, 
++     15,   0,   0,   0, 104,   0, 
++      0,   0,   3,   0,   0,   0, 
++      0,   0,   0,   0,   3,   0, 
++      0,   0,   3,   0,   0,   0, 
++     15,   0,   0,   0,  83,  86, 
++     95,  84,  65,  82,  71,  69, 
++     84,   0, 171, 171
++};
+diff --git a/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/clearfloat11ps.h b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/clearfloat11ps.h
+new file mode 100644
+index 00000000..63d70b87
+--- /dev/null
++++ b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/clearfloat11ps.h
+@@ -0,0 +1,193 @@
++#if 0
++//
++// Generated by Microsoft (R) HLSL Shader Compiler 10.1
++//
++//
++//
++// Input signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_POSITION              0   xyzw        0      POS   float       
++// COLOR                    0   xyzw        1     NONE   float   xyzw
++//
++//
++// Output signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_TARGET                0   xyzw        0   TARGET   float   xyzw
++// SV_TARGET                1   xyzw        1   TARGET   float   xyzw
++// SV_TARGET                2   xyzw        2   TARGET   float   xyzw
++// SV_TARGET                3   xyzw        3   TARGET   float   xyzw
++// SV_TARGET                4   xyzw        4   TARGET   float   xyzw
++// SV_TARGET                5   xyzw        5   TARGET   float   xyzw
++// SV_TARGET                6   xyzw        6   TARGET   float   xyzw
++// SV_TARGET                7   xyzw        7   TARGET   float   xyzw
++//
++ps_4_0
++dcl_input_ps linear v1.xyzw
++dcl_output o0.xyzw
++dcl_output o1.xyzw
++dcl_output o2.xyzw
++dcl_output o3.xyzw
++dcl_output o4.xyzw
++dcl_output o5.xyzw
++dcl_output o6.xyzw
++dcl_output o7.xyzw
++mov o0.xyzw, v1.xyzw
++mov o1.xyzw, v1.xyzw
++mov o2.xyzw, v1.xyzw
++mov o3.xyzw, v1.xyzw
++mov o4.xyzw, v1.xyzw
++mov o5.xyzw, v1.xyzw
++mov o6.xyzw, v1.xyzw
++mov o7.xyzw, v1.xyzw
++ret 
++// Approximately 9 instruction slots used
++#endif
++
++const BYTE g_PS_ClearFloat[] =
++{
++     68,  88,  66,  67, 214, 100, 
++    248, 153,  67,  15,  99,  93, 
++     29, 104, 115, 249, 177, 225, 
++     61, 255,   1,   0,   0,   0, 
++     76,   3,   0,   0,   5,   0, 
++      0,   0,  52,   0,   0,   0, 
++    128,   0,   0,   0, 212,   0, 
++      0,   0, 176,   1,   0,   0, 
++    208,   2,   0,   0,  82,  68, 
++     69,  70,  68,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++     28,   0,   0,   0,   0,   4, 
++    255, 255,   0,   1,   0,   0, 
++     28,   0,   0,   0,  77, 105, 
++     99, 114, 111, 115, 111, 102, 
++    116,  32,  40,  82,  41,  32, 
++     72,  76,  83,  76,  32,  83, 
++    104,  97, 100, 101, 114,  32, 
++     67, 111, 109, 112, 105, 108, 
++    101, 114,  32,  49,  48,  46, 
++     49,   0,  73,  83,  71,  78, 
++     76,   0,   0,   0,   2,   0, 
++      0,   0,   8,   0,   0,   0, 
++     56,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++      3,   0,   0,   0,   0,   0, 
++      0,   0,  15,   0,   0,   0, 
++     68,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      3,   0,   0,   0,   1,   0, 
++      0,   0,  15,  15,   0,   0, 
++     83,  86,  95,  80,  79,  83, 
++     73,  84,  73,  79,  78,   0, 
++     67,  79,  76,  79,  82,   0, 
++    171, 171,  79,  83,  71,  78, 
++    212,   0,   0,   0,   8,   0, 
++      0,   0,   8,   0,   0,   0, 
++    200,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      3,   0,   0,   0,   0,   0, 
++      0,   0,  15,   0,   0,   0, 
++    200,   0,   0,   0,   1,   0, 
++      0,   0,   0,   0,   0,   0, 
++      3,   0,   0,   0,   1,   0, 
++      0,   0,  15,   0,   0,   0, 
++    200,   0,   0,   0,   2,   0, 
++      0,   0,   0,   0,   0,   0, 
++      3,   0,   0,   0,   2,   0, 
++      0,   0,  15,   0,   0,   0, 
++    200,   0,   0,   0,   3,   0, 
++      0,   0,   0,   0,   0,   0, 
++      3,   0,   0,   0,   3,   0, 
++      0,   0,  15,   0,   0,   0, 
++    200,   0,   0,   0,   4,   0, 
++      0,   0,   0,   0,   0,   0, 
++      3,   0,   0,   0,   4,   0, 
++      0,   0,  15,   0,   0,   0, 
++    200,   0,   0,   0,   5,   0, 
++      0,   0,   0,   0,   0,   0, 
++      3,   0,   0,   0,   5,   0, 
++      0,   0,  15,   0,   0,   0, 
++    200,   0,   0,   0,   6,   0, 
++      0,   0,   0,   0,   0,   0, 
++      3,   0,   0,   0,   6,   0, 
++      0,   0,  15,   0,   0,   0, 
++    200,   0,   0,   0,   7,   0, 
++      0,   0,   0,   0,   0,   0, 
++      3,   0,   0,   0,   7,   0, 
++      0,   0,  15,   0,   0,   0, 
++     83,  86,  95,  84,  65,  82, 
++     71,  69,  84,   0, 171, 171, 
++     83,  72,  68,  82,  24,   1, 
++      0,   0,  64,   0,   0,   0, 
++     70,   0,   0,   0,  98,  16, 
++      0,   3, 242,  16,  16,   0, 
++      1,   0,   0,   0, 101,   0, 
++      0,   3, 242,  32,  16,   0, 
++      0,   0,   0,   0, 101,   0, 
++      0,   3, 242,  32,  16,   0, 
++      1,   0,   0,   0, 101,   0, 
++      0,   3, 242,  32,  16,   0, 
++      2,   0,   0,   0, 101,   0, 
++      0,   3, 242,  32,  16,   0, 
++      3,   0,   0,   0, 101,   0, 
++      0,   3, 242,  32,  16,   0, 
++      4,   0,   0,   0, 101,   0, 
++      0,   3, 242,  32,  16,   0, 
++      5,   0,   0,   0, 101,   0, 
++      0,   3, 242,  32,  16,   0, 
++      6,   0,   0,   0, 101,   0, 
++      0,   3, 242,  32,  16,   0, 
++      7,   0,   0,   0,  54,   0, 
++      0,   5, 242,  32,  16,   0, 
++      0,   0,   0,   0,  70,  30, 
++     16,   0,   1,   0,   0,   0, 
++     54,   0,   0,   5, 242,  32, 
++     16,   0,   1,   0,   0,   0, 
++     70,  30,  16,   0,   1,   0, 
++      0,   0,  54,   0,   0,   5, 
++    242,  32,  16,   0,   2,   0, 
++      0,   0,  70,  30,  16,   0, 
++      1,   0,   0,   0,  54,   0, 
++      0,   5, 242,  32,  16,   0, 
++      3,   0,   0,   0,  70,  30, 
++     16,   0,   1,   0,   0,   0, 
++     54,   0,   0,   5, 242,  32, 
++     16,   0,   4,   0,   0,   0, 
++     70,  30,  16,   0,   1,   0, 
++      0,   0,  54,   0,   0,   5, 
++    242,  32,  16,   0,   5,   0, 
++      0,   0,  70,  30,  16,   0, 
++      1,   0,   0,   0,  54,   0, 
++      0,   5, 242,  32,  16,   0, 
++      6,   0,   0,   0,  70,  30, 
++     16,   0,   1,   0,   0,   0, 
++     54,   0,   0,   5, 242,  32, 
++     16,   0,   7,   0,   0,   0, 
++     70,  30,  16,   0,   1,   0, 
++      0,   0,  62,   0,   0,   1, 
++     83,  84,  65,  84, 116,   0, 
++      0,   0,   9,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   9,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      8,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0
++};
+diff --git a/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/clearfloat11vs.h b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/clearfloat11vs.h
+new file mode 100644
+index 00000000..fdae7d7a
+--- /dev/null
++++ b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/clearfloat11vs.h
+@@ -0,0 +1,173 @@
++#if 0
++//
++// Generated by Microsoft (R) HLSL Shader Compiler 10.1
++//
++//
++//
++// Input signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// POSITION                 0   xyz         0     NONE   float   xyz 
++// COLOR                    0   xyzw        1     NONE   float   xyzw
++//
++//
++// Output signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_POSITION              0   xyzw        0      POS   float   xyzw
++// COLOR                    0   xyzw        1     NONE   float   xyzw
++//
++//
++// Runtime generated constant mappings:
++//
++// Target Reg                               Constant Description
++// ---------- --------------------------------------------------
++// c0                              Vertex Shader position offset
++//
++//
++// Level9 shader bytecode:
++//
++    vs_2_x
++    def c1, 1, 0, 0, 0
++    dcl_texcoord v0
++    dcl_texcoord1 v1
++    add oPos.xy, v0, c0
++    mad oPos.zw, v0.z, c1.xyxy, c1.xyyx
++    mov oT0, v1
++
++// approximately 3 instruction slots used
++vs_4_0
++dcl_input v0.xyz
++dcl_input v1.xyzw
++dcl_output_siv o0.xyzw, position
++dcl_output o1.xyzw
++mov o0.xyz, v0.xyzx
++mov o0.w, l(1.000000)
++mov o1.xyzw, v1.xyzw
++ret 
++// Approximately 4 instruction slots used
++#endif
++
++const BYTE g_VS_ClearFloat[] =
++{
++     68,  88,  66,  67, 198,  12, 
++    195,  15, 230, 198, 163,  72, 
++     25,  60,  12, 139,  91, 248, 
++      1, 183,   1,   0,   0,   0, 
++    192,   2,   0,   0,   6,   0, 
++      0,   0,  56,   0,   0,   0, 
++    208,   0,   0,   0,  84,   1, 
++      0,   0, 208,   1,   0,   0, 
++     28,   2,   0,   0, 108,   2, 
++      0,   0,  65, 111, 110,  57, 
++    144,   0,   0,   0, 144,   0, 
++      0,   0,   0,   2, 254, 255, 
++    104,   0,   0,   0,  40,   0, 
++      0,   0,   0,   0,  36,   0, 
++      0,   0,  36,   0,   0,   0, 
++     36,   0,   0,   0,  36,   0, 
++      1,   0,  36,   0,   0,   0, 
++      0,   0,   1,   2, 254, 255, 
++     81,   0,   0,   5,   1,   0, 
++     15, 160,   0,   0, 128,  63, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++     31,   0,   0,   2,   5,   0, 
++      0, 128,   0,   0,  15, 144, 
++     31,   0,   0,   2,   5,   0, 
++      1, 128,   1,   0,  15, 144, 
++      2,   0,   0,   3,   0,   0, 
++      3, 192,   0,   0, 228, 144, 
++      0,   0, 228, 160,   4,   0, 
++      0,   4,   0,   0,  12, 192, 
++      0,   0, 170, 144,   1,   0, 
++     68, 160,   1,   0,  20, 160, 
++      1,   0,   0,   2,   0,   0, 
++     15, 224,   1,   0, 228, 144, 
++    255, 255,   0,   0,  83,  72, 
++     68,  82, 124,   0,   0,   0, 
++     64,   0,   1,   0,  31,   0, 
++      0,   0,  95,   0,   0,   3, 
++    114,  16,  16,   0,   0,   0, 
++      0,   0,  95,   0,   0,   3, 
++    242,  16,  16,   0,   1,   0, 
++      0,   0, 103,   0,   0,   4, 
++    242,  32,  16,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++    101,   0,   0,   3, 242,  32, 
++     16,   0,   1,   0,   0,   0, 
++     54,   0,   0,   5, 114,  32, 
++     16,   0,   0,   0,   0,   0, 
++     70,  18,  16,   0,   0,   0, 
++      0,   0,  54,   0,   0,   5, 
++    130,  32,  16,   0,   0,   0, 
++      0,   0,   1,  64,   0,   0, 
++      0,   0, 128,  63,  54,   0, 
++      0,   5, 242,  32,  16,   0, 
++      1,   0,   0,   0,  70,  30, 
++     16,   0,   1,   0,   0,   0, 
++     62,   0,   0,   1,  83,  84, 
++     65,  84, 116,   0,   0,   0, 
++      4,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      4,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   3,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,  82,  68,  69,  70, 
++     68,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,  28,   0, 
++      0,   0,   0,   4, 254, 255, 
++      0,   1,   0,   0,  28,   0, 
++      0,   0,  77, 105,  99, 114, 
++    111, 115, 111, 102, 116,  32, 
++     40,  82,  41,  32,  72,  76, 
++     83,  76,  32,  83, 104,  97, 
++    100, 101, 114,  32,  67, 111, 
++    109, 112, 105, 108, 101, 114, 
++     32,  49,  48,  46,  49,   0, 
++     73,  83,  71,  78,  72,   0, 
++      0,   0,   2,   0,   0,   0, 
++      8,   0,   0,   0,  56,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   3,   0, 
++      0,   0,   0,   0,   0,   0, 
++      7,   7,   0,   0,  65,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   3,   0, 
++      0,   0,   1,   0,   0,   0, 
++     15,  15,   0,   0,  80,  79, 
++     83,  73,  84,  73,  79,  78, 
++      0,  67,  79,  76,  79,  82, 
++      0, 171,  79,  83,  71,  78, 
++     76,   0,   0,   0,   2,   0, 
++      0,   0,   8,   0,   0,   0, 
++     56,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++      3,   0,   0,   0,   0,   0, 
++      0,   0,  15,   0,   0,   0, 
++     68,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      3,   0,   0,   0,   1,   0, 
++      0,   0,  15,   0,   0,   0, 
++     83,  86,  95,  80,  79,  83, 
++     73,  84,  73,  79,  78,   0, 
++     67,  79,  76,  79,  82,   0, 
++    171, 171
++};
+diff --git a/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/clearsint11ps.h b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/clearsint11ps.h
+new file mode 100644
+index 00000000..71431c68
+--- /dev/null
++++ b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/clearsint11ps.h
+@@ -0,0 +1,193 @@
++#if 0
++//
++// Generated by Microsoft (R) HLSL Shader Compiler 10.1
++//
++//
++//
++// Input signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_POSITION              0   xyzw        0      POS   float       
++// COLOR                    0   xyzw        1     NONE     int   xyzw
++//
++//
++// Output signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_TARGET                0   xyzw        0   TARGET     int   xyzw
++// SV_TARGET                1   xyzw        1   TARGET     int   xyzw
++// SV_TARGET                2   xyzw        2   TARGET     int   xyzw
++// SV_TARGET                3   xyzw        3   TARGET     int   xyzw
++// SV_TARGET                4   xyzw        4   TARGET     int   xyzw
++// SV_TARGET                5   xyzw        5   TARGET     int   xyzw
++// SV_TARGET                6   xyzw        6   TARGET     int   xyzw
++// SV_TARGET                7   xyzw        7   TARGET     int   xyzw
++//
++ps_4_0
++dcl_input_ps constant v1.xyzw
++dcl_output o0.xyzw
++dcl_output o1.xyzw
++dcl_output o2.xyzw
++dcl_output o3.xyzw
++dcl_output o4.xyzw
++dcl_output o5.xyzw
++dcl_output o6.xyzw
++dcl_output o7.xyzw
++mov o0.xyzw, v1.xyzw
++mov o1.xyzw, v1.xyzw
++mov o2.xyzw, v1.xyzw
++mov o3.xyzw, v1.xyzw
++mov o4.xyzw, v1.xyzw
++mov o5.xyzw, v1.xyzw
++mov o6.xyzw, v1.xyzw
++mov o7.xyzw, v1.xyzw
++ret 
++// Approximately 9 instruction slots used
++#endif
++
++const BYTE g_PS_ClearSint[] =
++{
++     68,  88,  66,  67, 180,  32, 
++    180,  64, 232, 151, 140,  24, 
++    148, 204, 184,  88, 202, 183, 
++    227, 117,   1,   0,   0,   0, 
++     76,   3,   0,   0,   5,   0, 
++      0,   0,  52,   0,   0,   0, 
++    128,   0,   0,   0, 212,   0, 
++      0,   0, 176,   1,   0,   0, 
++    208,   2,   0,   0,  82,  68, 
++     69,  70,  68,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++     28,   0,   0,   0,   0,   4, 
++    255, 255,   0,   1,   0,   0, 
++     28,   0,   0,   0,  77, 105, 
++     99, 114, 111, 115, 111, 102, 
++    116,  32,  40,  82,  41,  32, 
++     72,  76,  83,  76,  32,  83, 
++    104,  97, 100, 101, 114,  32, 
++     67, 111, 109, 112, 105, 108, 
++    101, 114,  32,  49,  48,  46, 
++     49,   0,  73,  83,  71,  78, 
++     76,   0,   0,   0,   2,   0, 
++      0,   0,   8,   0,   0,   0, 
++     56,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++      3,   0,   0,   0,   0,   0, 
++      0,   0,  15,   0,   0,   0, 
++     68,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      2,   0,   0,   0,   1,   0, 
++      0,   0,  15,  15,   0,   0, 
++     83,  86,  95,  80,  79,  83, 
++     73,  84,  73,  79,  78,   0, 
++     67,  79,  76,  79,  82,   0, 
++    171, 171,  79,  83,  71,  78, 
++    212,   0,   0,   0,   8,   0, 
++      0,   0,   8,   0,   0,   0, 
++    200,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      2,   0,   0,   0,   0,   0, 
++      0,   0,  15,   0,   0,   0, 
++    200,   0,   0,   0,   1,   0, 
++      0,   0,   0,   0,   0,   0, 
++      2,   0,   0,   0,   1,   0, 
++      0,   0,  15,   0,   0,   0, 
++    200,   0,   0,   0,   2,   0, 
++      0,   0,   0,   0,   0,   0, 
++      2,   0,   0,   0,   2,   0, 
++      0,   0,  15,   0,   0,   0, 
++    200,   0,   0,   0,   3,   0, 
++      0,   0,   0,   0,   0,   0, 
++      2,   0,   0,   0,   3,   0, 
++      0,   0,  15,   0,   0,   0, 
++    200,   0,   0,   0,   4,   0, 
++      0,   0,   0,   0,   0,   0, 
++      2,   0,   0,   0,   4,   0, 
++      0,   0,  15,   0,   0,   0, 
++    200,   0,   0,   0,   5,   0, 
++      0,   0,   0,   0,   0,   0, 
++      2,   0,   0,   0,   5,   0, 
++      0,   0,  15,   0,   0,   0, 
++    200,   0,   0,   0,   6,   0, 
++      0,   0,   0,   0,   0,   0, 
++      2,   0,   0,   0,   6,   0, 
++      0,   0,  15,   0,   0,   0, 
++    200,   0,   0,   0,   7,   0, 
++      0,   0,   0,   0,   0,   0, 
++      2,   0,   0,   0,   7,   0, 
++      0,   0,  15,   0,   0,   0, 
++     83,  86,  95,  84,  65,  82, 
++     71,  69,  84,   0, 171, 171, 
++     83,  72,  68,  82,  24,   1, 
++      0,   0,  64,   0,   0,   0, 
++     70,   0,   0,   0,  98,   8, 
++      0,   3, 242,  16,  16,   0, 
++      1,   0,   0,   0, 101,   0, 
++      0,   3, 242,  32,  16,   0, 
++      0,   0,   0,   0, 101,   0, 
++      0,   3, 242,  32,  16,   0, 
++      1,   0,   0,   0, 101,   0, 
++      0,   3, 242,  32,  16,   0, 
++      2,   0,   0,   0, 101,   0, 
++      0,   3, 242,  32,  16,   0, 
++      3,   0,   0,   0, 101,   0, 
++      0,   3, 242,  32,  16,   0, 
++      4,   0,   0,   0, 101,   0, 
++      0,   3, 242,  32,  16,   0, 
++      5,   0,   0,   0, 101,   0, 
++      0,   3, 242,  32,  16,   0, 
++      6,   0,   0,   0, 101,   0, 
++      0,   3, 242,  32,  16,   0, 
++      7,   0,   0,   0,  54,   0, 
++      0,   5, 242,  32,  16,   0, 
++      0,   0,   0,   0,  70,  30, 
++     16,   0,   1,   0,   0,   0, 
++     54,   0,   0,   5, 242,  32, 
++     16,   0,   1,   0,   0,   0, 
++     70,  30,  16,   0,   1,   0, 
++      0,   0,  54,   0,   0,   5, 
++    242,  32,  16,   0,   2,   0, 
++      0,   0,  70,  30,  16,   0, 
++      1,   0,   0,   0,  54,   0, 
++      0,   5, 242,  32,  16,   0, 
++      3,   0,   0,   0,  70,  30, 
++     16,   0,   1,   0,   0,   0, 
++     54,   0,   0,   5, 242,  32, 
++     16,   0,   4,   0,   0,   0, 
++     70,  30,  16,   0,   1,   0, 
++      0,   0,  54,   0,   0,   5, 
++    242,  32,  16,   0,   5,   0, 
++      0,   0,  70,  30,  16,   0, 
++      1,   0,   0,   0,  54,   0, 
++      0,   5, 242,  32,  16,   0, 
++      6,   0,   0,   0,  70,  30, 
++     16,   0,   1,   0,   0,   0, 
++     54,   0,   0,   5, 242,  32, 
++     16,   0,   7,   0,   0,   0, 
++     70,  30,  16,   0,   1,   0, 
++      0,   0,  62,   0,   0,   1, 
++     83,  84,  65,  84, 116,   0, 
++      0,   0,   9,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   9,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      8,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0
++};
+diff --git a/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/clearsint11vs.h b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/clearsint11vs.h
+new file mode 100644
+index 00000000..3d3b7014
+--- /dev/null
++++ b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/clearsint11vs.h
+@@ -0,0 +1,128 @@
++#if 0
++//
++// Generated by Microsoft (R) HLSL Shader Compiler 10.1
++//
++//
++//
++// Input signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// POSITION                 0   xyz         0     NONE   float   xyz 
++// COLOR                    0   xyzw        1     NONE     int   xyzw
++//
++//
++// Output signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_POSITION              0   xyzw        0      POS   float   xyzw
++// COLOR                    0   xyzw        1     NONE     int   xyzw
++//
++vs_4_0
++dcl_input v0.xyz
++dcl_input v1.xyzw
++dcl_output_siv o0.xyzw, position
++dcl_output o1.xyzw
++mov o0.xyz, v0.xyzx
++mov o0.w, l(1.000000)
++mov o1.xyzw, v1.xyzw
++ret 
++// Approximately 4 instruction slots used
++#endif
++
++const BYTE g_VS_ClearSint[] =
++{
++     68,  88,  66,  67,  54,  47, 
++    169, 242, 175,  43, 113, 236, 
++    198, 100, 114, 197, 140, 253, 
++    169, 194,   1,   0,   0,   0, 
++     36,   2,   0,   0,   5,   0, 
++      0,   0,  52,   0,   0,   0, 
++    128,   0,   0,   0, 208,   0, 
++      0,   0,  36,   1,   0,   0, 
++    168,   1,   0,   0,  82,  68, 
++     69,  70,  68,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++     28,   0,   0,   0,   0,   4, 
++    254, 255,   0,   1,   0,   0, 
++     28,   0,   0,   0,  77, 105, 
++     99, 114, 111, 115, 111, 102, 
++    116,  32,  40,  82,  41,  32, 
++     72,  76,  83,  76,  32,  83, 
++    104,  97, 100, 101, 114,  32, 
++     67, 111, 109, 112, 105, 108, 
++    101, 114,  32,  49,  48,  46, 
++     49,   0,  73,  83,  71,  78, 
++     72,   0,   0,   0,   2,   0, 
++      0,   0,   8,   0,   0,   0, 
++     56,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      3,   0,   0,   0,   0,   0, 
++      0,   0,   7,   7,   0,   0, 
++     65,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      2,   0,   0,   0,   1,   0, 
++      0,   0,  15,  15,   0,   0, 
++     80,  79,  83,  73,  84,  73, 
++     79,  78,   0,  67,  79,  76, 
++     79,  82,   0, 171,  79,  83, 
++     71,  78,  76,   0,   0,   0, 
++      2,   0,   0,   0,   8,   0, 
++      0,   0,  56,   0,   0,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,   3,   0,   0,   0, 
++      0,   0,   0,   0,  15,   0, 
++      0,   0,  68,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   2,   0,   0,   0, 
++      1,   0,   0,   0,  15,   0, 
++      0,   0,  83,  86,  95,  80, 
++     79,  83,  73,  84,  73,  79, 
++     78,   0,  67,  79,  76,  79, 
++     82,   0, 171, 171,  83,  72, 
++     68,  82, 124,   0,   0,   0, 
++     64,   0,   1,   0,  31,   0, 
++      0,   0,  95,   0,   0,   3, 
++    114,  16,  16,   0,   0,   0, 
++      0,   0,  95,   0,   0,   3, 
++    242,  16,  16,   0,   1,   0, 
++      0,   0, 103,   0,   0,   4, 
++    242,  32,  16,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++    101,   0,   0,   3, 242,  32, 
++     16,   0,   1,   0,   0,   0, 
++     54,   0,   0,   5, 114,  32, 
++     16,   0,   0,   0,   0,   0, 
++     70,  18,  16,   0,   0,   0, 
++      0,   0,  54,   0,   0,   5, 
++    130,  32,  16,   0,   0,   0, 
++      0,   0,   1,  64,   0,   0, 
++      0,   0, 128,  63,  54,   0, 
++      0,   5, 242,  32,  16,   0, 
++      1,   0,   0,   0,  70,  30, 
++     16,   0,   1,   0,   0,   0, 
++     62,   0,   0,   1,  83,  84, 
++     65,  84, 116,   0,   0,   0, 
++      4,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      4,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   3,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0
++};
+diff --git a/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/clearuint11ps.h b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/clearuint11ps.h
+new file mode 100644
+index 00000000..77315299
+--- /dev/null
++++ b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/clearuint11ps.h
+@@ -0,0 +1,193 @@
++#if 0
++//
++// Generated by Microsoft (R) HLSL Shader Compiler 10.1
++//
++//
++//
++// Input signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_POSITION              0   xyzw        0      POS   float       
++// COLOR                    0   xyzw        1     NONE    uint   xyzw
++//
++//
++// Output signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_TARGET                0   xyzw        0   TARGET    uint   xyzw
++// SV_TARGET                1   xyzw        1   TARGET    uint   xyzw
++// SV_TARGET                2   xyzw        2   TARGET    uint   xyzw
++// SV_TARGET                3   xyzw        3   TARGET    uint   xyzw
++// SV_TARGET                4   xyzw        4   TARGET    uint   xyzw
++// SV_TARGET                5   xyzw        5   TARGET    uint   xyzw
++// SV_TARGET                6   xyzw        6   TARGET    uint   xyzw
++// SV_TARGET                7   xyzw        7   TARGET    uint   xyzw
++//
++ps_4_0
++dcl_input_ps constant v1.xyzw
++dcl_output o0.xyzw
++dcl_output o1.xyzw
++dcl_output o2.xyzw
++dcl_output o3.xyzw
++dcl_output o4.xyzw
++dcl_output o5.xyzw
++dcl_output o6.xyzw
++dcl_output o7.xyzw
++mov o0.xyzw, v1.xyzw
++mov o1.xyzw, v1.xyzw
++mov o2.xyzw, v1.xyzw
++mov o3.xyzw, v1.xyzw
++mov o4.xyzw, v1.xyzw
++mov o5.xyzw, v1.xyzw
++mov o6.xyzw, v1.xyzw
++mov o7.xyzw, v1.xyzw
++ret 
++// Approximately 9 instruction slots used
++#endif
++
++const BYTE g_PS_ClearUint[] =
++{
++     68,  88,  66,  67,  85, 227, 
++    173, 103, 229, 166, 129, 112, 
++     83, 255, 231, 138, 235, 111, 
++     90, 200,   1,   0,   0,   0, 
++     76,   3,   0,   0,   5,   0, 
++      0,   0,  52,   0,   0,   0, 
++    128,   0,   0,   0, 212,   0, 
++      0,   0, 176,   1,   0,   0, 
++    208,   2,   0,   0,  82,  68, 
++     69,  70,  68,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++     28,   0,   0,   0,   0,   4, 
++    255, 255,   0,   1,   0,   0, 
++     28,   0,   0,   0,  77, 105, 
++     99, 114, 111, 115, 111, 102, 
++    116,  32,  40,  82,  41,  32, 
++     72,  76,  83,  76,  32,  83, 
++    104,  97, 100, 101, 114,  32, 
++     67, 111, 109, 112, 105, 108, 
++    101, 114,  32,  49,  48,  46, 
++     49,   0,  73,  83,  71,  78, 
++     76,   0,   0,   0,   2,   0, 
++      0,   0,   8,   0,   0,   0, 
++     56,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++      3,   0,   0,   0,   0,   0, 
++      0,   0,  15,   0,   0,   0, 
++     68,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0,   1,   0, 
++      0,   0,  15,  15,   0,   0, 
++     83,  86,  95,  80,  79,  83, 
++     73,  84,  73,  79,  78,   0, 
++     67,  79,  76,  79,  82,   0, 
++    171, 171,  79,  83,  71,  78, 
++    212,   0,   0,   0,   8,   0, 
++      0,   0,   8,   0,   0,   0, 
++    200,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0,  15,   0,   0,   0, 
++    200,   0,   0,   0,   1,   0, 
++      0,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0,   1,   0, 
++      0,   0,  15,   0,   0,   0, 
++    200,   0,   0,   0,   2,   0, 
++      0,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0,   2,   0, 
++      0,   0,  15,   0,   0,   0, 
++    200,   0,   0,   0,   3,   0, 
++      0,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0,   3,   0, 
++      0,   0,  15,   0,   0,   0, 
++    200,   0,   0,   0,   4,   0, 
++      0,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0,   4,   0, 
++      0,   0,  15,   0,   0,   0, 
++    200,   0,   0,   0,   5,   0, 
++      0,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0,   5,   0, 
++      0,   0,  15,   0,   0,   0, 
++    200,   0,   0,   0,   6,   0, 
++      0,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0,   6,   0, 
++      0,   0,  15,   0,   0,   0, 
++    200,   0,   0,   0,   7,   0, 
++      0,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0,   7,   0, 
++      0,   0,  15,   0,   0,   0, 
++     83,  86,  95,  84,  65,  82, 
++     71,  69,  84,   0, 171, 171, 
++     83,  72,  68,  82,  24,   1, 
++      0,   0,  64,   0,   0,   0, 
++     70,   0,   0,   0,  98,   8, 
++      0,   3, 242,  16,  16,   0, 
++      1,   0,   0,   0, 101,   0, 
++      0,   3, 242,  32,  16,   0, 
++      0,   0,   0,   0, 101,   0, 
++      0,   3, 242,  32,  16,   0, 
++      1,   0,   0,   0, 101,   0, 
++      0,   3, 242,  32,  16,   0, 
++      2,   0,   0,   0, 101,   0, 
++      0,   3, 242,  32,  16,   0, 
++      3,   0,   0,   0, 101,   0, 
++      0,   3, 242,  32,  16,   0, 
++      4,   0,   0,   0, 101,   0, 
++      0,   3, 242,  32,  16,   0, 
++      5,   0,   0,   0, 101,   0, 
++      0,   3, 242,  32,  16,   0, 
++      6,   0,   0,   0, 101,   0, 
++      0,   3, 242,  32,  16,   0, 
++      7,   0,   0,   0,  54,   0, 
++      0,   5, 242,  32,  16,   0, 
++      0,   0,   0,   0,  70,  30, 
++     16,   0,   1,   0,   0,   0, 
++     54,   0,   0,   5, 242,  32, 
++     16,   0,   1,   0,   0,   0, 
++     70,  30,  16,   0,   1,   0, 
++      0,   0,  54,   0,   0,   5, 
++    242,  32,  16,   0,   2,   0, 
++      0,   0,  70,  30,  16,   0, 
++      1,   0,   0,   0,  54,   0, 
++      0,   5, 242,  32,  16,   0, 
++      3,   0,   0,   0,  70,  30, 
++     16,   0,   1,   0,   0,   0, 
++     54,   0,   0,   5, 242,  32, 
++     16,   0,   4,   0,   0,   0, 
++     70,  30,  16,   0,   1,   0, 
++      0,   0,  54,   0,   0,   5, 
++    242,  32,  16,   0,   5,   0, 
++      0,   0,  70,  30,  16,   0, 
++      1,   0,   0,   0,  54,   0, 
++      0,   5, 242,  32,  16,   0, 
++      6,   0,   0,   0,  70,  30, 
++     16,   0,   1,   0,   0,   0, 
++     54,   0,   0,   5, 242,  32, 
++     16,   0,   7,   0,   0,   0, 
++     70,  30,  16,   0,   1,   0, 
++      0,   0,  62,   0,   0,   1, 
++     83,  84,  65,  84, 116,   0, 
++      0,   0,   9,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   9,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      8,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0
++};
+diff --git a/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/clearuint11vs.h b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/clearuint11vs.h
+new file mode 100644
+index 00000000..2f46504c
+--- /dev/null
++++ b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/clearuint11vs.h
+@@ -0,0 +1,128 @@
++#if 0
++//
++// Generated by Microsoft (R) HLSL Shader Compiler 10.1
++//
++//
++//
++// Input signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// POSITION                 0   xyz         0     NONE   float   xyz 
++// COLOR                    0   xyzw        1     NONE    uint   xyzw
++//
++//
++// Output signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_POSITION              0   xyzw        0      POS   float   xyzw
++// COLOR                    0   xyzw        1     NONE    uint   xyzw
++//
++vs_4_0
++dcl_input v0.xyz
++dcl_input v1.xyzw
++dcl_output_siv o0.xyzw, position
++dcl_output o1.xyzw
++mov o0.xyz, v0.xyzx
++mov o0.w, l(1.000000)
++mov o1.xyzw, v1.xyzw
++ret 
++// Approximately 4 instruction slots used
++#endif
++
++const BYTE g_VS_ClearUint[] =
++{
++     68,  88,  66,  67,  49, 153, 
++    143,  25, 205, 216, 250, 117, 
++    205, 234, 248, 237, 154,  18, 
++    110,  72,   1,   0,   0,   0, 
++     36,   2,   0,   0,   5,   0, 
++      0,   0,  52,   0,   0,   0, 
++    128,   0,   0,   0, 208,   0, 
++      0,   0,  36,   1,   0,   0, 
++    168,   1,   0,   0,  82,  68, 
++     69,  70,  68,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++     28,   0,   0,   0,   0,   4, 
++    254, 255,   0,   1,   0,   0, 
++     28,   0,   0,   0,  77, 105, 
++     99, 114, 111, 115, 111, 102, 
++    116,  32,  40,  82,  41,  32, 
++     72,  76,  83,  76,  32,  83, 
++    104,  97, 100, 101, 114,  32, 
++     67, 111, 109, 112, 105, 108, 
++    101, 114,  32,  49,  48,  46, 
++     49,   0,  73,  83,  71,  78, 
++     72,   0,   0,   0,   2,   0, 
++      0,   0,   8,   0,   0,   0, 
++     56,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      3,   0,   0,   0,   0,   0, 
++      0,   0,   7,   7,   0,   0, 
++     65,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0,   1,   0, 
++      0,   0,  15,  15,   0,   0, 
++     80,  79,  83,  73,  84,  73, 
++     79,  78,   0,  67,  79,  76, 
++     79,  82,   0, 171,  79,  83, 
++     71,  78,  76,   0,   0,   0, 
++      2,   0,   0,   0,   8,   0, 
++      0,   0,  56,   0,   0,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,   3,   0,   0,   0, 
++      0,   0,   0,   0,  15,   0, 
++      0,   0,  68,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++      1,   0,   0,   0,  15,   0, 
++      0,   0,  83,  86,  95,  80, 
++     79,  83,  73,  84,  73,  79, 
++     78,   0,  67,  79,  76,  79, 
++     82,   0, 171, 171,  83,  72, 
++     68,  82, 124,   0,   0,   0, 
++     64,   0,   1,   0,  31,   0, 
++      0,   0,  95,   0,   0,   3, 
++    114,  16,  16,   0,   0,   0, 
++      0,   0,  95,   0,   0,   3, 
++    242,  16,  16,   0,   1,   0, 
++      0,   0, 103,   0,   0,   4, 
++    242,  32,  16,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++    101,   0,   0,   3, 242,  32, 
++     16,   0,   1,   0,   0,   0, 
++     54,   0,   0,   5, 114,  32, 
++     16,   0,   0,   0,   0,   0, 
++     70,  18,  16,   0,   0,   0, 
++      0,   0,  54,   0,   0,   5, 
++    130,  32,  16,   0,   0,   0, 
++      0,   0,   1,  64,   0,   0, 
++      0,   0, 128,  63,  54,   0, 
++      0,   5, 242,  32,  16,   0, 
++      1,   0,   0,   0,  70,  30, 
++     16,   0,   1,   0,   0,   0, 
++     62,   0,   0,   1,  83,  84, 
++     65,  84, 116,   0,   0,   0, 
++      4,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      4,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   3,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0
++};
+diff --git a/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthrough2d11vs.h b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthrough2d11vs.h
+new file mode 100644
+index 00000000..eeed6a4e
+--- /dev/null
++++ b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthrough2d11vs.h
+@@ -0,0 +1,175 @@
++#if 0
++//
++// Generated by Microsoft (R) HLSL Shader Compiler 10.1
++//
++//
++//
++// Input signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// POSITION                 0   xy          0     NONE   float   xy  
++// TEXCOORD                 0   xy          1     NONE   float   xy  
++//
++//
++// Output signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_POSITION              0   xyzw        0      POS   float   xyzw
++// TEXCOORD                 0   xy          1     NONE   float   xy  
++//
++//
++// Runtime generated constant mappings:
++//
++// Target Reg                               Constant Description
++// ---------- --------------------------------------------------
++// c0                              Vertex Shader position offset
++//
++//
++// Level9 shader bytecode:
++//
++    vs_2_x
++    def c1, 0, 1, 0, 0
++    dcl_texcoord v0
++    dcl_texcoord1 v1
++    add oPos.xy, v0, c0
++    mov oPos.zw, c1.xyxy
++    mov oT0.xy, v1
++
++// approximately 3 instruction slots used
++vs_4_0
++dcl_input v0.xy
++dcl_input v1.xy
++dcl_output_siv o0.xyzw, position
++dcl_output o1.xy
++mov o0.xy, v0.xyxx
++mov o0.zw, l(0,0,0,1.000000)
++mov o1.xy, v1.xyxx
++ret 
++// Approximately 4 instruction slots used
++#endif
++
++const BYTE g_VS_Passthrough2D[] =
++{
++     68,  88,  66,  67, 157, 119, 
++    222, 216,  39, 186, 195,  24, 
++    174, 138,  22,  73, 223, 185, 
++    107,  36,   1,   0,   0,   0, 
++    204,   2,   0,   0,   6,   0, 
++      0,   0,  56,   0,   0,   0, 
++    200,   0,   0,   0,  88,   1, 
++      0,   0, 212,   1,   0,   0, 
++     32,   2,   0,   0, 116,   2, 
++      0,   0,  65, 111, 110,  57, 
++    136,   0,   0,   0, 136,   0, 
++      0,   0,   0,   2, 254, 255, 
++     96,   0,   0,   0,  40,   0, 
++      0,   0,   0,   0,  36,   0, 
++      0,   0,  36,   0,   0,   0, 
++     36,   0,   0,   0,  36,   0, 
++      1,   0,  36,   0,   0,   0, 
++      0,   0,   1,   2, 254, 255, 
++     81,   0,   0,   5,   1,   0, 
++     15, 160,   0,   0,   0,   0, 
++      0,   0, 128,  63,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++     31,   0,   0,   2,   5,   0, 
++      0, 128,   0,   0,  15, 144, 
++     31,   0,   0,   2,   5,   0, 
++      1, 128,   1,   0,  15, 144, 
++      2,   0,   0,   3,   0,   0, 
++      3, 192,   0,   0, 228, 144, 
++      0,   0, 228, 160,   1,   0, 
++      0,   2,   0,   0,  12, 192, 
++      1,   0,  68, 160,   1,   0, 
++      0,   2,   0,   0,   3, 224, 
++      1,   0, 228, 144, 255, 255, 
++      0,   0,  83,  72,  68,  82, 
++    136,   0,   0,   0,  64,   0, 
++      1,   0,  34,   0,   0,   0, 
++     95,   0,   0,   3,  50,  16, 
++     16,   0,   0,   0,   0,   0, 
++     95,   0,   0,   3,  50,  16, 
++     16,   0,   1,   0,   0,   0, 
++    103,   0,   0,   4, 242,  32, 
++     16,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0, 101,   0, 
++      0,   3,  50,  32,  16,   0, 
++      1,   0,   0,   0,  54,   0, 
++      0,   5,  50,  32,  16,   0, 
++      0,   0,   0,   0,  70,  16, 
++     16,   0,   0,   0,   0,   0, 
++     54,   0,   0,   8, 194,  32, 
++     16,   0,   0,   0,   0,   0, 
++      2,  64,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++    128,  63,  54,   0,   0,   5, 
++     50,  32,  16,   0,   1,   0, 
++      0,   0,  70,  16,  16,   0, 
++      1,   0,   0,   0,  62,   0, 
++      0,   1,  83,  84,  65,  84, 
++    116,   0,   0,   0,   4,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   4,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   3,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++     82,  68,  69,  70,  68,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,  28,   0,   0,   0, 
++      0,   4, 254, 255,   0,   1, 
++      0,   0,  28,   0,   0,   0, 
++     77, 105,  99, 114, 111, 115, 
++    111, 102, 116,  32,  40,  82, 
++     41,  32,  72,  76,  83,  76, 
++     32,  83, 104,  97, 100, 101, 
++    114,  32,  67, 111, 109, 112, 
++    105, 108, 101, 114,  32,  49, 
++     48,  46,  49,   0,  73,  83, 
++     71,  78,  76,   0,   0,   0, 
++      2,   0,   0,   0,   8,   0, 
++      0,   0,  56,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   3,   0,   0,   0, 
++      0,   0,   0,   0,   3,   3, 
++      0,   0,  65,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   3,   0,   0,   0, 
++      1,   0,   0,   0,   3,   3, 
++      0,   0,  80,  79,  83,  73, 
++     84,  73,  79,  78,   0,  84, 
++     69,  88,  67,  79,  79,  82, 
++     68,   0, 171, 171,  79,  83, 
++     71,  78,  80,   0,   0,   0, 
++      2,   0,   0,   0,   8,   0, 
++      0,   0,  56,   0,   0,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,   3,   0,   0,   0, 
++      0,   0,   0,   0,  15,   0, 
++      0,   0,  68,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   3,   0,   0,   0, 
++      1,   0,   0,   0,   3,  12, 
++      0,   0,  83,  86,  95,  80, 
++     79,  83,  73,  84,  73,  79, 
++     78,   0,  84,  69,  88,  67, 
++     79,  79,  82,  68,   0, 171, 
++    171, 171
++};
+diff --git a/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthrough3d11gs.h b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthrough3d11gs.h
+new file mode 100644
+index 00000000..5f6f062a
+--- /dev/null
++++ b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthrough3d11gs.h
+@@ -0,0 +1,189 @@
++#if 0
++//
++// Generated by Microsoft (R) HLSL Shader Compiler 10.1
++//
++//
++//
++// Input signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_POSITION              0   xyzw        0      POS   float   xyzw
++// LAYER                    0   x           1     NONE    uint   x   
++// TEXCOORD                 0   xyz         2     NONE   float   xyz 
++//
++//
++// Output signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_POSITION              0   xyzw        0      POS   float   xyzw
++// SV_RENDERTARGETARRAYINDEX     0   x           1  RTINDEX    uint   x   
++// TEXCOORD                 0   xyz         2     NONE   float   xyz 
++//
++gs_4_0
++dcl_input_siv v[3][0].xyzw, position
++dcl_input v[3][1].x
++dcl_input v[3][2].xyz
++dcl_temps 1
++dcl_inputprimitive triangle 
++dcl_outputtopology trianglestrip 
++dcl_output_siv o0.xyzw, position
++dcl_output_siv o1.x, rendertarget_array_index
++dcl_output o2.xyz
++dcl_maxout 3
++mov r0.x, l(0)
++loop 
++  ige r0.y, r0.x, l(3)
++  breakc_nz r0.y
++  mov o0.xyzw, v[r0.x + 0][0].xyzw
++  mov o1.x, v[r0.x + 0][1].x
++  mov o2.xyz, v[r0.x + 0][2].xyzx
++  emit 
++  iadd r0.x, r0.x, l(1)
++endloop 
++ret 
++// Approximately 11 instruction slots used
++#endif
++
++const BYTE g_GS_Passthrough3D[] =
++{
++     68,  88,  66,  67, 226, 188, 
++    145,  36, 193,  19, 254,   1, 
++    249,  51, 174,  53,  33,  65, 
++    233,  89,   1,   0,   0,   0, 
++     60,   3,   0,   0,   5,   0, 
++      0,   0,  52,   0,   0,   0, 
++    128,   0,   0,   0, 244,   0, 
++      0,   0, 124,   1,   0,   0, 
++    192,   2,   0,   0,  82,  68, 
++     69,  70,  68,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++     28,   0,   0,   0,   0,   4, 
++     83,  71,   0,   1,   0,   0, 
++     28,   0,   0,   0,  77, 105, 
++     99, 114, 111, 115, 111, 102, 
++    116,  32,  40,  82,  41,  32, 
++     72,  76,  83,  76,  32,  83, 
++    104,  97, 100, 101, 114,  32, 
++     67, 111, 109, 112, 105, 108, 
++    101, 114,  32,  49,  48,  46, 
++     49,   0,  73,  83,  71,  78, 
++    108,   0,   0,   0,   3,   0, 
++      0,   0,   8,   0,   0,   0, 
++     80,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++      3,   0,   0,   0,   0,   0, 
++      0,   0,  15,  15,   0,   0, 
++     92,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0,   1,   0, 
++      0,   0,   1,   1,   0,   0, 
++     98,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      3,   0,   0,   0,   2,   0, 
++      0,   0,   7,   7,   0,   0, 
++     83,  86,  95,  80,  79,  83, 
++     73,  84,  73,  79,  78,   0, 
++     76,  65,  89,  69,  82,   0, 
++     84,  69,  88,  67,  79,  79, 
++     82,  68,   0, 171,  79,  83, 
++     71,  78, 128,   0,   0,   0, 
++      3,   0,   0,   0,   8,   0, 
++      0,   0,  80,   0,   0,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,   3,   0,   0,   0, 
++      0,   0,   0,   0,  15,   0, 
++      0,   0,  92,   0,   0,   0, 
++      0,   0,   0,   0,   4,   0, 
++      0,   0,   1,   0,   0,   0, 
++      1,   0,   0,   0,   1,  14, 
++      0,   0, 118,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   3,   0,   0,   0, 
++      2,   0,   0,   0,   7,   8, 
++      0,   0,  83,  86,  95,  80, 
++     79,  83,  73,  84,  73,  79, 
++     78,   0,  83,  86,  95,  82, 
++     69,  78,  68,  69,  82,  84, 
++     65,  82,  71,  69,  84,  65, 
++     82,  82,  65,  89,  73,  78, 
++     68,  69,  88,   0,  84,  69, 
++     88,  67,  79,  79,  82,  68, 
++      0, 171,  83,  72,  68,  82, 
++     60,   1,   0,   0,  64,   0, 
++      2,   0,  79,   0,   0,   0, 
++     97,   0,   0,   5, 242,  16, 
++     32,   0,   3,   0,   0,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,  95,   0,   0,   4, 
++     18,  16,  32,   0,   3,   0, 
++      0,   0,   1,   0,   0,   0, 
++     95,   0,   0,   4, 114,  16, 
++     32,   0,   3,   0,   0,   0, 
++      2,   0,   0,   0, 104,   0, 
++      0,   2,   1,   0,   0,   0, 
++     93,  24,   0,   1,  92,  40, 
++      0,   1, 103,   0,   0,   4, 
++    242,  32,  16,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++    103,   0,   0,   4,  18,  32, 
++     16,   0,   1,   0,   0,   0, 
++      4,   0,   0,   0, 101,   0, 
++      0,   3, 114,  32,  16,   0, 
++      2,   0,   0,   0,  94,   0, 
++      0,   2,   3,   0,   0,   0, 
++     54,   0,   0,   5,  18,   0, 
++     16,   0,   0,   0,   0,   0, 
++      1,  64,   0,   0,   0,   0, 
++      0,   0,  48,   0,   0,   1, 
++     33,   0,   0,   7,  34,   0, 
++     16,   0,   0,   0,   0,   0, 
++     10,   0,  16,   0,   0,   0, 
++      0,   0,   1,  64,   0,   0, 
++      3,   0,   0,   0,   3,   0, 
++      4,   3,  26,   0,  16,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   7, 242,  32,  16,   0, 
++      0,   0,   0,   0,  70,  30, 
++    160,   0,  10,   0,  16,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,  54,   0,   0,   7, 
++     18,  32,  16,   0,   1,   0, 
++      0,   0,  10,  16, 160,   0, 
++     10,   0,  16,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++     54,   0,   0,   7, 114,  32, 
++     16,   0,   2,   0,   0,   0, 
++     70,  18, 160,   0,  10,   0, 
++     16,   0,   0,   0,   0,   0, 
++      2,   0,   0,   0,  19,   0, 
++      0,   1,  30,   0,   0,   7, 
++     18,   0,  16,   0,   0,   0, 
++      0,   0,  10,   0,  16,   0, 
++      0,   0,   0,   0,   1,  64, 
++      0,   0,   1,   0,   0,   0, 
++     22,   0,   0,   1,  62,   0, 
++      0,   1,  83,  84,  65,  84, 
++    116,   0,   0,   0,  11,   0, 
++      0,   0,   1,   0,   0,   0, 
++      0,   0,   0,   0,   6,   0, 
++      0,   0,   0,   0,   0,   0, 
++      2,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      3,   0,   0,   0,   5,   0, 
++      0,   0,   3,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0
++};
+diff --git a/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthrough3d11vs.h b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthrough3d11vs.h
+new file mode 100644
+index 00000000..fba838d3
+--- /dev/null
++++ b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthrough3d11vs.h
+@@ -0,0 +1,153 @@
++#if 0
++//
++// Generated by Microsoft (R) HLSL Shader Compiler 10.1
++//
++//
++//
++// Input signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// POSITION                 0   xy          0     NONE   float   xy  
++// LAYER                    0   x           1     NONE    uint   x   
++// TEXCOORD                 0   xyz         2     NONE   float   xyz 
++//
++//
++// Output signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_POSITION              0   xyzw        0      POS   float   xyzw
++// LAYER                    0   x           1     NONE    uint   x   
++// TEXCOORD                 0   xyz         2     NONE   float   xyz 
++//
++vs_4_0
++dcl_input v0.xy
++dcl_input v1.x
++dcl_input v2.xyz
++dcl_output_siv o0.xyzw, position
++dcl_output o1.x
++dcl_output o2.xyz
++mov o0.xy, v0.xyxx
++mov o0.zw, l(0,0,0,1.000000)
++mov o1.x, v1.x
++mov o2.xyz, v2.xyzx
++ret 
++// Approximately 5 instruction slots used
++#endif
++
++const BYTE g_VS_Passthrough3D[] =
++{
++     68,  88,  66,  67, 136, 150, 
++    103, 162, 167, 195, 182, 112, 
++    150,  17,  18,  65,  73, 164, 
++     12, 142,   1,   0,   0,   0, 
++    156,   2,   0,   0,   5,   0, 
++      0,   0,  52,   0,   0,   0, 
++    128,   0,   0,   0, 240,   0, 
++      0,   0, 100,   1,   0,   0, 
++     32,   2,   0,   0,  82,  68, 
++     69,  70,  68,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++     28,   0,   0,   0,   0,   4, 
++    254, 255,   0,   1,   0,   0, 
++     28,   0,   0,   0,  77, 105, 
++     99, 114, 111, 115, 111, 102, 
++    116,  32,  40,  82,  41,  32, 
++     72,  76,  83,  76,  32,  83, 
++    104,  97, 100, 101, 114,  32, 
++     67, 111, 109, 112, 105, 108, 
++    101, 114,  32,  49,  48,  46, 
++     49,   0,  73,  83,  71,  78, 
++    104,   0,   0,   0,   3,   0, 
++      0,   0,   8,   0,   0,   0, 
++     80,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      3,   0,   0,   0,   0,   0, 
++      0,   0,   3,   3,   0,   0, 
++     89,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0,   1,   0, 
++      0,   0,   1,   1,   0,   0, 
++     95,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      3,   0,   0,   0,   2,   0, 
++      0,   0,   7,   7,   0,   0, 
++     80,  79,  83,  73,  84,  73, 
++     79,  78,   0,  76,  65,  89, 
++     69,  82,   0,  84,  69,  88, 
++     67,  79,  79,  82,  68,   0, 
++     79,  83,  71,  78, 108,   0, 
++      0,   0,   3,   0,   0,   0, 
++      8,   0,   0,   0,  80,   0, 
++      0,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0,   3,   0, 
++      0,   0,   0,   0,   0,   0, 
++     15,   0,   0,   0,  92,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,   1,   0,   0,   0, 
++      1,  14,   0,   0,  98,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   3,   0, 
++      0,   0,   2,   0,   0,   0, 
++      7,   8,   0,   0,  83,  86, 
++     95,  80,  79,  83,  73,  84, 
++     73,  79,  78,   0,  76,  65, 
++     89,  69,  82,   0,  84,  69, 
++     88,  67,  79,  79,  82,  68, 
++      0, 171,  83,  72,  68,  82, 
++    180,   0,   0,   0,  64,   0, 
++      1,   0,  45,   0,   0,   0, 
++     95,   0,   0,   3,  50,  16, 
++     16,   0,   0,   0,   0,   0, 
++     95,   0,   0,   3,  18,  16, 
++     16,   0,   1,   0,   0,   0, 
++     95,   0,   0,   3, 114,  16, 
++     16,   0,   2,   0,   0,   0, 
++    103,   0,   0,   4, 242,  32, 
++     16,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0, 101,   0, 
++      0,   3,  18,  32,  16,   0, 
++      1,   0,   0,   0, 101,   0, 
++      0,   3, 114,  32,  16,   0, 
++      2,   0,   0,   0,  54,   0, 
++      0,   5,  50,  32,  16,   0, 
++      0,   0,   0,   0,  70,  16, 
++     16,   0,   0,   0,   0,   0, 
++     54,   0,   0,   8, 194,  32, 
++     16,   0,   0,   0,   0,   0, 
++      2,  64,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++    128,  63,  54,   0,   0,   5, 
++     18,  32,  16,   0,   1,   0, 
++      0,   0,  10,  16,  16,   0, 
++      1,   0,   0,   0,  54,   0, 
++      0,   5, 114,  32,  16,   0, 
++      2,   0,   0,   0,  70,  18, 
++     16,   0,   2,   0,   0,   0, 
++     62,   0,   0,   1,  83,  84, 
++     65,  84, 116,   0,   0,   0, 
++      5,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      6,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   4,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0
++};
+diff --git a/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughdepth2d11ps.h b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughdepth2d11ps.h
+new file mode 100644
+index 00000000..6596e988
+--- /dev/null
++++ b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughdepth2d11ps.h
+@@ -0,0 +1,144 @@
++#if 0
++//
++// Generated by Microsoft (R) HLSL Shader Compiler 10.1
++//
++//
++// Resource Bindings:
++//
++// Name                                 Type  Format         Dim      HLSL Bind  Count
++// ------------------------------ ---------- ------- ----------- -------------- ------
++// Sampler                           sampler      NA          NA             s0      1 
++// TextureF                          texture  float4          2d             t0      1 
++//
++//
++//
++// Input signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_POSITION              0   xyzw        0      POS   float       
++// TEXCOORD                 0   xy          1     NONE   float   xy  
++//
++//
++// Output signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_DEPTH                 0    N/A   oDepth    DEPTH   float    YES
++//
++ps_4_0
++dcl_sampler s0, mode_default
++dcl_resource_texture2d (float,float,float,float) t0
++dcl_input_ps linear v1.xy
++dcl_output oDepth
++dcl_temps 1
++sample r0.xyzw, v1.xyxx, t0.xyzw, s0
++mov oDepth, r0.x
++ret 
++// Approximately 3 instruction slots used
++#endif
++
++const BYTE g_PS_PassthroughDepth2D[] =
++{
++     68,  88,  66,  67, 215, 216, 
++    149,  20, 177,  67, 115, 222, 
++      9, 179, 226,  21,  58, 197, 
++    172, 136,   1,   0,   0,   0, 
++     92,   2,   0,   0,   5,   0, 
++      0,   0,  52,   0,   0,   0, 
++    212,   0,   0,   0,  44,   1, 
++      0,   0,  96,   1,   0,   0, 
++    224,   1,   0,   0,  82,  68, 
++     69,  70, 152,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   2,   0,   0,   0, 
++     28,   0,   0,   0,   0,   4, 
++    255, 255,   0,   1,   0,   0, 
++    109,   0,   0,   0,  92,   0, 
++      0,   0,   3,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,   1,   0,   0,   0, 
++    100,   0,   0,   0,   2,   0, 
++      0,   0,   5,   0,   0,   0, 
++      4,   0,   0,   0, 255, 255, 
++    255, 255,   0,   0,   0,   0, 
++      1,   0,   0,   0,  13,   0, 
++      0,   0,  83,  97, 109, 112, 
++    108, 101, 114,   0,  84, 101, 
++    120, 116, 117, 114, 101,  70, 
++      0,  77, 105,  99, 114, 111, 
++    115, 111, 102, 116,  32,  40, 
++     82,  41,  32,  72,  76,  83, 
++     76,  32,  83, 104,  97, 100, 
++    101, 114,  32,  67, 111, 109, 
++    112, 105, 108, 101, 114,  32, 
++     49,  48,  46,  49,   0, 171, 
++    171, 171,  73,  83,  71,  78, 
++     80,   0,   0,   0,   2,   0, 
++      0,   0,   8,   0,   0,   0, 
++     56,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++      3,   0,   0,   0,   0,   0, 
++      0,   0,  15,   0,   0,   0, 
++     68,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      3,   0,   0,   0,   1,   0, 
++      0,   0,   3,   3,   0,   0, 
++     83,  86,  95,  80,  79,  83, 
++     73,  84,  73,  79,  78,   0, 
++     84,  69,  88,  67,  79,  79, 
++     82,  68,   0, 171, 171, 171, 
++     79,  83,  71,  78,  44,   0, 
++      0,   0,   1,   0,   0,   0, 
++      8,   0,   0,   0,  32,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   3,   0, 
++      0,   0, 255, 255, 255, 255, 
++      1,  14,   0,   0,  83,  86, 
++     95,  68,  69,  80,  84,  72, 
++      0, 171, 171, 171,  83,  72, 
++     68,  82, 120,   0,   0,   0, 
++     64,   0,   0,   0,  30,   0, 
++      0,   0,  90,   0,   0,   3, 
++      0,  96,  16,   0,   0,   0, 
++      0,   0,  88,  24,   0,   4, 
++      0, 112,  16,   0,   0,   0, 
++      0,   0,  85,  85,   0,   0, 
++     98,  16,   0,   3,  50,  16, 
++     16,   0,   1,   0,   0,   0, 
++    101,   0,   0,   2,   1, 192, 
++      0,   0, 104,   0,   0,   2, 
++      1,   0,   0,   0,  69,   0, 
++      0,   9, 242,   0,  16,   0, 
++      0,   0,   0,   0,  70,  16, 
++     16,   0,   1,   0,   0,   0, 
++     70, 126,  16,   0,   0,   0, 
++      0,   0,   0,  96,  16,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   4,   1, 192,   0,   0, 
++     10,   0,  16,   0,   0,   0, 
++      0,   0,  62,   0,   0,   1, 
++     83,  84,  65,  84, 116,   0, 
++      0,   0,   3,   0,   0,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0,   2,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0
++};
+diff --git a/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughlum2d11ps.h b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughlum2d11ps.h
+new file mode 100644
+index 00000000..5a1b489e
+--- /dev/null
++++ b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughlum2d11ps.h
+@@ -0,0 +1,195 @@
++#if 0
++//
++// Generated by Microsoft (R) HLSL Shader Compiler 10.1
++//
++//
++// Resource Bindings:
++//
++// Name                                 Type  Format         Dim      HLSL Bind  Count
++// ------------------------------ ---------- ------- ----------- -------------- ------
++// Sampler                           sampler      NA          NA             s0      1 
++// TextureF                          texture  float4          2d             t0      1 
++//
++//
++//
++// Input signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_POSITION              0   xyzw        0      POS   float       
++// TEXCOORD                 0   xy          1     NONE   float   xy  
++//
++//
++// Output signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_TARGET                0   xyzw        0   TARGET   float   xyzw
++//
++//
++// Sampler/Resource to DX9 shader sampler mappings:
++//
++// Target Sampler Source Sampler  Source Resource
++// -------------- --------------- ----------------
++// s0             s0              t0               
++//
++//
++// Level9 shader bytecode:
++//
++    ps_2_x
++    def c0, 1, 0, 0, 0
++    dcl t0.xy
++    dcl_2d s0
++    texld r0, t0, s0
++    mad r0, r0.x, c0.xxxy, c0.yyyx
++    mov oC0, r0
++
++// approximately 3 instruction slots used (1 texture, 2 arithmetic)
++ps_4_0
++dcl_sampler s0, mode_default
++dcl_resource_texture2d (float,float,float,float) t0
++dcl_input_ps linear v1.xy
++dcl_output o0.xyzw
++dcl_temps 1
++sample r0.xyzw, v1.xyxx, t0.xyzw, s0
++mov o0.xyz, r0.xxxx
++mov o0.w, l(1.000000)
++ret 
++// Approximately 4 instruction slots used
++#endif
++
++const BYTE g_PS_PassthroughLum2D[] =
++{
++     68,  88,  66,  67, 241, 199, 
++     66,  51, 118, 205, 236, 165, 
++    244, 231, 234, 126, 203,  25, 
++    231, 134,   1,   0,   0,   0, 
++     20,   3,   0,   0,   6,   0, 
++      0,   0,  56,   0,   0,   0, 
++    208,   0,   0,   0, 108,   1, 
++      0,   0, 232,   1,   0,   0, 
++    136,   2,   0,   0, 224,   2, 
++      0,   0,  65, 111, 110,  57, 
++    144,   0,   0,   0, 144,   0, 
++      0,   0,   0,   2, 255, 255, 
++    104,   0,   0,   0,  40,   0, 
++      0,   0,   0,   0,  40,   0, 
++      0,   0,  40,   0,   0,   0, 
++     40,   0,   1,   0,  36,   0, 
++      0,   0,  40,   0,   0,   0, 
++      0,   0,   1,   2, 255, 255, 
++     81,   0,   0,   5,   0,   0, 
++     15, 160,   0,   0, 128,  63, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++     31,   0,   0,   2,   0,   0, 
++      0, 128,   0,   0,   3, 176, 
++     31,   0,   0,   2,   0,   0, 
++      0, 144,   0,   8,  15, 160, 
++     66,   0,   0,   3,   0,   0, 
++     15, 128,   0,   0, 228, 176, 
++      0,   8, 228, 160,   4,   0, 
++      0,   4,   0,   0,  15, 128, 
++      0,   0,   0, 128,   0,   0, 
++     64, 160,   0,   0,  21, 160, 
++      1,   0,   0,   2,   0,   8, 
++     15, 128,   0,   0, 228, 128, 
++    255, 255,   0,   0,  83,  72, 
++     68,  82, 148,   0,   0,   0, 
++     64,   0,   0,   0,  37,   0, 
++      0,   0,  90,   0,   0,   3, 
++      0,  96,  16,   0,   0,   0, 
++      0,   0,  88,  24,   0,   4, 
++      0, 112,  16,   0,   0,   0, 
++      0,   0,  85,  85,   0,   0, 
++     98,  16,   0,   3,  50,  16, 
++     16,   0,   1,   0,   0,   0, 
++    101,   0,   0,   3, 242,  32, 
++     16,   0,   0,   0,   0,   0, 
++    104,   0,   0,   2,   1,   0, 
++      0,   0,  69,   0,   0,   9, 
++    242,   0,  16,   0,   0,   0, 
++      0,   0,  70,  16,  16,   0, 
++      1,   0,   0,   0,  70, 126, 
++     16,   0,   0,   0,   0,   0, 
++      0,  96,  16,   0,   0,   0, 
++      0,   0,  54,   0,   0,   5, 
++    114,  32,  16,   0,   0,   0, 
++      0,   0,   6,   0,  16,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   5, 130,  32,  16,   0, 
++      0,   0,   0,   0,   1,  64, 
++      0,   0,   0,   0, 128,  63, 
++     62,   0,   0,   1,  83,  84, 
++     65,  84, 116,   0,   0,   0, 
++      4,   0,   0,   0,   1,   0, 
++      0,   0,   0,   0,   0,   0, 
++      2,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   2,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,  82,  68,  69,  70, 
++    152,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      2,   0,   0,   0,  28,   0, 
++      0,   0,   0,   4, 255, 255, 
++      0,   1,   0,   0, 109,   0, 
++      0,   0,  92,   0,   0,   0, 
++      3,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++      1,   0,   0,   0, 100,   0, 
++      0,   0,   2,   0,   0,   0, 
++      5,   0,   0,   0,   4,   0, 
++      0,   0, 255, 255, 255, 255, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,  13,   0,   0,   0, 
++     83,  97, 109, 112, 108, 101, 
++    114,   0,  84, 101, 120, 116, 
++    117, 114, 101,  70,   0,  77, 
++    105,  99, 114, 111, 115, 111, 
++    102, 116,  32,  40,  82,  41, 
++     32,  72,  76,  83,  76,  32, 
++     83, 104,  97, 100, 101, 114, 
++     32,  67, 111, 109, 112, 105, 
++    108, 101, 114,  32,  49,  48, 
++     46,  49,   0, 171, 171, 171, 
++     73,  83,  71,  78,  80,   0, 
++      0,   0,   2,   0,   0,   0, 
++      8,   0,   0,   0,  56,   0, 
++      0,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0,   3,   0, 
++      0,   0,   0,   0,   0,   0, 
++     15,   0,   0,   0,  68,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   3,   0, 
++      0,   0,   1,   0,   0,   0, 
++      3,   3,   0,   0,  83,  86, 
++     95,  80,  79,  83,  73,  84, 
++     73,  79,  78,   0,  84,  69, 
++     88,  67,  79,  79,  82,  68, 
++      0, 171, 171, 171,  79,  83, 
++     71,  78,  44,   0,   0,   0, 
++      1,   0,   0,   0,   8,   0, 
++      0,   0,  32,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   3,   0,   0,   0, 
++      0,   0,   0,   0,  15,   0, 
++      0,   0,  83,  86,  95,  84, 
++     65,  82,  71,  69,  84,   0, 
++    171, 171
++};
+diff --git a/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughlum3d11ps.h b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughlum3d11ps.h
+new file mode 100644
+index 00000000..35f219a5
+--- /dev/null
++++ b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughlum3d11ps.h
+@@ -0,0 +1,159 @@
++#if 0
++//
++// Generated by Microsoft (R) HLSL Shader Compiler 10.1
++//
++//
++// Resource Bindings:
++//
++// Name                                 Type  Format         Dim      HLSL Bind  Count
++// ------------------------------ ---------- ------- ----------- -------------- ------
++// Sampler                           sampler      NA          NA             s0      1 
++// TextureF                          texture  float4          3d             t0      1 
++//
++//
++//
++// Input signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_POSITION              0   xyzw        0      POS   float       
++// SV_RENDERTARGETARRAYINDEX     0   x           1  RTINDEX    uint       
++// TEXCOORD                 0   xyz         2     NONE   float   xyz 
++//
++//
++// Output signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_TARGET                0   xyzw        0   TARGET   float   xyzw
++//
++ps_4_0
++dcl_sampler s0, mode_default
++dcl_resource_texture3d (float,float,float,float) t0
++dcl_input_ps linear v2.xyz
++dcl_output o0.xyzw
++dcl_temps 1
++sample r0.xyzw, v2.xyzx, t0.xyzw, s0
++mov o0.xyz, r0.xxxx
++mov o0.w, l(1.000000)
++ret 
++// Approximately 4 instruction slots used
++#endif
++
++const BYTE g_PS_PassthroughLum3D[] =
++{
++     68,  88,  66,  67,  15,  80, 
++    145,  76,  93, 127, 194, 208, 
++    106,  29,  26,  87, 147,  62, 
++    128, 143,   1,   0,   0,   0, 
++    168,   2,   0,   0,   5,   0, 
++      0,   0,  52,   0,   0,   0, 
++    212,   0,   0,   0,  92,   1, 
++      0,   0, 144,   1,   0,   0, 
++     44,   2,   0,   0,  82,  68, 
++     69,  70, 152,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   2,   0,   0,   0, 
++     28,   0,   0,   0,   0,   4, 
++    255, 255,   0,   1,   0,   0, 
++    109,   0,   0,   0,  92,   0, 
++      0,   0,   3,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,   1,   0,   0,   0, 
++    100,   0,   0,   0,   2,   0, 
++      0,   0,   5,   0,   0,   0, 
++      8,   0,   0,   0, 255, 255, 
++    255, 255,   0,   0,   0,   0, 
++      1,   0,   0,   0,  13,   0, 
++      0,   0,  83,  97, 109, 112, 
++    108, 101, 114,   0,  84, 101, 
++    120, 116, 117, 114, 101,  70, 
++      0,  77, 105,  99, 114, 111, 
++    115, 111, 102, 116,  32,  40, 
++     82,  41,  32,  72,  76,  83, 
++     76,  32,  83, 104,  97, 100, 
++    101, 114,  32,  67, 111, 109, 
++    112, 105, 108, 101, 114,  32, 
++     49,  48,  46,  49,   0, 171, 
++    171, 171,  73,  83,  71,  78, 
++    128,   0,   0,   0,   3,   0, 
++      0,   0,   8,   0,   0,   0, 
++     80,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++      3,   0,   0,   0,   0,   0, 
++      0,   0,  15,   0,   0,   0, 
++     92,   0,   0,   0,   0,   0, 
++      0,   0,   4,   0,   0,   0, 
++      1,   0,   0,   0,   1,   0, 
++      0,   0,   1,   0,   0,   0, 
++    118,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      3,   0,   0,   0,   2,   0, 
++      0,   0,   7,   7,   0,   0, 
++     83,  86,  95,  80,  79,  83, 
++     73,  84,  73,  79,  78,   0, 
++     83,  86,  95,  82,  69,  78, 
++     68,  69,  82,  84,  65,  82, 
++     71,  69,  84,  65,  82,  82, 
++     65,  89,  73,  78,  68,  69, 
++     88,   0,  84,  69,  88,  67, 
++     79,  79,  82,  68,   0, 171, 
++     79,  83,  71,  78,  44,   0, 
++      0,   0,   1,   0,   0,   0, 
++      8,   0,   0,   0,  32,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   3,   0, 
++      0,   0,   0,   0,   0,   0, 
++     15,   0,   0,   0,  83,  86, 
++     95,  84,  65,  82,  71,  69, 
++     84,   0, 171, 171,  83,  72, 
++     68,  82, 148,   0,   0,   0, 
++     64,   0,   0,   0,  37,   0, 
++      0,   0,  90,   0,   0,   3, 
++      0,  96,  16,   0,   0,   0, 
++      0,   0,  88,  40,   0,   4, 
++      0, 112,  16,   0,   0,   0, 
++      0,   0,  85,  85,   0,   0, 
++     98,  16,   0,   3, 114,  16, 
++     16,   0,   2,   0,   0,   0, 
++    101,   0,   0,   3, 242,  32, 
++     16,   0,   0,   0,   0,   0, 
++    104,   0,   0,   2,   1,   0, 
++      0,   0,  69,   0,   0,   9, 
++    242,   0,  16,   0,   0,   0, 
++      0,   0,  70,  18,  16,   0, 
++      2,   0,   0,   0,  70, 126, 
++     16,   0,   0,   0,   0,   0, 
++      0,  96,  16,   0,   0,   0, 
++      0,   0,  54,   0,   0,   5, 
++    114,  32,  16,   0,   0,   0, 
++      0,   0,   6,   0,  16,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   5, 130,  32,  16,   0, 
++      0,   0,   0,   0,   1,  64, 
++      0,   0,   0,   0, 128,  63, 
++     62,   0,   0,   1,  83,  84, 
++     65,  84, 116,   0,   0,   0, 
++      4,   0,   0,   0,   1,   0, 
++      0,   0,   0,   0,   0,   0, 
++      2,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   2,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0
++};
+diff --git a/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughlumalpha2d11ps.h b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughlumalpha2d11ps.h
+new file mode 100644
+index 00000000..87f1c9dc
+--- /dev/null
++++ b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughlumalpha2d11ps.h
+@@ -0,0 +1,184 @@
++#if 0
++//
++// Generated by Microsoft (R) HLSL Shader Compiler 10.1
++//
++//
++// Resource Bindings:
++//
++// Name                                 Type  Format         Dim      HLSL Bind  Count
++// ------------------------------ ---------- ------- ----------- -------------- ------
++// Sampler                           sampler      NA          NA             s0      1 
++// TextureF                          texture  float4          2d             t0      1 
++//
++//
++//
++// Input signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_POSITION              0   xyzw        0      POS   float       
++// TEXCOORD                 0   xy          1     NONE   float   xy  
++//
++//
++// Output signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_TARGET                0   xyzw        0   TARGET   float   xyzw
++//
++//
++// Sampler/Resource to DX9 shader sampler mappings:
++//
++// Target Sampler Source Sampler  Source Resource
++// -------------- --------------- ----------------
++// s0             s0              t0               
++//
++//
++// Level9 shader bytecode:
++//
++    ps_2_x
++    dcl t0.xy
++    dcl_2d s0
++    texld r0, t0, s0
++    mov r0, r0.xxxw
++    mov oC0, r0
++
++// approximately 3 instruction slots used (1 texture, 2 arithmetic)
++ps_4_0
++dcl_sampler s0, mode_default
++dcl_resource_texture2d (float,float,float,float) t0
++dcl_input_ps linear v1.xy
++dcl_output o0.xyzw
++dcl_temps 1
++sample r0.xyzw, v1.xyxx, t0.xyzw, s0
++mov o0.xyzw, r0.xxxw
++ret 
++// Approximately 3 instruction slots used
++#endif
++
++const BYTE g_PS_PassthroughLumAlpha2D[] =
++{
++     68,  88,  66,  67,  19, 109, 
++     76, 235, 225, 193,  54, 241, 
++     78, 207,  77,  62, 148, 127, 
++    172,  73,   1,   0,   0,   0, 
++    224,   2,   0,   0,   6,   0, 
++      0,   0,  56,   0,   0,   0, 
++    176,   0,   0,   0,  56,   1, 
++      0,   0, 180,   1,   0,   0, 
++     84,   2,   0,   0, 172,   2, 
++      0,   0,  65, 111, 110,  57, 
++    112,   0,   0,   0, 112,   0, 
++      0,   0,   0,   2, 255, 255, 
++     72,   0,   0,   0,  40,   0, 
++      0,   0,   0,   0,  40,   0, 
++      0,   0,  40,   0,   0,   0, 
++     40,   0,   1,   0,  36,   0, 
++      0,   0,  40,   0,   0,   0, 
++      0,   0,   1,   2, 255, 255, 
++     31,   0,   0,   2,   0,   0, 
++      0, 128,   0,   0,   3, 176, 
++     31,   0,   0,   2,   0,   0, 
++      0, 144,   0,   8,  15, 160, 
++     66,   0,   0,   3,   0,   0, 
++     15, 128,   0,   0, 228, 176, 
++      0,   8, 228, 160,   1,   0, 
++      0,   2,   0,   0,  15, 128, 
++      0,   0, 192, 128,   1,   0, 
++      0,   2,   0,   8,  15, 128, 
++      0,   0, 228, 128, 255, 255, 
++      0,   0,  83,  72,  68,  82, 
++    128,   0,   0,   0,  64,   0, 
++      0,   0,  32,   0,   0,   0, 
++     90,   0,   0,   3,   0,  96, 
++     16,   0,   0,   0,   0,   0, 
++     88,  24,   0,   4,   0, 112, 
++     16,   0,   0,   0,   0,   0, 
++     85,  85,   0,   0,  98,  16, 
++      0,   3,  50,  16,  16,   0, 
++      1,   0,   0,   0, 101,   0, 
++      0,   3, 242,  32,  16,   0, 
++      0,   0,   0,   0, 104,   0, 
++      0,   2,   1,   0,   0,   0, 
++     69,   0,   0,   9, 242,   0, 
++     16,   0,   0,   0,   0,   0, 
++     70,  16,  16,   0,   1,   0, 
++      0,   0,  70, 126,  16,   0, 
++      0,   0,   0,   0,   0,  96, 
++     16,   0,   0,   0,   0,   0, 
++     54,   0,   0,   5, 242,  32, 
++     16,   0,   0,   0,   0,   0, 
++      6,  12,  16,   0,   0,   0, 
++      0,   0,  62,   0,   0,   1, 
++     83,  84,  65,  84, 116,   0, 
++      0,   0,   3,   0,   0,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0,   2,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,  82,  68, 
++     69,  70, 152,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   2,   0,   0,   0, 
++     28,   0,   0,   0,   0,   4, 
++    255, 255,   0,   1,   0,   0, 
++    109,   0,   0,   0,  92,   0, 
++      0,   0,   3,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,   1,   0,   0,   0, 
++    100,   0,   0,   0,   2,   0, 
++      0,   0,   5,   0,   0,   0, 
++      4,   0,   0,   0, 255, 255, 
++    255, 255,   0,   0,   0,   0, 
++      1,   0,   0,   0,  13,   0, 
++      0,   0,  83,  97, 109, 112, 
++    108, 101, 114,   0,  84, 101, 
++    120, 116, 117, 114, 101,  70, 
++      0,  77, 105,  99, 114, 111, 
++    115, 111, 102, 116,  32,  40, 
++     82,  41,  32,  72,  76,  83, 
++     76,  32,  83, 104,  97, 100, 
++    101, 114,  32,  67, 111, 109, 
++    112, 105, 108, 101, 114,  32, 
++     49,  48,  46,  49,   0, 171, 
++    171, 171,  73,  83,  71,  78, 
++     80,   0,   0,   0,   2,   0, 
++      0,   0,   8,   0,   0,   0, 
++     56,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++      3,   0,   0,   0,   0,   0, 
++      0,   0,  15,   0,   0,   0, 
++     68,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      3,   0,   0,   0,   1,   0, 
++      0,   0,   3,   3,   0,   0, 
++     83,  86,  95,  80,  79,  83, 
++     73,  84,  73,  79,  78,   0, 
++     84,  69,  88,  67,  79,  79, 
++     82,  68,   0, 171, 171, 171, 
++     79,  83,  71,  78,  44,   0, 
++      0,   0,   1,   0,   0,   0, 
++      8,   0,   0,   0,  32,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   3,   0, 
++      0,   0,   0,   0,   0,   0, 
++     15,   0,   0,   0,  83,  86, 
++     95,  84,  65,  82,  71,  69, 
++     84,   0, 171, 171
++};
+diff --git a/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughlumalpha3d11ps.h b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughlumalpha3d11ps.h
+new file mode 100644
+index 00000000..4c201f33
+--- /dev/null
++++ b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughlumalpha3d11ps.h
+@@ -0,0 +1,154 @@
++#if 0
++//
++// Generated by Microsoft (R) HLSL Shader Compiler 10.1
++//
++//
++// Resource Bindings:
++//
++// Name                                 Type  Format         Dim      HLSL Bind  Count
++// ------------------------------ ---------- ------- ----------- -------------- ------
++// Sampler                           sampler      NA          NA             s0      1 
++// TextureF                          texture  float4          3d             t0      1 
++//
++//
++//
++// Input signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_POSITION              0   xyzw        0      POS   float       
++// SV_RENDERTARGETARRAYINDEX     0   x           1  RTINDEX    uint       
++// TEXCOORD                 0   xyz         2     NONE   float   xyz 
++//
++//
++// Output signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_TARGET                0   xyzw        0   TARGET   float   xyzw
++//
++ps_4_0
++dcl_sampler s0, mode_default
++dcl_resource_texture3d (float,float,float,float) t0
++dcl_input_ps linear v2.xyz
++dcl_output o0.xyzw
++dcl_temps 1
++sample r0.xyzw, v2.xyzx, t0.xyzw, s0
++mov o0.xyzw, r0.xxxw
++ret 
++// Approximately 3 instruction slots used
++#endif
++
++const BYTE g_PS_PassthroughLumAlpha3D[] =
++{
++     68,  88,  66,  67, 158,  22, 
++    231,  90, 211,  81,  99,   1, 
++    181, 209, 159, 145, 140, 162, 
++    254,  17,   1,   0,   0,   0, 
++    148,   2,   0,   0,   5,   0, 
++      0,   0,  52,   0,   0,   0, 
++    212,   0,   0,   0,  92,   1, 
++      0,   0, 144,   1,   0,   0, 
++     24,   2,   0,   0,  82,  68, 
++     69,  70, 152,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   2,   0,   0,   0, 
++     28,   0,   0,   0,   0,   4, 
++    255, 255,   0,   1,   0,   0, 
++    109,   0,   0,   0,  92,   0, 
++      0,   0,   3,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,   1,   0,   0,   0, 
++    100,   0,   0,   0,   2,   0, 
++      0,   0,   5,   0,   0,   0, 
++      8,   0,   0,   0, 255, 255, 
++    255, 255,   0,   0,   0,   0, 
++      1,   0,   0,   0,  13,   0, 
++      0,   0,  83,  97, 109, 112, 
++    108, 101, 114,   0,  84, 101, 
++    120, 116, 117, 114, 101,  70, 
++      0,  77, 105,  99, 114, 111, 
++    115, 111, 102, 116,  32,  40, 
++     82,  41,  32,  72,  76,  83, 
++     76,  32,  83, 104,  97, 100, 
++    101, 114,  32,  67, 111, 109, 
++    112, 105, 108, 101, 114,  32, 
++     49,  48,  46,  49,   0, 171, 
++    171, 171,  73,  83,  71,  78, 
++    128,   0,   0,   0,   3,   0, 
++      0,   0,   8,   0,   0,   0, 
++     80,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++      3,   0,   0,   0,   0,   0, 
++      0,   0,  15,   0,   0,   0, 
++     92,   0,   0,   0,   0,   0, 
++      0,   0,   4,   0,   0,   0, 
++      1,   0,   0,   0,   1,   0, 
++      0,   0,   1,   0,   0,   0, 
++    118,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      3,   0,   0,   0,   2,   0, 
++      0,   0,   7,   7,   0,   0, 
++     83,  86,  95,  80,  79,  83, 
++     73,  84,  73,  79,  78,   0, 
++     83,  86,  95,  82,  69,  78, 
++     68,  69,  82,  84,  65,  82, 
++     71,  69,  84,  65,  82,  82, 
++     65,  89,  73,  78,  68,  69, 
++     88,   0,  84,  69,  88,  67, 
++     79,  79,  82,  68,   0, 171, 
++     79,  83,  71,  78,  44,   0, 
++      0,   0,   1,   0,   0,   0, 
++      8,   0,   0,   0,  32,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   3,   0, 
++      0,   0,   0,   0,   0,   0, 
++     15,   0,   0,   0,  83,  86, 
++     95,  84,  65,  82,  71,  69, 
++     84,   0, 171, 171,  83,  72, 
++     68,  82, 128,   0,   0,   0, 
++     64,   0,   0,   0,  32,   0, 
++      0,   0,  90,   0,   0,   3, 
++      0,  96,  16,   0,   0,   0, 
++      0,   0,  88,  40,   0,   4, 
++      0, 112,  16,   0,   0,   0, 
++      0,   0,  85,  85,   0,   0, 
++     98,  16,   0,   3, 114,  16, 
++     16,   0,   2,   0,   0,   0, 
++    101,   0,   0,   3, 242,  32, 
++     16,   0,   0,   0,   0,   0, 
++    104,   0,   0,   2,   1,   0, 
++      0,   0,  69,   0,   0,   9, 
++    242,   0,  16,   0,   0,   0, 
++      0,   0,  70,  18,  16,   0, 
++      2,   0,   0,   0,  70, 126, 
++     16,   0,   0,   0,   0,   0, 
++      0,  96,  16,   0,   0,   0, 
++      0,   0,  54,   0,   0,   5, 
++    242,  32,  16,   0,   0,   0, 
++      0,   0,   6,  12,  16,   0, 
++      0,   0,   0,   0,  62,   0, 
++      0,   1,  83,  84,  65,  84, 
++    116,   0,   0,   0,   3,   0, 
++      0,   0,   1,   0,   0,   0, 
++      0,   0,   0,   0,   2,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0
++};
+diff --git a/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughr2d11ps.h b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughr2d11ps.h
+new file mode 100644
+index 00000000..b4afe128
+--- /dev/null
++++ b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughr2d11ps.h
+@@ -0,0 +1,197 @@
++#if 0
++//
++// Generated by Microsoft (R) HLSL Shader Compiler 10.1
++//
++//
++// Resource Bindings:
++//
++// Name                                 Type  Format         Dim      HLSL Bind  Count
++// ------------------------------ ---------- ------- ----------- -------------- ------
++// Sampler                           sampler      NA          NA             s0      1 
++// TextureF                          texture  float4          2d             t0      1 
++//
++//
++//
++// Input signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_POSITION              0   xyzw        0      POS   float       
++// TEXCOORD                 0   xy          1     NONE   float   xy  
++//
++//
++// Output signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_TARGET                0   xyzw        0   TARGET   float   xyzw
++//
++//
++// Sampler/Resource to DX9 shader sampler mappings:
++//
++// Target Sampler Source Sampler  Source Resource
++// -------------- --------------- ----------------
++// s0             s0              t0               
++//
++//
++// Level9 shader bytecode:
++//
++    ps_2_x
++    def c0, 1, 0, 0, 0
++    dcl t0.xy
++    dcl_2d s0
++    texld r0, t0, s0
++    mad r0, r0.x, c0.xyyy, c0.yyyx
++    mov oC0, r0
++
++// approximately 3 instruction slots used (1 texture, 2 arithmetic)
++ps_4_0
++dcl_sampler s0, mode_default
++dcl_resource_texture2d (float,float,float,float) t0
++dcl_input_ps linear v1.xy
++dcl_output o0.xyzw
++dcl_temps 1
++sample r0.xyzw, v1.xyxx, t0.xyzw, s0
++mov o0.x, r0.x
++mov o0.yzw, l(0,0,0,1.000000)
++ret 
++// Approximately 4 instruction slots used
++#endif
++
++const BYTE g_PS_PassthroughR2D[] =
++{
++     68,  88,  66,  67,  14, 165, 
++    206,  90, 117,   2, 221,  45, 
++    225,  30, 128, 173,  62, 238, 
++     39,  64,   1,   0,   0,   0, 
++     32,   3,   0,   0,   6,   0, 
++      0,   0,  56,   0,   0,   0, 
++    208,   0,   0,   0, 120,   1, 
++      0,   0, 244,   1,   0,   0, 
++    148,   2,   0,   0, 236,   2, 
++      0,   0,  65, 111, 110,  57, 
++    144,   0,   0,   0, 144,   0, 
++      0,   0,   0,   2, 255, 255, 
++    104,   0,   0,   0,  40,   0, 
++      0,   0,   0,   0,  40,   0, 
++      0,   0,  40,   0,   0,   0, 
++     40,   0,   1,   0,  36,   0, 
++      0,   0,  40,   0,   0,   0, 
++      0,   0,   1,   2, 255, 255, 
++     81,   0,   0,   5,   0,   0, 
++     15, 160,   0,   0, 128,  63, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++     31,   0,   0,   2,   0,   0, 
++      0, 128,   0,   0,   3, 176, 
++     31,   0,   0,   2,   0,   0, 
++      0, 144,   0,   8,  15, 160, 
++     66,   0,   0,   3,   0,   0, 
++     15, 128,   0,   0, 228, 176, 
++      0,   8, 228, 160,   4,   0, 
++      0,   4,   0,   0,  15, 128, 
++      0,   0,   0, 128,   0,   0, 
++     84, 160,   0,   0,  21, 160, 
++      1,   0,   0,   2,   0,   8, 
++     15, 128,   0,   0, 228, 128, 
++    255, 255,   0,   0,  83,  72, 
++     68,  82, 160,   0,   0,   0, 
++     64,   0,   0,   0,  40,   0, 
++      0,   0,  90,   0,   0,   3, 
++      0,  96,  16,   0,   0,   0, 
++      0,   0,  88,  24,   0,   4, 
++      0, 112,  16,   0,   0,   0, 
++      0,   0,  85,  85,   0,   0, 
++     98,  16,   0,   3,  50,  16, 
++     16,   0,   1,   0,   0,   0, 
++    101,   0,   0,   3, 242,  32, 
++     16,   0,   0,   0,   0,   0, 
++    104,   0,   0,   2,   1,   0, 
++      0,   0,  69,   0,   0,   9, 
++    242,   0,  16,   0,   0,   0, 
++      0,   0,  70,  16,  16,   0, 
++      1,   0,   0,   0,  70, 126, 
++     16,   0,   0,   0,   0,   0, 
++      0,  96,  16,   0,   0,   0, 
++      0,   0,  54,   0,   0,   5, 
++     18,  32,  16,   0,   0,   0, 
++      0,   0,  10,   0,  16,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   8, 226,  32,  16,   0, 
++      0,   0,   0,   0,   2,  64, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0, 128,  63, 
++     62,   0,   0,   1,  83,  84, 
++     65,  84, 116,   0,   0,   0, 
++      4,   0,   0,   0,   1,   0, 
++      0,   0,   0,   0,   0,   0, 
++      2,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   2,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,  82,  68,  69,  70, 
++    152,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      2,   0,   0,   0,  28,   0, 
++      0,   0,   0,   4, 255, 255, 
++      0,   1,   0,   0, 109,   0, 
++      0,   0,  92,   0,   0,   0, 
++      3,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++      1,   0,   0,   0, 100,   0, 
++      0,   0,   2,   0,   0,   0, 
++      5,   0,   0,   0,   4,   0, 
++      0,   0, 255, 255, 255, 255, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,  13,   0,   0,   0, 
++     83,  97, 109, 112, 108, 101, 
++    114,   0,  84, 101, 120, 116, 
++    117, 114, 101,  70,   0,  77, 
++    105,  99, 114, 111, 115, 111, 
++    102, 116,  32,  40,  82,  41, 
++     32,  72,  76,  83,  76,  32, 
++     83, 104,  97, 100, 101, 114, 
++     32,  67, 111, 109, 112, 105, 
++    108, 101, 114,  32,  49,  48, 
++     46,  49,   0, 171, 171, 171, 
++     73,  83,  71,  78,  80,   0, 
++      0,   0,   2,   0,   0,   0, 
++      8,   0,   0,   0,  56,   0, 
++      0,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0,   3,   0, 
++      0,   0,   0,   0,   0,   0, 
++     15,   0,   0,   0,  68,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   3,   0, 
++      0,   0,   1,   0,   0,   0, 
++      3,   3,   0,   0,  83,  86, 
++     95,  80,  79,  83,  73,  84, 
++     73,  79,  78,   0,  84,  69, 
++     88,  67,  79,  79,  82,  68, 
++      0, 171, 171, 171,  79,  83, 
++     71,  78,  44,   0,   0,   0, 
++      1,   0,   0,   0,   8,   0, 
++      0,   0,  32,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   3,   0,   0,   0, 
++      0,   0,   0,   0,  15,   0, 
++      0,   0,  83,  86,  95,  84, 
++     65,  82,  71,  69,  84,   0, 
++    171, 171
++};
+diff --git a/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughr2di11ps.h b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughr2di11ps.h
+new file mode 100644
+index 00000000..d02d776c
+--- /dev/null
++++ b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughr2di11ps.h
+@@ -0,0 +1,166 @@
++#if 0
++//
++// Generated by Microsoft (R) HLSL Shader Compiler 10.1
++//
++//
++// Resource Bindings:
++//
++// Name                                 Type  Format         Dim      HLSL Bind  Count
++// ------------------------------ ---------- ------- ----------- -------------- ------
++// TextureI                          texture   sint4          2d             t0      1 
++//
++//
++//
++// Input signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_POSITION              0   xyzw        0      POS   float       
++// TEXCOORD                 0   xy          1     NONE   float   xy  
++//
++//
++// Output signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_TARGET                0   xyzw        0   TARGET     int   xyzw
++//
++ps_4_0
++dcl_resource_texture2d (sint,sint,sint,sint) t0
++dcl_input_ps linear v1.xy
++dcl_output o0.xyzw
++dcl_temps 1
++resinfo_uint r0.xyzw, l(0), t0.xyzw
++utof r0.xy, r0.xyxx
++mul r0.xy, r0.xyxx, v1.xyxx
++ftoi r0.xy, r0.xyxx
++mov r0.zw, l(0,0,0,0)
++ld r0.xyzw, r0.xyzw, t0.xyzw
++mov o0.x, r0.x
++mov o0.yzw, l(0,0,0,0)
++ret 
++// Approximately 9 instruction slots used
++#endif
++
++const BYTE g_PS_PassthroughR2DI[] =
++{
++     68,  88,  66,  67,   8,  16, 
++    169, 157, 145, 179, 119,  85, 
++     36,  37,  85, 107,  44, 112, 
++    158, 100,   1,   0,   0,   0, 
++    200,   2,   0,   0,   5,   0, 
++      0,   0,  52,   0,   0,   0, 
++    172,   0,   0,   0,   4,   1, 
++      0,   0,  56,   1,   0,   0, 
++     76,   2,   0,   0,  82,  68, 
++     69,  70, 112,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++     28,   0,   0,   0,   0,   4, 
++    255, 255,   0,   1,   0,   0, 
++     69,   0,   0,   0,  60,   0, 
++      0,   0,   2,   0,   0,   0, 
++      3,   0,   0,   0,   4,   0, 
++      0,   0, 255, 255, 255, 255, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,  13,   0,   0,   0, 
++     84, 101, 120, 116, 117, 114, 
++    101,  73,   0,  77, 105,  99, 
++    114, 111, 115, 111, 102, 116, 
++     32,  40,  82,  41,  32,  72, 
++     76,  83,  76,  32,  83, 104, 
++     97, 100, 101, 114,  32,  67, 
++    111, 109, 112, 105, 108, 101, 
++    114,  32,  49,  48,  46,  49, 
++      0, 171, 171, 171,  73,  83, 
++     71,  78,  80,   0,   0,   0, 
++      2,   0,   0,   0,   8,   0, 
++      0,   0,  56,   0,   0,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,   3,   0,   0,   0, 
++      0,   0,   0,   0,  15,   0, 
++      0,   0,  68,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   3,   0,   0,   0, 
++      1,   0,   0,   0,   3,   3, 
++      0,   0,  83,  86,  95,  80, 
++     79,  83,  73,  84,  73,  79, 
++     78,   0,  84,  69,  88,  67, 
++     79,  79,  82,  68,   0, 171, 
++    171, 171,  79,  83,  71,  78, 
++     44,   0,   0,   0,   1,   0, 
++      0,   0,   8,   0,   0,   0, 
++     32,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      2,   0,   0,   0,   0,   0, 
++      0,   0,  15,   0,   0,   0, 
++     83,  86,  95,  84,  65,  82, 
++     71,  69,  84,   0, 171, 171, 
++     83,  72,  68,  82,  12,   1, 
++      0,   0,  64,   0,   0,   0, 
++     67,   0,   0,   0,  88,  24, 
++      0,   4,   0, 112,  16,   0, 
++      0,   0,   0,   0,  51,  51, 
++      0,   0,  98,  16,   0,   3, 
++     50,  16,  16,   0,   1,   0, 
++      0,   0, 101,   0,   0,   3, 
++    242,  32,  16,   0,   0,   0, 
++      0,   0, 104,   0,   0,   2, 
++      1,   0,   0,   0,  61,  16, 
++      0,   7, 242,   0,  16,   0, 
++      0,   0,   0,   0,   1,  64, 
++      0,   0,   0,   0,   0,   0, 
++     70, 126,  16,   0,   0,   0, 
++      0,   0,  86,   0,   0,   5, 
++     50,   0,  16,   0,   0,   0, 
++      0,   0,  70,   0,  16,   0, 
++      0,   0,   0,   0,  56,   0, 
++      0,   7,  50,   0,  16,   0, 
++      0,   0,   0,   0,  70,   0, 
++     16,   0,   0,   0,   0,   0, 
++     70,  16,  16,   0,   1,   0, 
++      0,   0,  27,   0,   0,   5, 
++     50,   0,  16,   0,   0,   0, 
++      0,   0,  70,   0,  16,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   8, 194,   0,  16,   0, 
++      0,   0,   0,   0,   2,  64, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++     45,   0,   0,   7, 242,   0, 
++     16,   0,   0,   0,   0,   0, 
++     70,  14,  16,   0,   0,   0, 
++      0,   0,  70, 126,  16,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   5,  18,  32,  16,   0, 
++      0,   0,   0,   0,  10,   0, 
++     16,   0,   0,   0,   0,   0, 
++     54,   0,   0,   8, 226,  32, 
++     16,   0,   0,   0,   0,   0, 
++      2,  64,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,  62,   0,   0,   1, 
++     83,  84,  65,  84, 116,   0, 
++      0,   0,   9,   0,   0,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0,   2,   0,   0,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      3,   0,   0,   0,   0,   0, 
++      0,   0,   2,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0
++};
+diff --git a/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughr2dui11ps.h b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughr2dui11ps.h
+new file mode 100644
+index 00000000..561b4345
+--- /dev/null
++++ b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughr2dui11ps.h
+@@ -0,0 +1,166 @@
++#if 0
++//
++// Generated by Microsoft (R) HLSL Shader Compiler 10.1
++//
++//
++// Resource Bindings:
++//
++// Name                                 Type  Format         Dim      HLSL Bind  Count
++// ------------------------------ ---------- ------- ----------- -------------- ------
++// TextureUI                         texture   uint4          2d             t0      1 
++//
++//
++//
++// Input signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_POSITION              0   xyzw        0      POS   float       
++// TEXCOORD                 0   xy          1     NONE   float   xy  
++//
++//
++// Output signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_TARGET                0   xyzw        0   TARGET    uint   xyzw
++//
++ps_4_0
++dcl_resource_texture2d (uint,uint,uint,uint) t0
++dcl_input_ps linear v1.xy
++dcl_output o0.xyzw
++dcl_temps 1
++resinfo_uint r0.xyzw, l(0), t0.xyzw
++utof r0.xy, r0.xyxx
++mul r0.xy, r0.xyxx, v1.xyxx
++ftoi r0.xy, r0.xyxx
++mov r0.zw, l(0,0,0,0)
++ld r0.xyzw, r0.xyzw, t0.xyzw
++mov o0.x, r0.x
++mov o0.yzw, l(0,0,0,0)
++ret 
++// Approximately 9 instruction slots used
++#endif
++
++const BYTE g_PS_PassthroughR2DUI[] =
++{
++     68,  88,  66,  67,   6,  47, 
++    175, 167,  62, 144, 171, 206, 
++     77, 165, 245, 226, 135, 124, 
++    142, 188,   1,   0,   0,   0, 
++    200,   2,   0,   0,   5,   0, 
++      0,   0,  52,   0,   0,   0, 
++    172,   0,   0,   0,   4,   1, 
++      0,   0,  56,   1,   0,   0, 
++     76,   2,   0,   0,  82,  68, 
++     69,  70, 112,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++     28,   0,   0,   0,   0,   4, 
++    255, 255,   0,   1,   0,   0, 
++     70,   0,   0,   0,  60,   0, 
++      0,   0,   2,   0,   0,   0, 
++      4,   0,   0,   0,   4,   0, 
++      0,   0, 255, 255, 255, 255, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,  13,   0,   0,   0, 
++     84, 101, 120, 116, 117, 114, 
++    101,  85,  73,   0,  77, 105, 
++     99, 114, 111, 115, 111, 102, 
++    116,  32,  40,  82,  41,  32, 
++     72,  76,  83,  76,  32,  83, 
++    104,  97, 100, 101, 114,  32, 
++     67, 111, 109, 112, 105, 108, 
++    101, 114,  32,  49,  48,  46, 
++     49,   0, 171, 171,  73,  83, 
++     71,  78,  80,   0,   0,   0, 
++      2,   0,   0,   0,   8,   0, 
++      0,   0,  56,   0,   0,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,   3,   0,   0,   0, 
++      0,   0,   0,   0,  15,   0, 
++      0,   0,  68,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   3,   0,   0,   0, 
++      1,   0,   0,   0,   3,   3, 
++      0,   0,  83,  86,  95,  80, 
++     79,  83,  73,  84,  73,  79, 
++     78,   0,  84,  69,  88,  67, 
++     79,  79,  82,  68,   0, 171, 
++    171, 171,  79,  83,  71,  78, 
++     44,   0,   0,   0,   1,   0, 
++      0,   0,   8,   0,   0,   0, 
++     32,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0,  15,   0,   0,   0, 
++     83,  86,  95,  84,  65,  82, 
++     71,  69,  84,   0, 171, 171, 
++     83,  72,  68,  82,  12,   1, 
++      0,   0,  64,   0,   0,   0, 
++     67,   0,   0,   0,  88,  24, 
++      0,   4,   0, 112,  16,   0, 
++      0,   0,   0,   0,  68,  68, 
++      0,   0,  98,  16,   0,   3, 
++     50,  16,  16,   0,   1,   0, 
++      0,   0, 101,   0,   0,   3, 
++    242,  32,  16,   0,   0,   0, 
++      0,   0, 104,   0,   0,   2, 
++      1,   0,   0,   0,  61,  16, 
++      0,   7, 242,   0,  16,   0, 
++      0,   0,   0,   0,   1,  64, 
++      0,   0,   0,   0,   0,   0, 
++     70, 126,  16,   0,   0,   0, 
++      0,   0,  86,   0,   0,   5, 
++     50,   0,  16,   0,   0,   0, 
++      0,   0,  70,   0,  16,   0, 
++      0,   0,   0,   0,  56,   0, 
++      0,   7,  50,   0,  16,   0, 
++      0,   0,   0,   0,  70,   0, 
++     16,   0,   0,   0,   0,   0, 
++     70,  16,  16,   0,   1,   0, 
++      0,   0,  27,   0,   0,   5, 
++     50,   0,  16,   0,   0,   0, 
++      0,   0,  70,   0,  16,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   8, 194,   0,  16,   0, 
++      0,   0,   0,   0,   2,  64, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++     45,   0,   0,   7, 242,   0, 
++     16,   0,   0,   0,   0,   0, 
++     70,  14,  16,   0,   0,   0, 
++      0,   0,  70, 126,  16,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   5,  18,  32,  16,   0, 
++      0,   0,   0,   0,  10,   0, 
++     16,   0,   0,   0,   0,   0, 
++     54,   0,   0,   8, 226,  32, 
++     16,   0,   0,   0,   0,   0, 
++      2,  64,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,  62,   0,   0,   1, 
++     83,  84,  65,  84, 116,   0, 
++      0,   0,   9,   0,   0,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0,   2,   0,   0,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      3,   0,   0,   0,   0,   0, 
++      0,   0,   2,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0
++};
+diff --git a/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughr3d11ps.h b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughr3d11ps.h
+new file mode 100644
+index 00000000..62b7403c
+--- /dev/null
++++ b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughr3d11ps.h
+@@ -0,0 +1,161 @@
++#if 0
++//
++// Generated by Microsoft (R) HLSL Shader Compiler 10.1
++//
++//
++// Resource Bindings:
++//
++// Name                                 Type  Format         Dim      HLSL Bind  Count
++// ------------------------------ ---------- ------- ----------- -------------- ------
++// Sampler                           sampler      NA          NA             s0      1 
++// TextureF                          texture  float4          3d             t0      1 
++//
++//
++//
++// Input signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_POSITION              0   xyzw        0      POS   float       
++// SV_RENDERTARGETARRAYINDEX     0   x           1  RTINDEX    uint       
++// TEXCOORD                 0   xyz         2     NONE   float   xyz 
++//
++//
++// Output signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_TARGET                0   xyzw        0   TARGET   float   xyzw
++//
++ps_4_0
++dcl_sampler s0, mode_default
++dcl_resource_texture3d (float,float,float,float) t0
++dcl_input_ps linear v2.xyz
++dcl_output o0.xyzw
++dcl_temps 1
++sample r0.xyzw, v2.xyzx, t0.xyzw, s0
++mov o0.x, r0.x
++mov o0.yzw, l(0,0,0,1.000000)
++ret 
++// Approximately 4 instruction slots used
++#endif
++
++const BYTE g_PS_PassthroughR3D[] =
++{
++     68,  88,  66,  67, 134, 101, 
++     76,  73, 205, 199,  65, 249, 
++    170, 201,  40, 128, 129,  87, 
++     93, 148,   1,   0,   0,   0, 
++    180,   2,   0,   0,   5,   0, 
++      0,   0,  52,   0,   0,   0, 
++    212,   0,   0,   0,  92,   1, 
++      0,   0, 144,   1,   0,   0, 
++     56,   2,   0,   0,  82,  68, 
++     69,  70, 152,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   2,   0,   0,   0, 
++     28,   0,   0,   0,   0,   4, 
++    255, 255,   0,   1,   0,   0, 
++    109,   0,   0,   0,  92,   0, 
++      0,   0,   3,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,   1,   0,   0,   0, 
++    100,   0,   0,   0,   2,   0, 
++      0,   0,   5,   0,   0,   0, 
++      8,   0,   0,   0, 255, 255, 
++    255, 255,   0,   0,   0,   0, 
++      1,   0,   0,   0,  13,   0, 
++      0,   0,  83,  97, 109, 112, 
++    108, 101, 114,   0,  84, 101, 
++    120, 116, 117, 114, 101,  70, 
++      0,  77, 105,  99, 114, 111, 
++    115, 111, 102, 116,  32,  40, 
++     82,  41,  32,  72,  76,  83, 
++     76,  32,  83, 104,  97, 100, 
++    101, 114,  32,  67, 111, 109, 
++    112, 105, 108, 101, 114,  32, 
++     49,  48,  46,  49,   0, 171, 
++    171, 171,  73,  83,  71,  78, 
++    128,   0,   0,   0,   3,   0, 
++      0,   0,   8,   0,   0,   0, 
++     80,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++      3,   0,   0,   0,   0,   0, 
++      0,   0,  15,   0,   0,   0, 
++     92,   0,   0,   0,   0,   0, 
++      0,   0,   4,   0,   0,   0, 
++      1,   0,   0,   0,   1,   0, 
++      0,   0,   1,   0,   0,   0, 
++    118,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      3,   0,   0,   0,   2,   0, 
++      0,   0,   7,   7,   0,   0, 
++     83,  86,  95,  80,  79,  83, 
++     73,  84,  73,  79,  78,   0, 
++     83,  86,  95,  82,  69,  78, 
++     68,  69,  82,  84,  65,  82, 
++     71,  69,  84,  65,  82,  82, 
++     65,  89,  73,  78,  68,  69, 
++     88,   0,  84,  69,  88,  67, 
++     79,  79,  82,  68,   0, 171, 
++     79,  83,  71,  78,  44,   0, 
++      0,   0,   1,   0,   0,   0, 
++      8,   0,   0,   0,  32,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   3,   0, 
++      0,   0,   0,   0,   0,   0, 
++     15,   0,   0,   0,  83,  86, 
++     95,  84,  65,  82,  71,  69, 
++     84,   0, 171, 171,  83,  72, 
++     68,  82, 160,   0,   0,   0, 
++     64,   0,   0,   0,  40,   0, 
++      0,   0,  90,   0,   0,   3, 
++      0,  96,  16,   0,   0,   0, 
++      0,   0,  88,  40,   0,   4, 
++      0, 112,  16,   0,   0,   0, 
++      0,   0,  85,  85,   0,   0, 
++     98,  16,   0,   3, 114,  16, 
++     16,   0,   2,   0,   0,   0, 
++    101,   0,   0,   3, 242,  32, 
++     16,   0,   0,   0,   0,   0, 
++    104,   0,   0,   2,   1,   0, 
++      0,   0,  69,   0,   0,   9, 
++    242,   0,  16,   0,   0,   0, 
++      0,   0,  70,  18,  16,   0, 
++      2,   0,   0,   0,  70, 126, 
++     16,   0,   0,   0,   0,   0, 
++      0,  96,  16,   0,   0,   0, 
++      0,   0,  54,   0,   0,   5, 
++     18,  32,  16,   0,   0,   0, 
++      0,   0,  10,   0,  16,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   8, 226,  32,  16,   0, 
++      0,   0,   0,   0,   2,  64, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0, 128,  63, 
++     62,   0,   0,   1,  83,  84, 
++     65,  84, 116,   0,   0,   0, 
++      4,   0,   0,   0,   1,   0, 
++      0,   0,   0,   0,   0,   0, 
++      2,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   2,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0
++};
+diff --git a/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughr3di11ps.h b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughr3di11ps.h
+new file mode 100644
+index 00000000..a8e72aac
+--- /dev/null
++++ b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughr3di11ps.h
+@@ -0,0 +1,173 @@
++#if 0
++//
++// Generated by Microsoft (R) HLSL Shader Compiler 10.1
++//
++//
++// Resource Bindings:
++//
++// Name                                 Type  Format         Dim      HLSL Bind  Count
++// ------------------------------ ---------- ------- ----------- -------------- ------
++// TextureI                          texture   sint4          3d             t0      1 
++//
++//
++//
++// Input signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_POSITION              0   xyzw        0      POS   float       
++// SV_RENDERTARGETARRAYINDEX     0   x           1  RTINDEX    uint       
++// TEXCOORD                 0   xyz         2     NONE   float   xyz 
++//
++//
++// Output signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_TARGET                0   xyzw        0   TARGET     int   xyzw
++//
++ps_4_0
++dcl_resource_texture3d (sint,sint,sint,sint) t0
++dcl_input_ps linear v2.xyz
++dcl_output o0.xyzw
++dcl_temps 1
++resinfo_uint r0.xyzw, l(0), t0.xyzw
++utof r0.xyz, r0.xyzx
++mul r0.xyz, r0.xyzx, v2.xyzx
++ftoi r0.xyz, r0.xyzx
++mov r0.w, l(0)
++ld r0.xyzw, r0.xyzw, t0.xyzw
++mov o0.x, r0.x
++mov o0.yzw, l(0,0,0,0)
++ret 
++// Approximately 9 instruction slots used
++#endif
++
++const BYTE g_PS_PassthroughR3DI[] =
++{
++     68,  88,  66,  67, 250, 224, 
++     56, 242,   8, 157,  92, 236, 
++    205, 252,  68, 242,  80,  46, 
++    223,  98,   1,   0,   0,   0, 
++    236,   2,   0,   0,   5,   0, 
++      0,   0,  52,   0,   0,   0, 
++    172,   0,   0,   0,  52,   1, 
++      0,   0, 104,   1,   0,   0, 
++    112,   2,   0,   0,  82,  68, 
++     69,  70, 112,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++     28,   0,   0,   0,   0,   4, 
++    255, 255,   0,   1,   0,   0, 
++     69,   0,   0,   0,  60,   0, 
++      0,   0,   2,   0,   0,   0, 
++      3,   0,   0,   0,   8,   0, 
++      0,   0, 255, 255, 255, 255, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,  13,   0,   0,   0, 
++     84, 101, 120, 116, 117, 114, 
++    101,  73,   0,  77, 105,  99, 
++    114, 111, 115, 111, 102, 116, 
++     32,  40,  82,  41,  32,  72, 
++     76,  83,  76,  32,  83, 104, 
++     97, 100, 101, 114,  32,  67, 
++    111, 109, 112, 105, 108, 101, 
++    114,  32,  49,  48,  46,  49, 
++      0, 171, 171, 171,  73,  83, 
++     71,  78, 128,   0,   0,   0, 
++      3,   0,   0,   0,   8,   0, 
++      0,   0,  80,   0,   0,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,   3,   0,   0,   0, 
++      0,   0,   0,   0,  15,   0, 
++      0,   0,  92,   0,   0,   0, 
++      0,   0,   0,   0,   4,   0, 
++      0,   0,   1,   0,   0,   0, 
++      1,   0,   0,   0,   1,   0, 
++      0,   0, 118,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   3,   0,   0,   0, 
++      2,   0,   0,   0,   7,   7, 
++      0,   0,  83,  86,  95,  80, 
++     79,  83,  73,  84,  73,  79, 
++     78,   0,  83,  86,  95,  82, 
++     69,  78,  68,  69,  82,  84, 
++     65,  82,  71,  69,  84,  65, 
++     82,  82,  65,  89,  73,  78, 
++     68,  69,  88,   0,  84,  69, 
++     88,  67,  79,  79,  82,  68, 
++      0, 171,  79,  83,  71,  78, 
++     44,   0,   0,   0,   1,   0, 
++      0,   0,   8,   0,   0,   0, 
++     32,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      2,   0,   0,   0,   0,   0, 
++      0,   0,  15,   0,   0,   0, 
++     83,  86,  95,  84,  65,  82, 
++     71,  69,  84,   0, 171, 171, 
++     83,  72,  68,  82,   0,   1, 
++      0,   0,  64,   0,   0,   0, 
++     64,   0,   0,   0,  88,  40, 
++      0,   4,   0, 112,  16,   0, 
++      0,   0,   0,   0,  51,  51, 
++      0,   0,  98,  16,   0,   3, 
++    114,  16,  16,   0,   2,   0, 
++      0,   0, 101,   0,   0,   3, 
++    242,  32,  16,   0,   0,   0, 
++      0,   0, 104,   0,   0,   2, 
++      1,   0,   0,   0,  61,  16, 
++      0,   7, 242,   0,  16,   0, 
++      0,   0,   0,   0,   1,  64, 
++      0,   0,   0,   0,   0,   0, 
++     70, 126,  16,   0,   0,   0, 
++      0,   0,  86,   0,   0,   5, 
++    114,   0,  16,   0,   0,   0, 
++      0,   0,  70,   2,  16,   0, 
++      0,   0,   0,   0,  56,   0, 
++      0,   7, 114,   0,  16,   0, 
++      0,   0,   0,   0,  70,   2, 
++     16,   0,   0,   0,   0,   0, 
++     70,  18,  16,   0,   2,   0, 
++      0,   0,  27,   0,   0,   5, 
++    114,   0,  16,   0,   0,   0, 
++      0,   0,  70,   2,  16,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   5, 130,   0,  16,   0, 
++      0,   0,   0,   0,   1,  64, 
++      0,   0,   0,   0,   0,   0, 
++     45,   0,   0,   7, 242,   0, 
++     16,   0,   0,   0,   0,   0, 
++     70,  14,  16,   0,   0,   0, 
++      0,   0,  70, 126,  16,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   5,  18,  32,  16,   0, 
++      0,   0,   0,   0,  10,   0, 
++     16,   0,   0,   0,   0,   0, 
++     54,   0,   0,   8, 226,  32, 
++     16,   0,   0,   0,   0,   0, 
++      2,  64,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,  62,   0,   0,   1, 
++     83,  84,  65,  84, 116,   0, 
++      0,   0,   9,   0,   0,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0,   2,   0,   0,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      3,   0,   0,   0,   0,   0, 
++      0,   0,   2,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0
++};
+diff --git a/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughr3dui11ps.h b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughr3dui11ps.h
+new file mode 100644
+index 00000000..89e07eac
+--- /dev/null
++++ b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughr3dui11ps.h
+@@ -0,0 +1,173 @@
++#if 0
++//
++// Generated by Microsoft (R) HLSL Shader Compiler 10.1
++//
++//
++// Resource Bindings:
++//
++// Name                                 Type  Format         Dim      HLSL Bind  Count
++// ------------------------------ ---------- ------- ----------- -------------- ------
++// TextureUI                         texture   uint4          3d             t0      1 
++//
++//
++//
++// Input signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_POSITION              0   xyzw        0      POS   float       
++// SV_RENDERTARGETARRAYINDEX     0   x           1  RTINDEX    uint       
++// TEXCOORD                 0   xyz         2     NONE   float   xyz 
++//
++//
++// Output signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_TARGET                0   xyzw        0   TARGET    uint   xyzw
++//
++ps_4_0
++dcl_resource_texture3d (uint,uint,uint,uint) t0
++dcl_input_ps linear v2.xyz
++dcl_output o0.xyzw
++dcl_temps 1
++resinfo_uint r0.xyzw, l(0), t0.xyzw
++utof r0.xyz, r0.xyzx
++mul r0.xyz, r0.xyzx, v2.xyzx
++ftoi r0.xyz, r0.xyzx
++mov r0.w, l(0)
++ld r0.xyzw, r0.xyzw, t0.xyzw
++mov o0.x, r0.x
++mov o0.yzw, l(0,0,0,0)
++ret 
++// Approximately 9 instruction slots used
++#endif
++
++const BYTE g_PS_PassthroughR3DUI[] =
++{
++     68,  88,  66,  67, 125,  15, 
++    246, 192,  16, 228, 182,  55, 
++      2,  24,  75,  71, 132, 253, 
++    233,  61,   1,   0,   0,   0, 
++    236,   2,   0,   0,   5,   0, 
++      0,   0,  52,   0,   0,   0, 
++    172,   0,   0,   0,  52,   1, 
++      0,   0, 104,   1,   0,   0, 
++    112,   2,   0,   0,  82,  68, 
++     69,  70, 112,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++     28,   0,   0,   0,   0,   4, 
++    255, 255,   0,   1,   0,   0, 
++     70,   0,   0,   0,  60,   0, 
++      0,   0,   2,   0,   0,   0, 
++      4,   0,   0,   0,   8,   0, 
++      0,   0, 255, 255, 255, 255, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,  13,   0,   0,   0, 
++     84, 101, 120, 116, 117, 114, 
++    101,  85,  73,   0,  77, 105, 
++     99, 114, 111, 115, 111, 102, 
++    116,  32,  40,  82,  41,  32, 
++     72,  76,  83,  76,  32,  83, 
++    104,  97, 100, 101, 114,  32, 
++     67, 111, 109, 112, 105, 108, 
++    101, 114,  32,  49,  48,  46, 
++     49,   0, 171, 171,  73,  83, 
++     71,  78, 128,   0,   0,   0, 
++      3,   0,   0,   0,   8,   0, 
++      0,   0,  80,   0,   0,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,   3,   0,   0,   0, 
++      0,   0,   0,   0,  15,   0, 
++      0,   0,  92,   0,   0,   0, 
++      0,   0,   0,   0,   4,   0, 
++      0,   0,   1,   0,   0,   0, 
++      1,   0,   0,   0,   1,   0, 
++      0,   0, 118,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   3,   0,   0,   0, 
++      2,   0,   0,   0,   7,   7, 
++      0,   0,  83,  86,  95,  80, 
++     79,  83,  73,  84,  73,  79, 
++     78,   0,  83,  86,  95,  82, 
++     69,  78,  68,  69,  82,  84, 
++     65,  82,  71,  69,  84,  65, 
++     82,  82,  65,  89,  73,  78, 
++     68,  69,  88,   0,  84,  69, 
++     88,  67,  79,  79,  82,  68, 
++      0, 171,  79,  83,  71,  78, 
++     44,   0,   0,   0,   1,   0, 
++      0,   0,   8,   0,   0,   0, 
++     32,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0,  15,   0,   0,   0, 
++     83,  86,  95,  84,  65,  82, 
++     71,  69,  84,   0, 171, 171, 
++     83,  72,  68,  82,   0,   1, 
++      0,   0,  64,   0,   0,   0, 
++     64,   0,   0,   0,  88,  40, 
++      0,   4,   0, 112,  16,   0, 
++      0,   0,   0,   0,  68,  68, 
++      0,   0,  98,  16,   0,   3, 
++    114,  16,  16,   0,   2,   0, 
++      0,   0, 101,   0,   0,   3, 
++    242,  32,  16,   0,   0,   0, 
++      0,   0, 104,   0,   0,   2, 
++      1,   0,   0,   0,  61,  16, 
++      0,   7, 242,   0,  16,   0, 
++      0,   0,   0,   0,   1,  64, 
++      0,   0,   0,   0,   0,   0, 
++     70, 126,  16,   0,   0,   0, 
++      0,   0,  86,   0,   0,   5, 
++    114,   0,  16,   0,   0,   0, 
++      0,   0,  70,   2,  16,   0, 
++      0,   0,   0,   0,  56,   0, 
++      0,   7, 114,   0,  16,   0, 
++      0,   0,   0,   0,  70,   2, 
++     16,   0,   0,   0,   0,   0, 
++     70,  18,  16,   0,   2,   0, 
++      0,   0,  27,   0,   0,   5, 
++    114,   0,  16,   0,   0,   0, 
++      0,   0,  70,   2,  16,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   5, 130,   0,  16,   0, 
++      0,   0,   0,   0,   1,  64, 
++      0,   0,   0,   0,   0,   0, 
++     45,   0,   0,   7, 242,   0, 
++     16,   0,   0,   0,   0,   0, 
++     70,  14,  16,   0,   0,   0, 
++      0,   0,  70, 126,  16,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   5,  18,  32,  16,   0, 
++      0,   0,   0,   0,  10,   0, 
++     16,   0,   0,   0,   0,   0, 
++     54,   0,   0,   8, 226,  32, 
++     16,   0,   0,   0,   0,   0, 
++      2,  64,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,  62,   0,   0,   1, 
++     83,  84,  65,  84, 116,   0, 
++      0,   0,   9,   0,   0,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0,   2,   0,   0,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      3,   0,   0,   0,   0,   0, 
++      0,   0,   2,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0
++};
+diff --git a/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughrg2d11ps.h b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughrg2d11ps.h
+new file mode 100644
+index 00000000..0d18c0c5
+--- /dev/null
++++ b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughrg2d11ps.h
+@@ -0,0 +1,197 @@
++#if 0
++//
++// Generated by Microsoft (R) HLSL Shader Compiler 10.1
++//
++//
++// Resource Bindings:
++//
++// Name                                 Type  Format         Dim      HLSL Bind  Count
++// ------------------------------ ---------- ------- ----------- -------------- ------
++// Sampler                           sampler      NA          NA             s0      1 
++// TextureF                          texture  float4          2d             t0      1 
++//
++//
++//
++// Input signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_POSITION              0   xyzw        0      POS   float       
++// TEXCOORD                 0   xy          1     NONE   float   xy  
++//
++//
++// Output signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_TARGET                0   xyzw        0   TARGET   float   xyzw
++//
++//
++// Sampler/Resource to DX9 shader sampler mappings:
++//
++// Target Sampler Source Sampler  Source Resource
++// -------------- --------------- ----------------
++// s0             s0              t0               
++//
++//
++// Level9 shader bytecode:
++//
++    ps_2_x
++    def c0, 1, 0, 0, 0
++    dcl t0.xy
++    dcl_2d s0
++    texld r0, t0, s0
++    mad r0, r0.xyxx, c0.xxyy, c0.yyyx
++    mov oC0, r0
++
++// approximately 3 instruction slots used (1 texture, 2 arithmetic)
++ps_4_0
++dcl_sampler s0, mode_default
++dcl_resource_texture2d (float,float,float,float) t0
++dcl_input_ps linear v1.xy
++dcl_output o0.xyzw
++dcl_temps 1
++sample r0.xyzw, v1.xyxx, t0.xyzw, s0
++mov o0.xy, r0.xyxx
++mov o0.zw, l(0,0,0,1.000000)
++ret 
++// Approximately 4 instruction slots used
++#endif
++
++const BYTE g_PS_PassthroughRG2D[] =
++{
++     68,  88,  66,  67, 151,  54, 
++    111, 200, 187, 200, 177, 214, 
++     12,  69, 246, 113, 254,  31, 
++     23,  45,   1,   0,   0,   0, 
++     32,   3,   0,   0,   6,   0, 
++      0,   0,  56,   0,   0,   0, 
++    208,   0,   0,   0, 120,   1, 
++      0,   0, 244,   1,   0,   0, 
++    148,   2,   0,   0, 236,   2, 
++      0,   0,  65, 111, 110,  57, 
++    144,   0,   0,   0, 144,   0, 
++      0,   0,   0,   2, 255, 255, 
++    104,   0,   0,   0,  40,   0, 
++      0,   0,   0,   0,  40,   0, 
++      0,   0,  40,   0,   0,   0, 
++     40,   0,   1,   0,  36,   0, 
++      0,   0,  40,   0,   0,   0, 
++      0,   0,   1,   2, 255, 255, 
++     81,   0,   0,   5,   0,   0, 
++     15, 160,   0,   0, 128,  63, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++     31,   0,   0,   2,   0,   0, 
++      0, 128,   0,   0,   3, 176, 
++     31,   0,   0,   2,   0,   0, 
++      0, 144,   0,   8,  15, 160, 
++     66,   0,   0,   3,   0,   0, 
++     15, 128,   0,   0, 228, 176, 
++      0,   8, 228, 160,   4,   0, 
++      0,   4,   0,   0,  15, 128, 
++      0,   0,   4, 128,   0,   0, 
++     80, 160,   0,   0,  21, 160, 
++      1,   0,   0,   2,   0,   8, 
++     15, 128,   0,   0, 228, 128, 
++    255, 255,   0,   0,  83,  72, 
++     68,  82, 160,   0,   0,   0, 
++     64,   0,   0,   0,  40,   0, 
++      0,   0,  90,   0,   0,   3, 
++      0,  96,  16,   0,   0,   0, 
++      0,   0,  88,  24,   0,   4, 
++      0, 112,  16,   0,   0,   0, 
++      0,   0,  85,  85,   0,   0, 
++     98,  16,   0,   3,  50,  16, 
++     16,   0,   1,   0,   0,   0, 
++    101,   0,   0,   3, 242,  32, 
++     16,   0,   0,   0,   0,   0, 
++    104,   0,   0,   2,   1,   0, 
++      0,   0,  69,   0,   0,   9, 
++    242,   0,  16,   0,   0,   0, 
++      0,   0,  70,  16,  16,   0, 
++      1,   0,   0,   0,  70, 126, 
++     16,   0,   0,   0,   0,   0, 
++      0,  96,  16,   0,   0,   0, 
++      0,   0,  54,   0,   0,   5, 
++     50,  32,  16,   0,   0,   0, 
++      0,   0,  70,   0,  16,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   8, 194,  32,  16,   0, 
++      0,   0,   0,   0,   2,  64, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0, 128,  63, 
++     62,   0,   0,   1,  83,  84, 
++     65,  84, 116,   0,   0,   0, 
++      4,   0,   0,   0,   1,   0, 
++      0,   0,   0,   0,   0,   0, 
++      2,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   2,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,  82,  68,  69,  70, 
++    152,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      2,   0,   0,   0,  28,   0, 
++      0,   0,   0,   4, 255, 255, 
++      0,   1,   0,   0, 109,   0, 
++      0,   0,  92,   0,   0,   0, 
++      3,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++      1,   0,   0,   0, 100,   0, 
++      0,   0,   2,   0,   0,   0, 
++      5,   0,   0,   0,   4,   0, 
++      0,   0, 255, 255, 255, 255, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,  13,   0,   0,   0, 
++     83,  97, 109, 112, 108, 101, 
++    114,   0,  84, 101, 120, 116, 
++    117, 114, 101,  70,   0,  77, 
++    105,  99, 114, 111, 115, 111, 
++    102, 116,  32,  40,  82,  41, 
++     32,  72,  76,  83,  76,  32, 
++     83, 104,  97, 100, 101, 114, 
++     32,  67, 111, 109, 112, 105, 
++    108, 101, 114,  32,  49,  48, 
++     46,  49,   0, 171, 171, 171, 
++     73,  83,  71,  78,  80,   0, 
++      0,   0,   2,   0,   0,   0, 
++      8,   0,   0,   0,  56,   0, 
++      0,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0,   3,   0, 
++      0,   0,   0,   0,   0,   0, 
++     15,   0,   0,   0,  68,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   3,   0, 
++      0,   0,   1,   0,   0,   0, 
++      3,   3,   0,   0,  83,  86, 
++     95,  80,  79,  83,  73,  84, 
++     73,  79,  78,   0,  84,  69, 
++     88,  67,  79,  79,  82,  68, 
++      0, 171, 171, 171,  79,  83, 
++     71,  78,  44,   0,   0,   0, 
++      1,   0,   0,   0,   8,   0, 
++      0,   0,  32,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   3,   0,   0,   0, 
++      0,   0,   0,   0,  15,   0, 
++      0,   0,  83,  86,  95,  84, 
++     65,  82,  71,  69,  84,   0, 
++    171, 171
++};
+diff --git a/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughrg2di11ps.h b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughrg2di11ps.h
+new file mode 100644
+index 00000000..4cbe3b50
+--- /dev/null
++++ b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughrg2di11ps.h
+@@ -0,0 +1,166 @@
++#if 0
++//
++// Generated by Microsoft (R) HLSL Shader Compiler 10.1
++//
++//
++// Resource Bindings:
++//
++// Name                                 Type  Format         Dim      HLSL Bind  Count
++// ------------------------------ ---------- ------- ----------- -------------- ------
++// TextureI                          texture   sint4          2d             t0      1 
++//
++//
++//
++// Input signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_POSITION              0   xyzw        0      POS   float       
++// TEXCOORD                 0   xy          1     NONE   float   xy  
++//
++//
++// Output signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_TARGET                0   xyzw        0   TARGET     int   xyzw
++//
++ps_4_0
++dcl_resource_texture2d (sint,sint,sint,sint) t0
++dcl_input_ps linear v1.xy
++dcl_output o0.xyzw
++dcl_temps 1
++resinfo_uint r0.xyzw, l(0), t0.xyzw
++utof r0.xy, r0.xyxx
++mul r0.xy, r0.xyxx, v1.xyxx
++ftoi r0.xy, r0.xyxx
++mov r0.zw, l(0,0,0,0)
++ld r0.xyzw, r0.xyzw, t0.xyzw
++mov o0.xy, r0.xyxx
++mov o0.zw, l(0,0,0,0)
++ret 
++// Approximately 9 instruction slots used
++#endif
++
++const BYTE g_PS_PassthroughRG2DI[] =
++{
++     68,  88,  66,  67, 161,  76, 
++      0, 115, 100,  69,   2, 128, 
++    179, 140, 112,  55, 172, 151, 
++    175, 231,   1,   0,   0,   0, 
++    200,   2,   0,   0,   5,   0, 
++      0,   0,  52,   0,   0,   0, 
++    172,   0,   0,   0,   4,   1, 
++      0,   0,  56,   1,   0,   0, 
++     76,   2,   0,   0,  82,  68, 
++     69,  70, 112,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++     28,   0,   0,   0,   0,   4, 
++    255, 255,   0,   1,   0,   0, 
++     69,   0,   0,   0,  60,   0, 
++      0,   0,   2,   0,   0,   0, 
++      3,   0,   0,   0,   4,   0, 
++      0,   0, 255, 255, 255, 255, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,  13,   0,   0,   0, 
++     84, 101, 120, 116, 117, 114, 
++    101,  73,   0,  77, 105,  99, 
++    114, 111, 115, 111, 102, 116, 
++     32,  40,  82,  41,  32,  72, 
++     76,  83,  76,  32,  83, 104, 
++     97, 100, 101, 114,  32,  67, 
++    111, 109, 112, 105, 108, 101, 
++    114,  32,  49,  48,  46,  49, 
++      0, 171, 171, 171,  73,  83, 
++     71,  78,  80,   0,   0,   0, 
++      2,   0,   0,   0,   8,   0, 
++      0,   0,  56,   0,   0,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,   3,   0,   0,   0, 
++      0,   0,   0,   0,  15,   0, 
++      0,   0,  68,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   3,   0,   0,   0, 
++      1,   0,   0,   0,   3,   3, 
++      0,   0,  83,  86,  95,  80, 
++     79,  83,  73,  84,  73,  79, 
++     78,   0,  84,  69,  88,  67, 
++     79,  79,  82,  68,   0, 171, 
++    171, 171,  79,  83,  71,  78, 
++     44,   0,   0,   0,   1,   0, 
++      0,   0,   8,   0,   0,   0, 
++     32,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      2,   0,   0,   0,   0,   0, 
++      0,   0,  15,   0,   0,   0, 
++     83,  86,  95,  84,  65,  82, 
++     71,  69,  84,   0, 171, 171, 
++     83,  72,  68,  82,  12,   1, 
++      0,   0,  64,   0,   0,   0, 
++     67,   0,   0,   0,  88,  24, 
++      0,   4,   0, 112,  16,   0, 
++      0,   0,   0,   0,  51,  51, 
++      0,   0,  98,  16,   0,   3, 
++     50,  16,  16,   0,   1,   0, 
++      0,   0, 101,   0,   0,   3, 
++    242,  32,  16,   0,   0,   0, 
++      0,   0, 104,   0,   0,   2, 
++      1,   0,   0,   0,  61,  16, 
++      0,   7, 242,   0,  16,   0, 
++      0,   0,   0,   0,   1,  64, 
++      0,   0,   0,   0,   0,   0, 
++     70, 126,  16,   0,   0,   0, 
++      0,   0,  86,   0,   0,   5, 
++     50,   0,  16,   0,   0,   0, 
++      0,   0,  70,   0,  16,   0, 
++      0,   0,   0,   0,  56,   0, 
++      0,   7,  50,   0,  16,   0, 
++      0,   0,   0,   0,  70,   0, 
++     16,   0,   0,   0,   0,   0, 
++     70,  16,  16,   0,   1,   0, 
++      0,   0,  27,   0,   0,   5, 
++     50,   0,  16,   0,   0,   0, 
++      0,   0,  70,   0,  16,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   8, 194,   0,  16,   0, 
++      0,   0,   0,   0,   2,  64, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++     45,   0,   0,   7, 242,   0, 
++     16,   0,   0,   0,   0,   0, 
++     70,  14,  16,   0,   0,   0, 
++      0,   0,  70, 126,  16,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   5,  50,  32,  16,   0, 
++      0,   0,   0,   0,  70,   0, 
++     16,   0,   0,   0,   0,   0, 
++     54,   0,   0,   8, 194,  32, 
++     16,   0,   0,   0,   0,   0, 
++      2,  64,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,  62,   0,   0,   1, 
++     83,  84,  65,  84, 116,   0, 
++      0,   0,   9,   0,   0,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0,   2,   0,   0,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      3,   0,   0,   0,   0,   0, 
++      0,   0,   2,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0
++};
+diff --git a/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughrg2dui11ps.h b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughrg2dui11ps.h
+new file mode 100644
+index 00000000..10ce718b
+--- /dev/null
++++ b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughrg2dui11ps.h
+@@ -0,0 +1,166 @@
++#if 0
++//
++// Generated by Microsoft (R) HLSL Shader Compiler 10.1
++//
++//
++// Resource Bindings:
++//
++// Name                                 Type  Format         Dim      HLSL Bind  Count
++// ------------------------------ ---------- ------- ----------- -------------- ------
++// TextureUI                         texture   uint4          2d             t0      1 
++//
++//
++//
++// Input signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_POSITION              0   xyzw        0      POS   float       
++// TEXCOORD                 0   xy          1     NONE   float   xy  
++//
++//
++// Output signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_TARGET                0   xyzw        0   TARGET    uint   xyzw
++//
++ps_4_0
++dcl_resource_texture2d (uint,uint,uint,uint) t0
++dcl_input_ps linear v1.xy
++dcl_output o0.xyzw
++dcl_temps 1
++resinfo_uint r0.xyzw, l(0), t0.xyzw
++utof r0.xy, r0.xyxx
++mul r0.xy, r0.xyxx, v1.xyxx
++ftoi r0.xy, r0.xyxx
++mov r0.zw, l(0,0,0,0)
++ld r0.xyzw, r0.xyzw, t0.xyzw
++mov o0.xy, r0.xyxx
++mov o0.zw, l(0,0,0,0)
++ret 
++// Approximately 9 instruction slots used
++#endif
++
++const BYTE g_PS_PassthroughRG2DUI[] =
++{
++     68,  88,  66,  67, 161,  19, 
++      0, 215, 231,  88,  50, 183, 
++    124,  43, 107, 122, 144, 150, 
++    193, 168,   1,   0,   0,   0, 
++    200,   2,   0,   0,   5,   0, 
++      0,   0,  52,   0,   0,   0, 
++    172,   0,   0,   0,   4,   1, 
++      0,   0,  56,   1,   0,   0, 
++     76,   2,   0,   0,  82,  68, 
++     69,  70, 112,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++     28,   0,   0,   0,   0,   4, 
++    255, 255,   0,   1,   0,   0, 
++     70,   0,   0,   0,  60,   0, 
++      0,   0,   2,   0,   0,   0, 
++      4,   0,   0,   0,   4,   0, 
++      0,   0, 255, 255, 255, 255, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,  13,   0,   0,   0, 
++     84, 101, 120, 116, 117, 114, 
++    101,  85,  73,   0,  77, 105, 
++     99, 114, 111, 115, 111, 102, 
++    116,  32,  40,  82,  41,  32, 
++     72,  76,  83,  76,  32,  83, 
++    104,  97, 100, 101, 114,  32, 
++     67, 111, 109, 112, 105, 108, 
++    101, 114,  32,  49,  48,  46, 
++     49,   0, 171, 171,  73,  83, 
++     71,  78,  80,   0,   0,   0, 
++      2,   0,   0,   0,   8,   0, 
++      0,   0,  56,   0,   0,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,   3,   0,   0,   0, 
++      0,   0,   0,   0,  15,   0, 
++      0,   0,  68,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   3,   0,   0,   0, 
++      1,   0,   0,   0,   3,   3, 
++      0,   0,  83,  86,  95,  80, 
++     79,  83,  73,  84,  73,  79, 
++     78,   0,  84,  69,  88,  67, 
++     79,  79,  82,  68,   0, 171, 
++    171, 171,  79,  83,  71,  78, 
++     44,   0,   0,   0,   1,   0, 
++      0,   0,   8,   0,   0,   0, 
++     32,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0,  15,   0,   0,   0, 
++     83,  86,  95,  84,  65,  82, 
++     71,  69,  84,   0, 171, 171, 
++     83,  72,  68,  82,  12,   1, 
++      0,   0,  64,   0,   0,   0, 
++     67,   0,   0,   0,  88,  24, 
++      0,   4,   0, 112,  16,   0, 
++      0,   0,   0,   0,  68,  68, 
++      0,   0,  98,  16,   0,   3, 
++     50,  16,  16,   0,   1,   0, 
++      0,   0, 101,   0,   0,   3, 
++    242,  32,  16,   0,   0,   0, 
++      0,   0, 104,   0,   0,   2, 
++      1,   0,   0,   0,  61,  16, 
++      0,   7, 242,   0,  16,   0, 
++      0,   0,   0,   0,   1,  64, 
++      0,   0,   0,   0,   0,   0, 
++     70, 126,  16,   0,   0,   0, 
++      0,   0,  86,   0,   0,   5, 
++     50,   0,  16,   0,   0,   0, 
++      0,   0,  70,   0,  16,   0, 
++      0,   0,   0,   0,  56,   0, 
++      0,   7,  50,   0,  16,   0, 
++      0,   0,   0,   0,  70,   0, 
++     16,   0,   0,   0,   0,   0, 
++     70,  16,  16,   0,   1,   0, 
++      0,   0,  27,   0,   0,   5, 
++     50,   0,  16,   0,   0,   0, 
++      0,   0,  70,   0,  16,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   8, 194,   0,  16,   0, 
++      0,   0,   0,   0,   2,  64, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++     45,   0,   0,   7, 242,   0, 
++     16,   0,   0,   0,   0,   0, 
++     70,  14,  16,   0,   0,   0, 
++      0,   0,  70, 126,  16,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   5,  50,  32,  16,   0, 
++      0,   0,   0,   0,  70,   0, 
++     16,   0,   0,   0,   0,   0, 
++     54,   0,   0,   8, 194,  32, 
++     16,   0,   0,   0,   0,   0, 
++      2,  64,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,  62,   0,   0,   1, 
++     83,  84,  65,  84, 116,   0, 
++      0,   0,   9,   0,   0,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0,   2,   0,   0,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      3,   0,   0,   0,   0,   0, 
++      0,   0,   2,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0
++};
+diff --git a/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughrg3d11ps.h b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughrg3d11ps.h
+new file mode 100644
+index 00000000..556bd7a2
+--- /dev/null
++++ b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughrg3d11ps.h
+@@ -0,0 +1,161 @@
++#if 0
++//
++// Generated by Microsoft (R) HLSL Shader Compiler 10.1
++//
++//
++// Resource Bindings:
++//
++// Name                                 Type  Format         Dim      HLSL Bind  Count
++// ------------------------------ ---------- ------- ----------- -------------- ------
++// Sampler                           sampler      NA          NA             s0      1 
++// TextureF                          texture  float4          3d             t0      1 
++//
++//
++//
++// Input signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_POSITION              0   xyzw        0      POS   float       
++// SV_RENDERTARGETARRAYINDEX     0   x           1  RTINDEX    uint       
++// TEXCOORD                 0   xyz         2     NONE   float   xyz 
++//
++//
++// Output signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_TARGET                0   xyzw        0   TARGET   float   xyzw
++//
++ps_4_0
++dcl_sampler s0, mode_default
++dcl_resource_texture3d (float,float,float,float) t0
++dcl_input_ps linear v2.xyz
++dcl_output o0.xyzw
++dcl_temps 1
++sample r0.xyzw, v2.xyzx, t0.xyzw, s0
++mov o0.xy, r0.xyxx
++mov o0.zw, l(0,0,0,1.000000)
++ret 
++// Approximately 4 instruction slots used
++#endif
++
++const BYTE g_PS_PassthroughRG3D[] =
++{
++     68,  88,  66,  67, 234, 174, 
++    205,  77, 197, 154, 113, 172, 
++    235, 131,  32, 212, 121,  65, 
++    136, 164,   1,   0,   0,   0, 
++    180,   2,   0,   0,   5,   0, 
++      0,   0,  52,   0,   0,   0, 
++    212,   0,   0,   0,  92,   1, 
++      0,   0, 144,   1,   0,   0, 
++     56,   2,   0,   0,  82,  68, 
++     69,  70, 152,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   2,   0,   0,   0, 
++     28,   0,   0,   0,   0,   4, 
++    255, 255,   0,   1,   0,   0, 
++    109,   0,   0,   0,  92,   0, 
++      0,   0,   3,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,   1,   0,   0,   0, 
++    100,   0,   0,   0,   2,   0, 
++      0,   0,   5,   0,   0,   0, 
++      8,   0,   0,   0, 255, 255, 
++    255, 255,   0,   0,   0,   0, 
++      1,   0,   0,   0,  13,   0, 
++      0,   0,  83,  97, 109, 112, 
++    108, 101, 114,   0,  84, 101, 
++    120, 116, 117, 114, 101,  70, 
++      0,  77, 105,  99, 114, 111, 
++    115, 111, 102, 116,  32,  40, 
++     82,  41,  32,  72,  76,  83, 
++     76,  32,  83, 104,  97, 100, 
++    101, 114,  32,  67, 111, 109, 
++    112, 105, 108, 101, 114,  32, 
++     49,  48,  46,  49,   0, 171, 
++    171, 171,  73,  83,  71,  78, 
++    128,   0,   0,   0,   3,   0, 
++      0,   0,   8,   0,   0,   0, 
++     80,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++      3,   0,   0,   0,   0,   0, 
++      0,   0,  15,   0,   0,   0, 
++     92,   0,   0,   0,   0,   0, 
++      0,   0,   4,   0,   0,   0, 
++      1,   0,   0,   0,   1,   0, 
++      0,   0,   1,   0,   0,   0, 
++    118,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      3,   0,   0,   0,   2,   0, 
++      0,   0,   7,   7,   0,   0, 
++     83,  86,  95,  80,  79,  83, 
++     73,  84,  73,  79,  78,   0, 
++     83,  86,  95,  82,  69,  78, 
++     68,  69,  82,  84,  65,  82, 
++     71,  69,  84,  65,  82,  82, 
++     65,  89,  73,  78,  68,  69, 
++     88,   0,  84,  69,  88,  67, 
++     79,  79,  82,  68,   0, 171, 
++     79,  83,  71,  78,  44,   0, 
++      0,   0,   1,   0,   0,   0, 
++      8,   0,   0,   0,  32,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   3,   0, 
++      0,   0,   0,   0,   0,   0, 
++     15,   0,   0,   0,  83,  86, 
++     95,  84,  65,  82,  71,  69, 
++     84,   0, 171, 171,  83,  72, 
++     68,  82, 160,   0,   0,   0, 
++     64,   0,   0,   0,  40,   0, 
++      0,   0,  90,   0,   0,   3, 
++      0,  96,  16,   0,   0,   0, 
++      0,   0,  88,  40,   0,   4, 
++      0, 112,  16,   0,   0,   0, 
++      0,   0,  85,  85,   0,   0, 
++     98,  16,   0,   3, 114,  16, 
++     16,   0,   2,   0,   0,   0, 
++    101,   0,   0,   3, 242,  32, 
++     16,   0,   0,   0,   0,   0, 
++    104,   0,   0,   2,   1,   0, 
++      0,   0,  69,   0,   0,   9, 
++    242,   0,  16,   0,   0,   0, 
++      0,   0,  70,  18,  16,   0, 
++      2,   0,   0,   0,  70, 126, 
++     16,   0,   0,   0,   0,   0, 
++      0,  96,  16,   0,   0,   0, 
++      0,   0,  54,   0,   0,   5, 
++     50,  32,  16,   0,   0,   0, 
++      0,   0,  70,   0,  16,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   8, 194,  32,  16,   0, 
++      0,   0,   0,   0,   2,  64, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0, 128,  63, 
++     62,   0,   0,   1,  83,  84, 
++     65,  84, 116,   0,   0,   0, 
++      4,   0,   0,   0,   1,   0, 
++      0,   0,   0,   0,   0,   0, 
++      2,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   2,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0
++};
+diff --git a/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughrg3di11ps.h b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughrg3di11ps.h
+new file mode 100644
+index 00000000..c5d3af2a
+--- /dev/null
++++ b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughrg3di11ps.h
+@@ -0,0 +1,173 @@
++#if 0
++//
++// Generated by Microsoft (R) HLSL Shader Compiler 10.1
++//
++//
++// Resource Bindings:
++//
++// Name                                 Type  Format         Dim      HLSL Bind  Count
++// ------------------------------ ---------- ------- ----------- -------------- ------
++// TextureI                          texture   sint4          3d             t0      1 
++//
++//
++//
++// Input signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_POSITION              0   xyzw        0      POS   float       
++// SV_RENDERTARGETARRAYINDEX     0   x           1  RTINDEX    uint       
++// TEXCOORD                 0   xyz         2     NONE   float   xyz 
++//
++//
++// Output signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_TARGET                0   xyzw        0   TARGET     int   xyzw
++//
++ps_4_0
++dcl_resource_texture3d (sint,sint,sint,sint) t0
++dcl_input_ps linear v2.xyz
++dcl_output o0.xyzw
++dcl_temps 1
++resinfo_uint r0.xyzw, l(0), t0.xyzw
++utof r0.xyz, r0.xyzx
++mul r0.xyz, r0.xyzx, v2.xyzx
++ftoi r0.xyz, r0.xyzx
++mov r0.w, l(0)
++ld r0.xyzw, r0.xyzw, t0.xyzw
++mov o0.xy, r0.xyxx
++mov o0.zw, l(0,0,0,0)
++ret 
++// Approximately 9 instruction slots used
++#endif
++
++const BYTE g_PS_PassthroughRG3DI[] =
++{
++     68,  88,  66,  67, 215,  62, 
++    152, 236,  50, 188,  41, 213, 
++    133,  37,  41, 228,  13,  20, 
++      9, 166,   1,   0,   0,   0, 
++    236,   2,   0,   0,   5,   0, 
++      0,   0,  52,   0,   0,   0, 
++    172,   0,   0,   0,  52,   1, 
++      0,   0, 104,   1,   0,   0, 
++    112,   2,   0,   0,  82,  68, 
++     69,  70, 112,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++     28,   0,   0,   0,   0,   4, 
++    255, 255,   0,   1,   0,   0, 
++     69,   0,   0,   0,  60,   0, 
++      0,   0,   2,   0,   0,   0, 
++      3,   0,   0,   0,   8,   0, 
++      0,   0, 255, 255, 255, 255, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,  13,   0,   0,   0, 
++     84, 101, 120, 116, 117, 114, 
++    101,  73,   0,  77, 105,  99, 
++    114, 111, 115, 111, 102, 116, 
++     32,  40,  82,  41,  32,  72, 
++     76,  83,  76,  32,  83, 104, 
++     97, 100, 101, 114,  32,  67, 
++    111, 109, 112, 105, 108, 101, 
++    114,  32,  49,  48,  46,  49, 
++      0, 171, 171, 171,  73,  83, 
++     71,  78, 128,   0,   0,   0, 
++      3,   0,   0,   0,   8,   0, 
++      0,   0,  80,   0,   0,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,   3,   0,   0,   0, 
++      0,   0,   0,   0,  15,   0, 
++      0,   0,  92,   0,   0,   0, 
++      0,   0,   0,   0,   4,   0, 
++      0,   0,   1,   0,   0,   0, 
++      1,   0,   0,   0,   1,   0, 
++      0,   0, 118,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   3,   0,   0,   0, 
++      2,   0,   0,   0,   7,   7, 
++      0,   0,  83,  86,  95,  80, 
++     79,  83,  73,  84,  73,  79, 
++     78,   0,  83,  86,  95,  82, 
++     69,  78,  68,  69,  82,  84, 
++     65,  82,  71,  69,  84,  65, 
++     82,  82,  65,  89,  73,  78, 
++     68,  69,  88,   0,  84,  69, 
++     88,  67,  79,  79,  82,  68, 
++      0, 171,  79,  83,  71,  78, 
++     44,   0,   0,   0,   1,   0, 
++      0,   0,   8,   0,   0,   0, 
++     32,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      2,   0,   0,   0,   0,   0, 
++      0,   0,  15,   0,   0,   0, 
++     83,  86,  95,  84,  65,  82, 
++     71,  69,  84,   0, 171, 171, 
++     83,  72,  68,  82,   0,   1, 
++      0,   0,  64,   0,   0,   0, 
++     64,   0,   0,   0,  88,  40, 
++      0,   4,   0, 112,  16,   0, 
++      0,   0,   0,   0,  51,  51, 
++      0,   0,  98,  16,   0,   3, 
++    114,  16,  16,   0,   2,   0, 
++      0,   0, 101,   0,   0,   3, 
++    242,  32,  16,   0,   0,   0, 
++      0,   0, 104,   0,   0,   2, 
++      1,   0,   0,   0,  61,  16, 
++      0,   7, 242,   0,  16,   0, 
++      0,   0,   0,   0,   1,  64, 
++      0,   0,   0,   0,   0,   0, 
++     70, 126,  16,   0,   0,   0, 
++      0,   0,  86,   0,   0,   5, 
++    114,   0,  16,   0,   0,   0, 
++      0,   0,  70,   2,  16,   0, 
++      0,   0,   0,   0,  56,   0, 
++      0,   7, 114,   0,  16,   0, 
++      0,   0,   0,   0,  70,   2, 
++     16,   0,   0,   0,   0,   0, 
++     70,  18,  16,   0,   2,   0, 
++      0,   0,  27,   0,   0,   5, 
++    114,   0,  16,   0,   0,   0, 
++      0,   0,  70,   2,  16,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   5, 130,   0,  16,   0, 
++      0,   0,   0,   0,   1,  64, 
++      0,   0,   0,   0,   0,   0, 
++     45,   0,   0,   7, 242,   0, 
++     16,   0,   0,   0,   0,   0, 
++     70,  14,  16,   0,   0,   0, 
++      0,   0,  70, 126,  16,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   5,  50,  32,  16,   0, 
++      0,   0,   0,   0,  70,   0, 
++     16,   0,   0,   0,   0,   0, 
++     54,   0,   0,   8, 194,  32, 
++     16,   0,   0,   0,   0,   0, 
++      2,  64,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,  62,   0,   0,   1, 
++     83,  84,  65,  84, 116,   0, 
++      0,   0,   9,   0,   0,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0,   2,   0,   0,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      3,   0,   0,   0,   0,   0, 
++      0,   0,   2,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0
++};
+diff --git a/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughrg3dui11ps.h b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughrg3dui11ps.h
+new file mode 100644
+index 00000000..24c69100
+--- /dev/null
++++ b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughrg3dui11ps.h
+@@ -0,0 +1,173 @@
++#if 0
++//
++// Generated by Microsoft (R) HLSL Shader Compiler 10.1
++//
++//
++// Resource Bindings:
++//
++// Name                                 Type  Format         Dim      HLSL Bind  Count
++// ------------------------------ ---------- ------- ----------- -------------- ------
++// TextureUI                         texture   uint4          3d             t0      1 
++//
++//
++//
++// Input signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_POSITION              0   xyzw        0      POS   float       
++// SV_RENDERTARGETARRAYINDEX     0   x           1  RTINDEX    uint       
++// TEXCOORD                 0   xyz         2     NONE   float   xyz 
++//
++//
++// Output signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_TARGET                0   xyzw        0   TARGET    uint   xyzw
++//
++ps_4_0
++dcl_resource_texture3d (uint,uint,uint,uint) t0
++dcl_input_ps linear v2.xyz
++dcl_output o0.xyzw
++dcl_temps 1
++resinfo_uint r0.xyzw, l(0), t0.xyzw
++utof r0.xyz, r0.xyzx
++mul r0.xyz, r0.xyzx, v2.xyzx
++ftoi r0.xyz, r0.xyzx
++mov r0.w, l(0)
++ld r0.xyzw, r0.xyzw, t0.xyzw
++mov o0.xy, r0.xyxx
++mov o0.zw, l(0,0,0,0)
++ret 
++// Approximately 9 instruction slots used
++#endif
++
++const BYTE g_PS_PassthroughRG3DUI[] =
++{
++     68,  88,  66,  67, 136, 113, 
++    120,  69, 210, 200, 206, 216, 
++    193, 132, 168, 220,  72, 141, 
++    170, 116,   1,   0,   0,   0, 
++    236,   2,   0,   0,   5,   0, 
++      0,   0,  52,   0,   0,   0, 
++    172,   0,   0,   0,  52,   1, 
++      0,   0, 104,   1,   0,   0, 
++    112,   2,   0,   0,  82,  68, 
++     69,  70, 112,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++     28,   0,   0,   0,   0,   4, 
++    255, 255,   0,   1,   0,   0, 
++     70,   0,   0,   0,  60,   0, 
++      0,   0,   2,   0,   0,   0, 
++      4,   0,   0,   0,   8,   0, 
++      0,   0, 255, 255, 255, 255, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,  13,   0,   0,   0, 
++     84, 101, 120, 116, 117, 114, 
++    101,  85,  73,   0,  77, 105, 
++     99, 114, 111, 115, 111, 102, 
++    116,  32,  40,  82,  41,  32, 
++     72,  76,  83,  76,  32,  83, 
++    104,  97, 100, 101, 114,  32, 
++     67, 111, 109, 112, 105, 108, 
++    101, 114,  32,  49,  48,  46, 
++     49,   0, 171, 171,  73,  83, 
++     71,  78, 128,   0,   0,   0, 
++      3,   0,   0,   0,   8,   0, 
++      0,   0,  80,   0,   0,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,   3,   0,   0,   0, 
++      0,   0,   0,   0,  15,   0, 
++      0,   0,  92,   0,   0,   0, 
++      0,   0,   0,   0,   4,   0, 
++      0,   0,   1,   0,   0,   0, 
++      1,   0,   0,   0,   1,   0, 
++      0,   0, 118,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   3,   0,   0,   0, 
++      2,   0,   0,   0,   7,   7, 
++      0,   0,  83,  86,  95,  80, 
++     79,  83,  73,  84,  73,  79, 
++     78,   0,  83,  86,  95,  82, 
++     69,  78,  68,  69,  82,  84, 
++     65,  82,  71,  69,  84,  65, 
++     82,  82,  65,  89,  73,  78, 
++     68,  69,  88,   0,  84,  69, 
++     88,  67,  79,  79,  82,  68, 
++      0, 171,  79,  83,  71,  78, 
++     44,   0,   0,   0,   1,   0, 
++      0,   0,   8,   0,   0,   0, 
++     32,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0,  15,   0,   0,   0, 
++     83,  86,  95,  84,  65,  82, 
++     71,  69,  84,   0, 171, 171, 
++     83,  72,  68,  82,   0,   1, 
++      0,   0,  64,   0,   0,   0, 
++     64,   0,   0,   0,  88,  40, 
++      0,   4,   0, 112,  16,   0, 
++      0,   0,   0,   0,  68,  68, 
++      0,   0,  98,  16,   0,   3, 
++    114,  16,  16,   0,   2,   0, 
++      0,   0, 101,   0,   0,   3, 
++    242,  32,  16,   0,   0,   0, 
++      0,   0, 104,   0,   0,   2, 
++      1,   0,   0,   0,  61,  16, 
++      0,   7, 242,   0,  16,   0, 
++      0,   0,   0,   0,   1,  64, 
++      0,   0,   0,   0,   0,   0, 
++     70, 126,  16,   0,   0,   0, 
++      0,   0,  86,   0,   0,   5, 
++    114,   0,  16,   0,   0,   0, 
++      0,   0,  70,   2,  16,   0, 
++      0,   0,   0,   0,  56,   0, 
++      0,   7, 114,   0,  16,   0, 
++      0,   0,   0,   0,  70,   2, 
++     16,   0,   0,   0,   0,   0, 
++     70,  18,  16,   0,   2,   0, 
++      0,   0,  27,   0,   0,   5, 
++    114,   0,  16,   0,   0,   0, 
++      0,   0,  70,   2,  16,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   5, 130,   0,  16,   0, 
++      0,   0,   0,   0,   1,  64, 
++      0,   0,   0,   0,   0,   0, 
++     45,   0,   0,   7, 242,   0, 
++     16,   0,   0,   0,   0,   0, 
++     70,  14,  16,   0,   0,   0, 
++      0,   0,  70, 126,  16,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   5,  50,  32,  16,   0, 
++      0,   0,   0,   0,  70,   0, 
++     16,   0,   0,   0,   0,   0, 
++     54,   0,   0,   8, 194,  32, 
++     16,   0,   0,   0,   0,   0, 
++      2,  64,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,  62,   0,   0,   1, 
++     83,  84,  65,  84, 116,   0, 
++      0,   0,   9,   0,   0,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0,   2,   0,   0,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      3,   0,   0,   0,   0,   0, 
++      0,   0,   2,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0
++};
+diff --git a/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughrgb2d11ps.h b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughrgb2d11ps.h
+new file mode 100644
+index 00000000..3875d25d
+--- /dev/null
++++ b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughrgb2d11ps.h
+@@ -0,0 +1,195 @@
++#if 0
++//
++// Generated by Microsoft (R) HLSL Shader Compiler 10.1
++//
++//
++// Resource Bindings:
++//
++// Name                                 Type  Format         Dim      HLSL Bind  Count
++// ------------------------------ ---------- ------- ----------- -------------- ------
++// Sampler                           sampler      NA          NA             s0      1 
++// TextureF                          texture  float4          2d             t0      1 
++//
++//
++//
++// Input signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_POSITION              0   xyzw        0      POS   float       
++// TEXCOORD                 0   xy          1     NONE   float   xy  
++//
++//
++// Output signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_TARGET                0   xyzw        0   TARGET   float   xyzw
++//
++//
++// Sampler/Resource to DX9 shader sampler mappings:
++//
++// Target Sampler Source Sampler  Source Resource
++// -------------- --------------- ----------------
++// s0             s0              t0               
++//
++//
++// Level9 shader bytecode:
++//
++    ps_2_x
++    def c0, 1, 0, 0, 0
++    dcl t0.xy
++    dcl_2d s0
++    texld r0, t0, s0
++    mad r0, r0.xyzx, c0.xxxy, c0.yyyx
++    mov oC0, r0
++
++// approximately 3 instruction slots used (1 texture, 2 arithmetic)
++ps_4_0
++dcl_sampler s0, mode_default
++dcl_resource_texture2d (float,float,float,float) t0
++dcl_input_ps linear v1.xy
++dcl_output o0.xyzw
++dcl_temps 1
++sample r0.xyzw, v1.xyxx, t0.xyzw, s0
++mov o0.xyz, r0.xyzx
++mov o0.w, l(1.000000)
++ret 
++// Approximately 4 instruction slots used
++#endif
++
++const BYTE g_PS_PassthroughRGB2D[] =
++{
++     68,  88,  66,  67, 250,  48, 
++    137,  17, 146, 199, 249,  10, 
++    198, 141, 227, 123, 246, 248, 
++    120,  90,   1,   0,   0,   0, 
++     20,   3,   0,   0,   6,   0, 
++      0,   0,  56,   0,   0,   0, 
++    208,   0,   0,   0, 108,   1, 
++      0,   0, 232,   1,   0,   0, 
++    136,   2,   0,   0, 224,   2, 
++      0,   0,  65, 111, 110,  57, 
++    144,   0,   0,   0, 144,   0, 
++      0,   0,   0,   2, 255, 255, 
++    104,   0,   0,   0,  40,   0, 
++      0,   0,   0,   0,  40,   0, 
++      0,   0,  40,   0,   0,   0, 
++     40,   0,   1,   0,  36,   0, 
++      0,   0,  40,   0,   0,   0, 
++      0,   0,   1,   2, 255, 255, 
++     81,   0,   0,   5,   0,   0, 
++     15, 160,   0,   0, 128,  63, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++     31,   0,   0,   2,   0,   0, 
++      0, 128,   0,   0,   3, 176, 
++     31,   0,   0,   2,   0,   0, 
++      0, 144,   0,   8,  15, 160, 
++     66,   0,   0,   3,   0,   0, 
++     15, 128,   0,   0, 228, 176, 
++      0,   8, 228, 160,   4,   0, 
++      0,   4,   0,   0,  15, 128, 
++      0,   0,  36, 128,   0,   0, 
++     64, 160,   0,   0,  21, 160, 
++      1,   0,   0,   2,   0,   8, 
++     15, 128,   0,   0, 228, 128, 
++    255, 255,   0,   0,  83,  72, 
++     68,  82, 148,   0,   0,   0, 
++     64,   0,   0,   0,  37,   0, 
++      0,   0,  90,   0,   0,   3, 
++      0,  96,  16,   0,   0,   0, 
++      0,   0,  88,  24,   0,   4, 
++      0, 112,  16,   0,   0,   0, 
++      0,   0,  85,  85,   0,   0, 
++     98,  16,   0,   3,  50,  16, 
++     16,   0,   1,   0,   0,   0, 
++    101,   0,   0,   3, 242,  32, 
++     16,   0,   0,   0,   0,   0, 
++    104,   0,   0,   2,   1,   0, 
++      0,   0,  69,   0,   0,   9, 
++    242,   0,  16,   0,   0,   0, 
++      0,   0,  70,  16,  16,   0, 
++      1,   0,   0,   0,  70, 126, 
++     16,   0,   0,   0,   0,   0, 
++      0,  96,  16,   0,   0,   0, 
++      0,   0,  54,   0,   0,   5, 
++    114,  32,  16,   0,   0,   0, 
++      0,   0,  70,   2,  16,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   5, 130,  32,  16,   0, 
++      0,   0,   0,   0,   1,  64, 
++      0,   0,   0,   0, 128,  63, 
++     62,   0,   0,   1,  83,  84, 
++     65,  84, 116,   0,   0,   0, 
++      4,   0,   0,   0,   1,   0, 
++      0,   0,   0,   0,   0,   0, 
++      2,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   2,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,  82,  68,  69,  70, 
++    152,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      2,   0,   0,   0,  28,   0, 
++      0,   0,   0,   4, 255, 255, 
++      0,   1,   0,   0, 109,   0, 
++      0,   0,  92,   0,   0,   0, 
++      3,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++      1,   0,   0,   0, 100,   0, 
++      0,   0,   2,   0,   0,   0, 
++      5,   0,   0,   0,   4,   0, 
++      0,   0, 255, 255, 255, 255, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,  13,   0,   0,   0, 
++     83,  97, 109, 112, 108, 101, 
++    114,   0,  84, 101, 120, 116, 
++    117, 114, 101,  70,   0,  77, 
++    105,  99, 114, 111, 115, 111, 
++    102, 116,  32,  40,  82,  41, 
++     32,  72,  76,  83,  76,  32, 
++     83, 104,  97, 100, 101, 114, 
++     32,  67, 111, 109, 112, 105, 
++    108, 101, 114,  32,  49,  48, 
++     46,  49,   0, 171, 171, 171, 
++     73,  83,  71,  78,  80,   0, 
++      0,   0,   2,   0,   0,   0, 
++      8,   0,   0,   0,  56,   0, 
++      0,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0,   3,   0, 
++      0,   0,   0,   0,   0,   0, 
++     15,   0,   0,   0,  68,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   3,   0, 
++      0,   0,   1,   0,   0,   0, 
++      3,   3,   0,   0,  83,  86, 
++     95,  80,  79,  83,  73,  84, 
++     73,  79,  78,   0,  84,  69, 
++     88,  67,  79,  79,  82,  68, 
++      0, 171, 171, 171,  79,  83, 
++     71,  78,  44,   0,   0,   0, 
++      1,   0,   0,   0,   8,   0, 
++      0,   0,  32,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   3,   0,   0,   0, 
++      0,   0,   0,   0,  15,   0, 
++      0,   0,  83,  86,  95,  84, 
++     65,  82,  71,  69,  84,   0, 
++    171, 171
++};
+diff --git a/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughrgb2di11ps.h b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughrgb2di11ps.h
+new file mode 100644
+index 00000000..62c1c415
+--- /dev/null
++++ b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughrgb2di11ps.h
+@@ -0,0 +1,164 @@
++#if 0
++//
++// Generated by Microsoft (R) HLSL Shader Compiler 10.1
++//
++//
++// Resource Bindings:
++//
++// Name                                 Type  Format         Dim      HLSL Bind  Count
++// ------------------------------ ---------- ------- ----------- -------------- ------
++// TextureI                          texture   sint4          2d             t0      1 
++//
++//
++//
++// Input signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_POSITION              0   xyzw        0      POS   float       
++// TEXCOORD                 0   xy          1     NONE   float   xy  
++//
++//
++// Output signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_TARGET                0   xyzw        0   TARGET     int   xyzw
++//
++ps_4_0
++dcl_resource_texture2d (sint,sint,sint,sint) t0
++dcl_input_ps linear v1.xy
++dcl_output o0.xyzw
++dcl_temps 1
++resinfo_uint r0.xyzw, l(0), t0.xyzw
++utof r0.xy, r0.xyxx
++mul r0.xy, r0.xyxx, v1.xyxx
++ftoi r0.xy, r0.xyxx
++mov r0.zw, l(0,0,0,0)
++ld r0.xyzw, r0.xyzw, t0.xyzw
++mov o0.xyz, r0.xyzx
++mov o0.w, l(0)
++ret 
++// Approximately 9 instruction slots used
++#endif
++
++const BYTE g_PS_PassthroughRGB2DI[] =
++{
++     68,  88,  66,  67, 190, 234, 
++    127, 190, 151,  71, 156, 183, 
++    160,  74, 156, 153,  91,  12, 
++     95,  85,   1,   0,   0,   0, 
++    188,   2,   0,   0,   5,   0, 
++      0,   0,  52,   0,   0,   0, 
++    172,   0,   0,   0,   4,   1, 
++      0,   0,  56,   1,   0,   0, 
++     64,   2,   0,   0,  82,  68, 
++     69,  70, 112,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++     28,   0,   0,   0,   0,   4, 
++    255, 255,   0,   1,   0,   0, 
++     69,   0,   0,   0,  60,   0, 
++      0,   0,   2,   0,   0,   0, 
++      3,   0,   0,   0,   4,   0, 
++      0,   0, 255, 255, 255, 255, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,  13,   0,   0,   0, 
++     84, 101, 120, 116, 117, 114, 
++    101,  73,   0,  77, 105,  99, 
++    114, 111, 115, 111, 102, 116, 
++     32,  40,  82,  41,  32,  72, 
++     76,  83,  76,  32,  83, 104, 
++     97, 100, 101, 114,  32,  67, 
++    111, 109, 112, 105, 108, 101, 
++    114,  32,  49,  48,  46,  49, 
++      0, 171, 171, 171,  73,  83, 
++     71,  78,  80,   0,   0,   0, 
++      2,   0,   0,   0,   8,   0, 
++      0,   0,  56,   0,   0,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,   3,   0,   0,   0, 
++      0,   0,   0,   0,  15,   0, 
++      0,   0,  68,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   3,   0,   0,   0, 
++      1,   0,   0,   0,   3,   3, 
++      0,   0,  83,  86,  95,  80, 
++     79,  83,  73,  84,  73,  79, 
++     78,   0,  84,  69,  88,  67, 
++     79,  79,  82,  68,   0, 171, 
++    171, 171,  79,  83,  71,  78, 
++     44,   0,   0,   0,   1,   0, 
++      0,   0,   8,   0,   0,   0, 
++     32,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      2,   0,   0,   0,   0,   0, 
++      0,   0,  15,   0,   0,   0, 
++     83,  86,  95,  84,  65,  82, 
++     71,  69,  84,   0, 171, 171, 
++     83,  72,  68,  82,   0,   1, 
++      0,   0,  64,   0,   0,   0, 
++     64,   0,   0,   0,  88,  24, 
++      0,   4,   0, 112,  16,   0, 
++      0,   0,   0,   0,  51,  51, 
++      0,   0,  98,  16,   0,   3, 
++     50,  16,  16,   0,   1,   0, 
++      0,   0, 101,   0,   0,   3, 
++    242,  32,  16,   0,   0,   0, 
++      0,   0, 104,   0,   0,   2, 
++      1,   0,   0,   0,  61,  16, 
++      0,   7, 242,   0,  16,   0, 
++      0,   0,   0,   0,   1,  64, 
++      0,   0,   0,   0,   0,   0, 
++     70, 126,  16,   0,   0,   0, 
++      0,   0,  86,   0,   0,   5, 
++     50,   0,  16,   0,   0,   0, 
++      0,   0,  70,   0,  16,   0, 
++      0,   0,   0,   0,  56,   0, 
++      0,   7,  50,   0,  16,   0, 
++      0,   0,   0,   0,  70,   0, 
++     16,   0,   0,   0,   0,   0, 
++     70,  16,  16,   0,   1,   0, 
++      0,   0,  27,   0,   0,   5, 
++     50,   0,  16,   0,   0,   0, 
++      0,   0,  70,   0,  16,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   8, 194,   0,  16,   0, 
++      0,   0,   0,   0,   2,  64, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++     45,   0,   0,   7, 242,   0, 
++     16,   0,   0,   0,   0,   0, 
++     70,  14,  16,   0,   0,   0, 
++      0,   0,  70, 126,  16,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   5, 114,  32,  16,   0, 
++      0,   0,   0,   0,  70,   2, 
++     16,   0,   0,   0,   0,   0, 
++     54,   0,   0,   5, 130,  32, 
++     16,   0,   0,   0,   0,   0, 
++      1,  64,   0,   0,   0,   0, 
++      0,   0,  62,   0,   0,   1, 
++     83,  84,  65,  84, 116,   0, 
++      0,   0,   9,   0,   0,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0,   2,   0,   0,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      3,   0,   0,   0,   0,   0, 
++      0,   0,   2,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0
++};
+diff --git a/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughrgb2dui11ps.h b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughrgb2dui11ps.h
+new file mode 100644
+index 00000000..71f77d22
+--- /dev/null
++++ b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughrgb2dui11ps.h
+@@ -0,0 +1,164 @@
++#if 0
++//
++// Generated by Microsoft (R) HLSL Shader Compiler 10.1
++//
++//
++// Resource Bindings:
++//
++// Name                                 Type  Format         Dim      HLSL Bind  Count
++// ------------------------------ ---------- ------- ----------- -------------- ------
++// TextureUI                         texture   uint4          2d             t0      1 
++//
++//
++//
++// Input signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_POSITION              0   xyzw        0      POS   float       
++// TEXCOORD                 0   xy          1     NONE   float   xy  
++//
++//
++// Output signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_TARGET                0   xyzw        0   TARGET    uint   xyzw
++//
++ps_4_0
++dcl_resource_texture2d (uint,uint,uint,uint) t0
++dcl_input_ps linear v1.xy
++dcl_output o0.xyzw
++dcl_temps 1
++resinfo_uint r0.xyzw, l(0), t0.xyzw
++utof r0.xy, r0.xyxx
++mul r0.xy, r0.xyxx, v1.xyxx
++ftoi r0.xy, r0.xyxx
++mov r0.zw, l(0,0,0,0)
++ld r0.xyzw, r0.xyzw, t0.xyzw
++mov o0.xyz, r0.xyzx
++mov o0.w, l(0)
++ret 
++// Approximately 9 instruction slots used
++#endif
++
++const BYTE g_PS_PassthroughRGB2DUI[] =
++{
++     68,  88,  66,  67, 240,  47, 
++     31,  84,  32, 155, 233,  36, 
++    235,  43,  92, 251, 152,  13, 
++    113, 169,   1,   0,   0,   0, 
++    188,   2,   0,   0,   5,   0, 
++      0,   0,  52,   0,   0,   0, 
++    172,   0,   0,   0,   4,   1, 
++      0,   0,  56,   1,   0,   0, 
++     64,   2,   0,   0,  82,  68, 
++     69,  70, 112,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++     28,   0,   0,   0,   0,   4, 
++    255, 255,   0,   1,   0,   0, 
++     70,   0,   0,   0,  60,   0, 
++      0,   0,   2,   0,   0,   0, 
++      4,   0,   0,   0,   4,   0, 
++      0,   0, 255, 255, 255, 255, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,  13,   0,   0,   0, 
++     84, 101, 120, 116, 117, 114, 
++    101,  85,  73,   0,  77, 105, 
++     99, 114, 111, 115, 111, 102, 
++    116,  32,  40,  82,  41,  32, 
++     72,  76,  83,  76,  32,  83, 
++    104,  97, 100, 101, 114,  32, 
++     67, 111, 109, 112, 105, 108, 
++    101, 114,  32,  49,  48,  46, 
++     49,   0, 171, 171,  73,  83, 
++     71,  78,  80,   0,   0,   0, 
++      2,   0,   0,   0,   8,   0, 
++      0,   0,  56,   0,   0,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,   3,   0,   0,   0, 
++      0,   0,   0,   0,  15,   0, 
++      0,   0,  68,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   3,   0,   0,   0, 
++      1,   0,   0,   0,   3,   3, 
++      0,   0,  83,  86,  95,  80, 
++     79,  83,  73,  84,  73,  79, 
++     78,   0,  84,  69,  88,  67, 
++     79,  79,  82,  68,   0, 171, 
++    171, 171,  79,  83,  71,  78, 
++     44,   0,   0,   0,   1,   0, 
++      0,   0,   8,   0,   0,   0, 
++     32,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0,  15,   0,   0,   0, 
++     83,  86,  95,  84,  65,  82, 
++     71,  69,  84,   0, 171, 171, 
++     83,  72,  68,  82,   0,   1, 
++      0,   0,  64,   0,   0,   0, 
++     64,   0,   0,   0,  88,  24, 
++      0,   4,   0, 112,  16,   0, 
++      0,   0,   0,   0,  68,  68, 
++      0,   0,  98,  16,   0,   3, 
++     50,  16,  16,   0,   1,   0, 
++      0,   0, 101,   0,   0,   3, 
++    242,  32,  16,   0,   0,   0, 
++      0,   0, 104,   0,   0,   2, 
++      1,   0,   0,   0,  61,  16, 
++      0,   7, 242,   0,  16,   0, 
++      0,   0,   0,   0,   1,  64, 
++      0,   0,   0,   0,   0,   0, 
++     70, 126,  16,   0,   0,   0, 
++      0,   0,  86,   0,   0,   5, 
++     50,   0,  16,   0,   0,   0, 
++      0,   0,  70,   0,  16,   0, 
++      0,   0,   0,   0,  56,   0, 
++      0,   7,  50,   0,  16,   0, 
++      0,   0,   0,   0,  70,   0, 
++     16,   0,   0,   0,   0,   0, 
++     70,  16,  16,   0,   1,   0, 
++      0,   0,  27,   0,   0,   5, 
++     50,   0,  16,   0,   0,   0, 
++      0,   0,  70,   0,  16,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   8, 194,   0,  16,   0, 
++      0,   0,   0,   0,   2,  64, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++     45,   0,   0,   7, 242,   0, 
++     16,   0,   0,   0,   0,   0, 
++     70,  14,  16,   0,   0,   0, 
++      0,   0,  70, 126,  16,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   5, 114,  32,  16,   0, 
++      0,   0,   0,   0,  70,   2, 
++     16,   0,   0,   0,   0,   0, 
++     54,   0,   0,   5, 130,  32, 
++     16,   0,   0,   0,   0,   0, 
++      1,  64,   0,   0,   0,   0, 
++      0,   0,  62,   0,   0,   1, 
++     83,  84,  65,  84, 116,   0, 
++      0,   0,   9,   0,   0,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0,   2,   0,   0,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      3,   0,   0,   0,   0,   0, 
++      0,   0,   2,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0
++};
+diff --git a/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughrgb3d11ps.h b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughrgb3d11ps.h
+new file mode 100644
+index 00000000..d7ad312a
+--- /dev/null
++++ b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughrgb3d11ps.h
+@@ -0,0 +1,159 @@
++#if 0
++//
++// Generated by Microsoft (R) HLSL Shader Compiler 10.1
++//
++//
++// Resource Bindings:
++//
++// Name                                 Type  Format         Dim      HLSL Bind  Count
++// ------------------------------ ---------- ------- ----------- -------------- ------
++// Sampler                           sampler      NA          NA             s0      1 
++// TextureF                          texture  float4          3d             t0      1 
++//
++//
++//
++// Input signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_POSITION              0   xyzw        0      POS   float       
++// SV_RENDERTARGETARRAYINDEX     0   x           1  RTINDEX    uint       
++// TEXCOORD                 0   xyz         2     NONE   float   xyz 
++//
++//
++// Output signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_TARGET                0   xyzw        0   TARGET   float   xyzw
++//
++ps_4_0
++dcl_sampler s0, mode_default
++dcl_resource_texture3d (float,float,float,float) t0
++dcl_input_ps linear v2.xyz
++dcl_output o0.xyzw
++dcl_temps 1
++sample r0.xyzw, v2.xyzx, t0.xyzw, s0
++mov o0.xyz, r0.xyzx
++mov o0.w, l(1.000000)
++ret 
++// Approximately 4 instruction slots used
++#endif
++
++const BYTE g_PS_PassthroughRGB3D[] =
++{
++     68,  88,  66,  67, 121, 178, 
++     78, 177,  99, 144, 108,  81, 
++     39, 245, 135,  91,  55,  31, 
++     56, 111,   1,   0,   0,   0, 
++    168,   2,   0,   0,   5,   0, 
++      0,   0,  52,   0,   0,   0, 
++    212,   0,   0,   0,  92,   1, 
++      0,   0, 144,   1,   0,   0, 
++     44,   2,   0,   0,  82,  68, 
++     69,  70, 152,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   2,   0,   0,   0, 
++     28,   0,   0,   0,   0,   4, 
++    255, 255,   0,   1,   0,   0, 
++    109,   0,   0,   0,  92,   0, 
++      0,   0,   3,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,   1,   0,   0,   0, 
++    100,   0,   0,   0,   2,   0, 
++      0,   0,   5,   0,   0,   0, 
++      8,   0,   0,   0, 255, 255, 
++    255, 255,   0,   0,   0,   0, 
++      1,   0,   0,   0,  13,   0, 
++      0,   0,  83,  97, 109, 112, 
++    108, 101, 114,   0,  84, 101, 
++    120, 116, 117, 114, 101,  70, 
++      0,  77, 105,  99, 114, 111, 
++    115, 111, 102, 116,  32,  40, 
++     82,  41,  32,  72,  76,  83, 
++     76,  32,  83, 104,  97, 100, 
++    101, 114,  32,  67, 111, 109, 
++    112, 105, 108, 101, 114,  32, 
++     49,  48,  46,  49,   0, 171, 
++    171, 171,  73,  83,  71,  78, 
++    128,   0,   0,   0,   3,   0, 
++      0,   0,   8,   0,   0,   0, 
++     80,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++      3,   0,   0,   0,   0,   0, 
++      0,   0,  15,   0,   0,   0, 
++     92,   0,   0,   0,   0,   0, 
++      0,   0,   4,   0,   0,   0, 
++      1,   0,   0,   0,   1,   0, 
++      0,   0,   1,   0,   0,   0, 
++    118,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      3,   0,   0,   0,   2,   0, 
++      0,   0,   7,   7,   0,   0, 
++     83,  86,  95,  80,  79,  83, 
++     73,  84,  73,  79,  78,   0, 
++     83,  86,  95,  82,  69,  78, 
++     68,  69,  82,  84,  65,  82, 
++     71,  69,  84,  65,  82,  82, 
++     65,  89,  73,  78,  68,  69, 
++     88,   0,  84,  69,  88,  67, 
++     79,  79,  82,  68,   0, 171, 
++     79,  83,  71,  78,  44,   0, 
++      0,   0,   1,   0,   0,   0, 
++      8,   0,   0,   0,  32,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   3,   0, 
++      0,   0,   0,   0,   0,   0, 
++     15,   0,   0,   0,  83,  86, 
++     95,  84,  65,  82,  71,  69, 
++     84,   0, 171, 171,  83,  72, 
++     68,  82, 148,   0,   0,   0, 
++     64,   0,   0,   0,  37,   0, 
++      0,   0,  90,   0,   0,   3, 
++      0,  96,  16,   0,   0,   0, 
++      0,   0,  88,  40,   0,   4, 
++      0, 112,  16,   0,   0,   0, 
++      0,   0,  85,  85,   0,   0, 
++     98,  16,   0,   3, 114,  16, 
++     16,   0,   2,   0,   0,   0, 
++    101,   0,   0,   3, 242,  32, 
++     16,   0,   0,   0,   0,   0, 
++    104,   0,   0,   2,   1,   0, 
++      0,   0,  69,   0,   0,   9, 
++    242,   0,  16,   0,   0,   0, 
++      0,   0,  70,  18,  16,   0, 
++      2,   0,   0,   0,  70, 126, 
++     16,   0,   0,   0,   0,   0, 
++      0,  96,  16,   0,   0,   0, 
++      0,   0,  54,   0,   0,   5, 
++    114,  32,  16,   0,   0,   0, 
++      0,   0,  70,   2,  16,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   5, 130,  32,  16,   0, 
++      0,   0,   0,   0,   1,  64, 
++      0,   0,   0,   0, 128,  63, 
++     62,   0,   0,   1,  83,  84, 
++     65,  84, 116,   0,   0,   0, 
++      4,   0,   0,   0,   1,   0, 
++      0,   0,   0,   0,   0,   0, 
++      2,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   2,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0
++};
+diff --git a/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughrgb3di11ps.h b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughrgb3di11ps.h
+new file mode 100644
+index 00000000..765526ea
+--- /dev/null
++++ b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughrgb3di11ps.h
+@@ -0,0 +1,171 @@
++#if 0
++//
++// Generated by Microsoft (R) HLSL Shader Compiler 10.1
++//
++//
++// Resource Bindings:
++//
++// Name                                 Type  Format         Dim      HLSL Bind  Count
++// ------------------------------ ---------- ------- ----------- -------------- ------
++// TextureI                          texture   sint4          3d             t0      1 
++//
++//
++//
++// Input signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_POSITION              0   xyzw        0      POS   float       
++// SV_RENDERTARGETARRAYINDEX     0   x           1  RTINDEX    uint       
++// TEXCOORD                 0   xyz         2     NONE   float   xyz 
++//
++//
++// Output signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_TARGET                0   xyzw        0   TARGET     int   xyzw
++//
++ps_4_0
++dcl_resource_texture3d (sint,sint,sint,sint) t0
++dcl_input_ps linear v2.xyz
++dcl_output o0.xyzw
++dcl_temps 1
++resinfo_uint r0.xyzw, l(0), t0.xyzw
++utof r0.xyz, r0.xyzx
++mul r0.xyz, r0.xyzx, v2.xyzx
++ftoi r0.xyz, r0.xyzx
++mov r0.w, l(0)
++ld r0.xyzw, r0.xyzw, t0.xyzw
++mov o0.xyz, r0.xyzx
++mov o0.w, l(0)
++ret 
++// Approximately 9 instruction slots used
++#endif
++
++const BYTE g_PS_PassthroughRGB3DI[] =
++{
++     68,  88,  66,  67, 122,  80, 
++    149,  91, 225,  62,  16, 173, 
++     12, 194, 248,  74, 159,  33, 
++    217, 135,   1,   0,   0,   0, 
++    224,   2,   0,   0,   5,   0, 
++      0,   0,  52,   0,   0,   0, 
++    172,   0,   0,   0,  52,   1, 
++      0,   0, 104,   1,   0,   0, 
++    100,   2,   0,   0,  82,  68, 
++     69,  70, 112,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++     28,   0,   0,   0,   0,   4, 
++    255, 255,   0,   1,   0,   0, 
++     69,   0,   0,   0,  60,   0, 
++      0,   0,   2,   0,   0,   0, 
++      3,   0,   0,   0,   8,   0, 
++      0,   0, 255, 255, 255, 255, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,  13,   0,   0,   0, 
++     84, 101, 120, 116, 117, 114, 
++    101,  73,   0,  77, 105,  99, 
++    114, 111, 115, 111, 102, 116, 
++     32,  40,  82,  41,  32,  72, 
++     76,  83,  76,  32,  83, 104, 
++     97, 100, 101, 114,  32,  67, 
++    111, 109, 112, 105, 108, 101, 
++    114,  32,  49,  48,  46,  49, 
++      0, 171, 171, 171,  73,  83, 
++     71,  78, 128,   0,   0,   0, 
++      3,   0,   0,   0,   8,   0, 
++      0,   0,  80,   0,   0,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,   3,   0,   0,   0, 
++      0,   0,   0,   0,  15,   0, 
++      0,   0,  92,   0,   0,   0, 
++      0,   0,   0,   0,   4,   0, 
++      0,   0,   1,   0,   0,   0, 
++      1,   0,   0,   0,   1,   0, 
++      0,   0, 118,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   3,   0,   0,   0, 
++      2,   0,   0,   0,   7,   7, 
++      0,   0,  83,  86,  95,  80, 
++     79,  83,  73,  84,  73,  79, 
++     78,   0,  83,  86,  95,  82, 
++     69,  78,  68,  69,  82,  84, 
++     65,  82,  71,  69,  84,  65, 
++     82,  82,  65,  89,  73,  78, 
++     68,  69,  88,   0,  84,  69, 
++     88,  67,  79,  79,  82,  68, 
++      0, 171,  79,  83,  71,  78, 
++     44,   0,   0,   0,   1,   0, 
++      0,   0,   8,   0,   0,   0, 
++     32,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      2,   0,   0,   0,   0,   0, 
++      0,   0,  15,   0,   0,   0, 
++     83,  86,  95,  84,  65,  82, 
++     71,  69,  84,   0, 171, 171, 
++     83,  72,  68,  82, 244,   0, 
++      0,   0,  64,   0,   0,   0, 
++     61,   0,   0,   0,  88,  40, 
++      0,   4,   0, 112,  16,   0, 
++      0,   0,   0,   0,  51,  51, 
++      0,   0,  98,  16,   0,   3, 
++    114,  16,  16,   0,   2,   0, 
++      0,   0, 101,   0,   0,   3, 
++    242,  32,  16,   0,   0,   0, 
++      0,   0, 104,   0,   0,   2, 
++      1,   0,   0,   0,  61,  16, 
++      0,   7, 242,   0,  16,   0, 
++      0,   0,   0,   0,   1,  64, 
++      0,   0,   0,   0,   0,   0, 
++     70, 126,  16,   0,   0,   0, 
++      0,   0,  86,   0,   0,   5, 
++    114,   0,  16,   0,   0,   0, 
++      0,   0,  70,   2,  16,   0, 
++      0,   0,   0,   0,  56,   0, 
++      0,   7, 114,   0,  16,   0, 
++      0,   0,   0,   0,  70,   2, 
++     16,   0,   0,   0,   0,   0, 
++     70,  18,  16,   0,   2,   0, 
++      0,   0,  27,   0,   0,   5, 
++    114,   0,  16,   0,   0,   0, 
++      0,   0,  70,   2,  16,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   5, 130,   0,  16,   0, 
++      0,   0,   0,   0,   1,  64, 
++      0,   0,   0,   0,   0,   0, 
++     45,   0,   0,   7, 242,   0, 
++     16,   0,   0,   0,   0,   0, 
++     70,  14,  16,   0,   0,   0, 
++      0,   0,  70, 126,  16,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   5, 114,  32,  16,   0, 
++      0,   0,   0,   0,  70,   2, 
++     16,   0,   0,   0,   0,   0, 
++     54,   0,   0,   5, 130,  32, 
++     16,   0,   0,   0,   0,   0, 
++      1,  64,   0,   0,   0,   0, 
++      0,   0,  62,   0,   0,   1, 
++     83,  84,  65,  84, 116,   0, 
++      0,   0,   9,   0,   0,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0,   2,   0,   0,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      3,   0,   0,   0,   0,   0, 
++      0,   0,   2,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0
++};
+diff --git a/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughrgb3dui11ps.h b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughrgb3dui11ps.h
+new file mode 100644
+index 00000000..ec9c5662
+--- /dev/null
++++ b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughrgb3dui11ps.h
+@@ -0,0 +1,171 @@
++#if 0
++//
++// Generated by Microsoft (R) HLSL Shader Compiler 10.1
++//
++//
++// Resource Bindings:
++//
++// Name                                 Type  Format         Dim      HLSL Bind  Count
++// ------------------------------ ---------- ------- ----------- -------------- ------
++// TextureUI                         texture   uint4          3d             t0      1 
++//
++//
++//
++// Input signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_POSITION              0   xyzw        0      POS   float       
++// SV_RENDERTARGETARRAYINDEX     0   x           1  RTINDEX    uint       
++// TEXCOORD                 0   xyz         2     NONE   float   xyz 
++//
++//
++// Output signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_TARGET                0   xyzw        0   TARGET    uint   xyzw
++//
++ps_4_0
++dcl_resource_texture3d (uint,uint,uint,uint) t0
++dcl_input_ps linear v2.xyz
++dcl_output o0.xyzw
++dcl_temps 1
++resinfo_uint r0.xyzw, l(0), t0.xyzw
++utof r0.xyz, r0.xyzx
++mul r0.xyz, r0.xyzx, v2.xyzx
++ftoi r0.xyz, r0.xyzx
++mov r0.w, l(0)
++ld r0.xyzw, r0.xyzw, t0.xyzw
++mov o0.xyz, r0.xyzx
++mov o0.w, l(0)
++ret 
++// Approximately 9 instruction slots used
++#endif
++
++const BYTE g_PS_PassthroughRGB3DUI[] =
++{
++     68,  88,  66,  67, 177, 156, 
++     23, 109,  67, 253, 176, 134, 
++    182, 213, 173,  70, 148, 235, 
++     60, 205,   1,   0,   0,   0, 
++    224,   2,   0,   0,   5,   0, 
++      0,   0,  52,   0,   0,   0, 
++    172,   0,   0,   0,  52,   1, 
++      0,   0, 104,   1,   0,   0, 
++    100,   2,   0,   0,  82,  68, 
++     69,  70, 112,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++     28,   0,   0,   0,   0,   4, 
++    255, 255,   0,   1,   0,   0, 
++     70,   0,   0,   0,  60,   0, 
++      0,   0,   2,   0,   0,   0, 
++      4,   0,   0,   0,   8,   0, 
++      0,   0, 255, 255, 255, 255, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,  13,   0,   0,   0, 
++     84, 101, 120, 116, 117, 114, 
++    101,  85,  73,   0,  77, 105, 
++     99, 114, 111, 115, 111, 102, 
++    116,  32,  40,  82,  41,  32, 
++     72,  76,  83,  76,  32,  83, 
++    104,  97, 100, 101, 114,  32, 
++     67, 111, 109, 112, 105, 108, 
++    101, 114,  32,  49,  48,  46, 
++     49,   0, 171, 171,  73,  83, 
++     71,  78, 128,   0,   0,   0, 
++      3,   0,   0,   0,   8,   0, 
++      0,   0,  80,   0,   0,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,   3,   0,   0,   0, 
++      0,   0,   0,   0,  15,   0, 
++      0,   0,  92,   0,   0,   0, 
++      0,   0,   0,   0,   4,   0, 
++      0,   0,   1,   0,   0,   0, 
++      1,   0,   0,   0,   1,   0, 
++      0,   0, 118,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   3,   0,   0,   0, 
++      2,   0,   0,   0,   7,   7, 
++      0,   0,  83,  86,  95,  80, 
++     79,  83,  73,  84,  73,  79, 
++     78,   0,  83,  86,  95,  82, 
++     69,  78,  68,  69,  82,  84, 
++     65,  82,  71,  69,  84,  65, 
++     82,  82,  65,  89,  73,  78, 
++     68,  69,  88,   0,  84,  69, 
++     88,  67,  79,  79,  82,  68, 
++      0, 171,  79,  83,  71,  78, 
++     44,   0,   0,   0,   1,   0, 
++      0,   0,   8,   0,   0,   0, 
++     32,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0,  15,   0,   0,   0, 
++     83,  86,  95,  84,  65,  82, 
++     71,  69,  84,   0, 171, 171, 
++     83,  72,  68,  82, 244,   0, 
++      0,   0,  64,   0,   0,   0, 
++     61,   0,   0,   0,  88,  40, 
++      0,   4,   0, 112,  16,   0, 
++      0,   0,   0,   0,  68,  68, 
++      0,   0,  98,  16,   0,   3, 
++    114,  16,  16,   0,   2,   0, 
++      0,   0, 101,   0,   0,   3, 
++    242,  32,  16,   0,   0,   0, 
++      0,   0, 104,   0,   0,   2, 
++      1,   0,   0,   0,  61,  16, 
++      0,   7, 242,   0,  16,   0, 
++      0,   0,   0,   0,   1,  64, 
++      0,   0,   0,   0,   0,   0, 
++     70, 126,  16,   0,   0,   0, 
++      0,   0,  86,   0,   0,   5, 
++    114,   0,  16,   0,   0,   0, 
++      0,   0,  70,   2,  16,   0, 
++      0,   0,   0,   0,  56,   0, 
++      0,   7, 114,   0,  16,   0, 
++      0,   0,   0,   0,  70,   2, 
++     16,   0,   0,   0,   0,   0, 
++     70,  18,  16,   0,   2,   0, 
++      0,   0,  27,   0,   0,   5, 
++    114,   0,  16,   0,   0,   0, 
++      0,   0,  70,   2,  16,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   5, 130,   0,  16,   0, 
++      0,   0,   0,   0,   1,  64, 
++      0,   0,   0,   0,   0,   0, 
++     45,   0,   0,   7, 242,   0, 
++     16,   0,   0,   0,   0,   0, 
++     70,  14,  16,   0,   0,   0, 
++      0,   0,  70, 126,  16,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   5, 114,  32,  16,   0, 
++      0,   0,   0,   0,  70,   2, 
++     16,   0,   0,   0,   0,   0, 
++     54,   0,   0,   5, 130,  32, 
++     16,   0,   0,   0,   0,   0, 
++      1,  64,   0,   0,   0,   0, 
++      0,   0,  62,   0,   0,   1, 
++     83,  84,  65,  84, 116,   0, 
++      0,   0,   9,   0,   0,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0,   2,   0,   0,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      3,   0,   0,   0,   0,   0, 
++      0,   0,   2,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0
++};
+diff --git a/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughrgba2d11ps.h b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughrgba2d11ps.h
+new file mode 100644
+index 00000000..b6161317
+--- /dev/null
++++ b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughrgba2d11ps.h
+@@ -0,0 +1,174 @@
++#if 0
++//
++// Generated by Microsoft (R) HLSL Shader Compiler 10.1
++//
++//
++// Resource Bindings:
++//
++// Name                                 Type  Format         Dim      HLSL Bind  Count
++// ------------------------------ ---------- ------- ----------- -------------- ------
++// Sampler                           sampler      NA          NA             s0      1 
++// TextureF                          texture  float4          2d             t0      1 
++//
++//
++//
++// Input signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_POSITION              0   xyzw        0      POS   float       
++// TEXCOORD                 0   xy          1     NONE   float   xy  
++//
++//
++// Output signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_TARGET                0   xyzw        0   TARGET   float   xyzw
++//
++//
++// Sampler/Resource to DX9 shader sampler mappings:
++//
++// Target Sampler Source Sampler  Source Resource
++// -------------- --------------- ----------------
++// s0             s0              t0               
++//
++//
++// Level9 shader bytecode:
++//
++    ps_2_x
++    dcl t0.xy
++    dcl_2d s0
++    texld r0, t0, s0
++    mov oC0, r0
++
++// approximately 2 instruction slots used (1 texture, 1 arithmetic)
++ps_4_0
++dcl_sampler s0, mode_default
++dcl_resource_texture2d (float,float,float,float) t0
++dcl_input_ps linear v1.xy
++dcl_output o0.xyzw
++sample o0.xyzw, v1.xyxx, t0.xyzw, s0
++ret 
++// Approximately 2 instruction slots used
++#endif
++
++const BYTE g_PS_PassthroughRGBA2D[] =
++{
++     68,  88,  66,  67,  23,  65, 
++     12, 167,  50,  71, 137, 250, 
++    170,  67,  18, 134, 110, 213, 
++    196, 219,   1,   0,   0,   0, 
++    184,   2,   0,   0,   6,   0, 
++      0,   0,  56,   0,   0,   0, 
++    164,   0,   0,   0,  16,   1, 
++      0,   0, 140,   1,   0,   0, 
++     44,   2,   0,   0, 132,   2, 
++      0,   0,  65, 111, 110,  57, 
++    100,   0,   0,   0, 100,   0, 
++      0,   0,   0,   2, 255, 255, 
++     60,   0,   0,   0,  40,   0, 
++      0,   0,   0,   0,  40,   0, 
++      0,   0,  40,   0,   0,   0, 
++     40,   0,   1,   0,  36,   0, 
++      0,   0,  40,   0,   0,   0, 
++      0,   0,   1,   2, 255, 255, 
++     31,   0,   0,   2,   0,   0, 
++      0, 128,   0,   0,   3, 176, 
++     31,   0,   0,   2,   0,   0, 
++      0, 144,   0,   8,  15, 160, 
++     66,   0,   0,   3,   0,   0, 
++     15, 128,   0,   0, 228, 176, 
++      0,   8, 228, 160,   1,   0, 
++      0,   2,   0,   8,  15, 128, 
++      0,   0, 228, 128, 255, 255, 
++      0,   0,  83,  72,  68,  82, 
++    100,   0,   0,   0,  64,   0, 
++      0,   0,  25,   0,   0,   0, 
++     90,   0,   0,   3,   0,  96, 
++     16,   0,   0,   0,   0,   0, 
++     88,  24,   0,   4,   0, 112, 
++     16,   0,   0,   0,   0,   0, 
++     85,  85,   0,   0,  98,  16, 
++      0,   3,  50,  16,  16,   0, 
++      1,   0,   0,   0, 101,   0, 
++      0,   3, 242,  32,  16,   0, 
++      0,   0,   0,   0,  69,   0, 
++      0,   9, 242,  32,  16,   0, 
++      0,   0,   0,   0,  70,  16, 
++     16,   0,   1,   0,   0,   0, 
++     70, 126,  16,   0,   0,   0, 
++      0,   0,   0,  96,  16,   0, 
++      0,   0,   0,   0,  62,   0, 
++      0,   1,  83,  84,  65,  84, 
++    116,   0,   0,   0,   2,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   2,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++     82,  68,  69,  70, 152,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   2,   0, 
++      0,   0,  28,   0,   0,   0, 
++      0,   4, 255, 255,   0,   1, 
++      0,   0, 109,   0,   0,   0, 
++     92,   0,   0,   0,   3,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0,   1,   0, 
++      0,   0, 100,   0,   0,   0, 
++      2,   0,   0,   0,   5,   0, 
++      0,   0,   4,   0,   0,   0, 
++    255, 255, 255, 255,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++     13,   0,   0,   0,  83,  97, 
++    109, 112, 108, 101, 114,   0, 
++     84, 101, 120, 116, 117, 114, 
++    101,  70,   0,  77, 105,  99, 
++    114, 111, 115, 111, 102, 116, 
++     32,  40,  82,  41,  32,  72, 
++     76,  83,  76,  32,  83, 104, 
++     97, 100, 101, 114,  32,  67, 
++    111, 109, 112, 105, 108, 101, 
++    114,  32,  49,  48,  46,  49, 
++      0, 171, 171, 171,  73,  83, 
++     71,  78,  80,   0,   0,   0, 
++      2,   0,   0,   0,   8,   0, 
++      0,   0,  56,   0,   0,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,   3,   0,   0,   0, 
++      0,   0,   0,   0,  15,   0, 
++      0,   0,  68,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   3,   0,   0,   0, 
++      1,   0,   0,   0,   3,   3, 
++      0,   0,  83,  86,  95,  80, 
++     79,  83,  73,  84,  73,  79, 
++     78,   0,  84,  69,  88,  67, 
++     79,  79,  82,  68,   0, 171, 
++    171, 171,  79,  83,  71,  78, 
++     44,   0,   0,   0,   1,   0, 
++      0,   0,   8,   0,   0,   0, 
++     32,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      3,   0,   0,   0,   0,   0, 
++      0,   0,  15,   0,   0,   0, 
++     83,  86,  95,  84,  65,  82, 
++     71,  69,  84,   0, 171, 171
++};
+diff --git a/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughrgba2di11ps.h b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughrgba2di11ps.h
+new file mode 100644
+index 00000000..199c4749
+--- /dev/null
++++ b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughrgba2di11ps.h
+@@ -0,0 +1,155 @@
++#if 0
++//
++// Generated by Microsoft (R) HLSL Shader Compiler 10.1
++//
++//
++// Resource Bindings:
++//
++// Name                                 Type  Format         Dim      HLSL Bind  Count
++// ------------------------------ ---------- ------- ----------- -------------- ------
++// TextureI                          texture   sint4          2d             t0      1 
++//
++//
++//
++// Input signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_POSITION              0   xyzw        0      POS   float       
++// TEXCOORD                 0   xy          1     NONE   float   xy  
++//
++//
++// Output signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_TARGET                0   xyzw        0   TARGET     int   xyzw
++//
++ps_4_0
++dcl_resource_texture2d (sint,sint,sint,sint) t0
++dcl_input_ps linear v1.xy
++dcl_output o0.xyzw
++dcl_temps 1
++resinfo_uint r0.xyzw, l(0), t0.xyzw
++utof r0.xy, r0.xyxx
++mul r0.xy, r0.xyxx, v1.xyxx
++ftoi r0.xy, r0.xyxx
++mov r0.zw, l(0,0,0,0)
++ld o0.xyzw, r0.xyzw, t0.xyzw
++ret 
++// Approximately 7 instruction slots used
++#endif
++
++const BYTE g_PS_PassthroughRGBA2DI[] =
++{
++     68,  88,  66,  67,  11, 194, 
++    121, 174,  53, 241,  53, 229, 
++    116,  76,  99, 226,  54,  79, 
++    165, 216,   1,   0,   0,   0, 
++    148,   2,   0,   0,   5,   0, 
++      0,   0,  52,   0,   0,   0, 
++    172,   0,   0,   0,   4,   1, 
++      0,   0,  56,   1,   0,   0, 
++     24,   2,   0,   0,  82,  68, 
++     69,  70, 112,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++     28,   0,   0,   0,   0,   4, 
++    255, 255,   0,   1,   0,   0, 
++     69,   0,   0,   0,  60,   0, 
++      0,   0,   2,   0,   0,   0, 
++      3,   0,   0,   0,   4,   0, 
++      0,   0, 255, 255, 255, 255, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,  13,   0,   0,   0, 
++     84, 101, 120, 116, 117, 114, 
++    101,  73,   0,  77, 105,  99, 
++    114, 111, 115, 111, 102, 116, 
++     32,  40,  82,  41,  32,  72, 
++     76,  83,  76,  32,  83, 104, 
++     97, 100, 101, 114,  32,  67, 
++    111, 109, 112, 105, 108, 101, 
++    114,  32,  49,  48,  46,  49, 
++      0, 171, 171, 171,  73,  83, 
++     71,  78,  80,   0,   0,   0, 
++      2,   0,   0,   0,   8,   0, 
++      0,   0,  56,   0,   0,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,   3,   0,   0,   0, 
++      0,   0,   0,   0,  15,   0, 
++      0,   0,  68,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   3,   0,   0,   0, 
++      1,   0,   0,   0,   3,   3, 
++      0,   0,  83,  86,  95,  80, 
++     79,  83,  73,  84,  73,  79, 
++     78,   0,  84,  69,  88,  67, 
++     79,  79,  82,  68,   0, 171, 
++    171, 171,  79,  83,  71,  78, 
++     44,   0,   0,   0,   1,   0, 
++      0,   0,   8,   0,   0,   0, 
++     32,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      2,   0,   0,   0,   0,   0, 
++      0,   0,  15,   0,   0,   0, 
++     83,  86,  95,  84,  65,  82, 
++     71,  69,  84,   0, 171, 171, 
++     83,  72,  68,  82, 216,   0, 
++      0,   0,  64,   0,   0,   0, 
++     54,   0,   0,   0,  88,  24, 
++      0,   4,   0, 112,  16,   0, 
++      0,   0,   0,   0,  51,  51, 
++      0,   0,  98,  16,   0,   3, 
++     50,  16,  16,   0,   1,   0, 
++      0,   0, 101,   0,   0,   3, 
++    242,  32,  16,   0,   0,   0, 
++      0,   0, 104,   0,   0,   2, 
++      1,   0,   0,   0,  61,  16, 
++      0,   7, 242,   0,  16,   0, 
++      0,   0,   0,   0,   1,  64, 
++      0,   0,   0,   0,   0,   0, 
++     70, 126,  16,   0,   0,   0, 
++      0,   0,  86,   0,   0,   5, 
++     50,   0,  16,   0,   0,   0, 
++      0,   0,  70,   0,  16,   0, 
++      0,   0,   0,   0,  56,   0, 
++      0,   7,  50,   0,  16,   0, 
++      0,   0,   0,   0,  70,   0, 
++     16,   0,   0,   0,   0,   0, 
++     70,  16,  16,   0,   1,   0, 
++      0,   0,  27,   0,   0,   5, 
++     50,   0,  16,   0,   0,   0, 
++      0,   0,  70,   0,  16,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   8, 194,   0,  16,   0, 
++      0,   0,   0,   0,   2,  64, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++     45,   0,   0,   7, 242,  32, 
++     16,   0,   0,   0,   0,   0, 
++     70,  14,  16,   0,   0,   0, 
++      0,   0,  70, 126,  16,   0, 
++      0,   0,   0,   0,  62,   0, 
++      0,   1,  83,  84,  65,  84, 
++    116,   0,   0,   0,   7,   0, 
++      0,   0,   1,   0,   0,   0, 
++      0,   0,   0,   0,   2,   0, 
++      0,   0,   1,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++      0,   0,   0,   0,   2,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0
++};
+diff --git a/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughrgba2dui11ps.h b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughrgba2dui11ps.h
+new file mode 100644
+index 00000000..004de6a1
+--- /dev/null
++++ b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughrgba2dui11ps.h
+@@ -0,0 +1,155 @@
++#if 0
++//
++// Generated by Microsoft (R) HLSL Shader Compiler 10.1
++//
++//
++// Resource Bindings:
++//
++// Name                                 Type  Format         Dim      HLSL Bind  Count
++// ------------------------------ ---------- ------- ----------- -------------- ------
++// TextureUI                         texture   uint4          2d             t0      1 
++//
++//
++//
++// Input signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_POSITION              0   xyzw        0      POS   float       
++// TEXCOORD                 0   xy          1     NONE   float   xy  
++//
++//
++// Output signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_TARGET                0   xyzw        0   TARGET    uint   xyzw
++//
++ps_4_0
++dcl_resource_texture2d (uint,uint,uint,uint) t0
++dcl_input_ps linear v1.xy
++dcl_output o0.xyzw
++dcl_temps 1
++resinfo_uint r0.xyzw, l(0), t0.xyzw
++utof r0.xy, r0.xyxx
++mul r0.xy, r0.xyxx, v1.xyxx
++ftoi r0.xy, r0.xyxx
++mov r0.zw, l(0,0,0,0)
++ld o0.xyzw, r0.xyzw, t0.xyzw
++ret 
++// Approximately 7 instruction slots used
++#endif
++
++const BYTE g_PS_PassthroughRGBA2DUI[] =
++{
++     68,  88,  66,  67, 116, 109, 
++     92, 124,  46,  28, 237, 165, 
++    173,  42,   6,  53, 183, 101, 
++    128,  93,   1,   0,   0,   0, 
++    148,   2,   0,   0,   5,   0, 
++      0,   0,  52,   0,   0,   0, 
++    172,   0,   0,   0,   4,   1, 
++      0,   0,  56,   1,   0,   0, 
++     24,   2,   0,   0,  82,  68, 
++     69,  70, 112,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++     28,   0,   0,   0,   0,   4, 
++    255, 255,   0,   1,   0,   0, 
++     70,   0,   0,   0,  60,   0, 
++      0,   0,   2,   0,   0,   0, 
++      4,   0,   0,   0,   4,   0, 
++      0,   0, 255, 255, 255, 255, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,  13,   0,   0,   0, 
++     84, 101, 120, 116, 117, 114, 
++    101,  85,  73,   0,  77, 105, 
++     99, 114, 111, 115, 111, 102, 
++    116,  32,  40,  82,  41,  32, 
++     72,  76,  83,  76,  32,  83, 
++    104,  97, 100, 101, 114,  32, 
++     67, 111, 109, 112, 105, 108, 
++    101, 114,  32,  49,  48,  46, 
++     49,   0, 171, 171,  73,  83, 
++     71,  78,  80,   0,   0,   0, 
++      2,   0,   0,   0,   8,   0, 
++      0,   0,  56,   0,   0,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,   3,   0,   0,   0, 
++      0,   0,   0,   0,  15,   0, 
++      0,   0,  68,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   3,   0,   0,   0, 
++      1,   0,   0,   0,   3,   3, 
++      0,   0,  83,  86,  95,  80, 
++     79,  83,  73,  84,  73,  79, 
++     78,   0,  84,  69,  88,  67, 
++     79,  79,  82,  68,   0, 171, 
++    171, 171,  79,  83,  71,  78, 
++     44,   0,   0,   0,   1,   0, 
++      0,   0,   8,   0,   0,   0, 
++     32,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0,  15,   0,   0,   0, 
++     83,  86,  95,  84,  65,  82, 
++     71,  69,  84,   0, 171, 171, 
++     83,  72,  68,  82, 216,   0, 
++      0,   0,  64,   0,   0,   0, 
++     54,   0,   0,   0,  88,  24, 
++      0,   4,   0, 112,  16,   0, 
++      0,   0,   0,   0,  68,  68, 
++      0,   0,  98,  16,   0,   3, 
++     50,  16,  16,   0,   1,   0, 
++      0,   0, 101,   0,   0,   3, 
++    242,  32,  16,   0,   0,   0, 
++      0,   0, 104,   0,   0,   2, 
++      1,   0,   0,   0,  61,  16, 
++      0,   7, 242,   0,  16,   0, 
++      0,   0,   0,   0,   1,  64, 
++      0,   0,   0,   0,   0,   0, 
++     70, 126,  16,   0,   0,   0, 
++      0,   0,  86,   0,   0,   5, 
++     50,   0,  16,   0,   0,   0, 
++      0,   0,  70,   0,  16,   0, 
++      0,   0,   0,   0,  56,   0, 
++      0,   7,  50,   0,  16,   0, 
++      0,   0,   0,   0,  70,   0, 
++     16,   0,   0,   0,   0,   0, 
++     70,  16,  16,   0,   1,   0, 
++      0,   0,  27,   0,   0,   5, 
++     50,   0,  16,   0,   0,   0, 
++      0,   0,  70,   0,  16,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   8, 194,   0,  16,   0, 
++      0,   0,   0,   0,   2,  64, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++     45,   0,   0,   7, 242,  32, 
++     16,   0,   0,   0,   0,   0, 
++     70,  14,  16,   0,   0,   0, 
++      0,   0,  70, 126,  16,   0, 
++      0,   0,   0,   0,  62,   0, 
++      0,   1,  83,  84,  65,  84, 
++    116,   0,   0,   0,   7,   0, 
++      0,   0,   1,   0,   0,   0, 
++      0,   0,   0,   0,   2,   0, 
++      0,   0,   1,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++      0,   0,   0,   0,   2,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0
++};
+diff --git a/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughrgba3d11ps.h b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughrgba3d11ps.h
+new file mode 100644
+index 00000000..c6ba47a4
+--- /dev/null
++++ b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughrgba3d11ps.h
+@@ -0,0 +1,148 @@
++#if 0
++//
++// Generated by Microsoft (R) HLSL Shader Compiler 10.1
++//
++//
++// Resource Bindings:
++//
++// Name                                 Type  Format         Dim      HLSL Bind  Count
++// ------------------------------ ---------- ------- ----------- -------------- ------
++// Sampler                           sampler      NA          NA             s0      1 
++// TextureF                          texture  float4          3d             t0      1 
++//
++//
++//
++// Input signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_POSITION              0   xyzw        0      POS   float       
++// SV_RENDERTARGETARRAYINDEX     0   x           1  RTINDEX    uint       
++// TEXCOORD                 0   xyz         2     NONE   float   xyz 
++//
++//
++// Output signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_TARGET                0   xyzw        0   TARGET   float   xyzw
++//
++ps_4_0
++dcl_sampler s0, mode_default
++dcl_resource_texture3d (float,float,float,float) t0
++dcl_input_ps linear v2.xyz
++dcl_output o0.xyzw
++sample o0.xyzw, v2.xyzx, t0.xyzw, s0
++ret 
++// Approximately 2 instruction slots used
++#endif
++
++const BYTE g_PS_PassthroughRGBA3D[] =
++{
++     68,  88,  66,  67,  68,  93, 
++    216,  66, 165,  49, 226,  52, 
++    230, 199, 150, 143, 253,  53, 
++    233, 213,   1,   0,   0,   0, 
++    120,   2,   0,   0,   5,   0, 
++      0,   0,  52,   0,   0,   0, 
++    212,   0,   0,   0,  92,   1, 
++      0,   0, 144,   1,   0,   0, 
++    252,   1,   0,   0,  82,  68, 
++     69,  70, 152,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   2,   0,   0,   0, 
++     28,   0,   0,   0,   0,   4, 
++    255, 255,   0,   1,   0,   0, 
++    109,   0,   0,   0,  92,   0, 
++      0,   0,   3,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,   1,   0,   0,   0, 
++    100,   0,   0,   0,   2,   0, 
++      0,   0,   5,   0,   0,   0, 
++      8,   0,   0,   0, 255, 255, 
++    255, 255,   0,   0,   0,   0, 
++      1,   0,   0,   0,  13,   0, 
++      0,   0,  83,  97, 109, 112, 
++    108, 101, 114,   0,  84, 101, 
++    120, 116, 117, 114, 101,  70, 
++      0,  77, 105,  99, 114, 111, 
++    115, 111, 102, 116,  32,  40, 
++     82,  41,  32,  72,  76,  83, 
++     76,  32,  83, 104,  97, 100, 
++    101, 114,  32,  67, 111, 109, 
++    112, 105, 108, 101, 114,  32, 
++     49,  48,  46,  49,   0, 171, 
++    171, 171,  73,  83,  71,  78, 
++    128,   0,   0,   0,   3,   0, 
++      0,   0,   8,   0,   0,   0, 
++     80,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++      3,   0,   0,   0,   0,   0, 
++      0,   0,  15,   0,   0,   0, 
++     92,   0,   0,   0,   0,   0, 
++      0,   0,   4,   0,   0,   0, 
++      1,   0,   0,   0,   1,   0, 
++      0,   0,   1,   0,   0,   0, 
++    118,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      3,   0,   0,   0,   2,   0, 
++      0,   0,   7,   7,   0,   0, 
++     83,  86,  95,  80,  79,  83, 
++     73,  84,  73,  79,  78,   0, 
++     83,  86,  95,  82,  69,  78, 
++     68,  69,  82,  84,  65,  82, 
++     71,  69,  84,  65,  82,  82, 
++     65,  89,  73,  78,  68,  69, 
++     88,   0,  84,  69,  88,  67, 
++     79,  79,  82,  68,   0, 171, 
++     79,  83,  71,  78,  44,   0, 
++      0,   0,   1,   0,   0,   0, 
++      8,   0,   0,   0,  32,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   3,   0, 
++      0,   0,   0,   0,   0,   0, 
++     15,   0,   0,   0,  83,  86, 
++     95,  84,  65,  82,  71,  69, 
++     84,   0, 171, 171,  83,  72, 
++     68,  82, 100,   0,   0,   0, 
++     64,   0,   0,   0,  25,   0, 
++      0,   0,  90,   0,   0,   3, 
++      0,  96,  16,   0,   0,   0, 
++      0,   0,  88,  40,   0,   4, 
++      0, 112,  16,   0,   0,   0, 
++      0,   0,  85,  85,   0,   0, 
++     98,  16,   0,   3, 114,  16, 
++     16,   0,   2,   0,   0,   0, 
++    101,   0,   0,   3, 242,  32, 
++     16,   0,   0,   0,   0,   0, 
++     69,   0,   0,   9, 242,  32, 
++     16,   0,   0,   0,   0,   0, 
++     70,  18,  16,   0,   2,   0, 
++      0,   0,  70, 126,  16,   0, 
++      0,   0,   0,   0,   0,  96, 
++     16,   0,   0,   0,   0,   0, 
++     62,   0,   0,   1,  83,  84, 
++     65,  84, 116,   0,   0,   0, 
++      2,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      2,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0
++};
+diff --git a/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughrgba3di11ps.h b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughrgba3di11ps.h
+new file mode 100644
+index 00000000..30792261
+--- /dev/null
++++ b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughrgba3di11ps.h
+@@ -0,0 +1,162 @@
++#if 0
++//
++// Generated by Microsoft (R) HLSL Shader Compiler 10.1
++//
++//
++// Resource Bindings:
++//
++// Name                                 Type  Format         Dim      HLSL Bind  Count
++// ------------------------------ ---------- ------- ----------- -------------- ------
++// TextureI                          texture   sint4          3d             t0      1 
++//
++//
++//
++// Input signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_POSITION              0   xyzw        0      POS   float       
++// SV_RENDERTARGETARRAYINDEX     0   x           1  RTINDEX    uint       
++// TEXCOORD                 0   xyz         2     NONE   float   xyz 
++//
++//
++// Output signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_TARGET                0   xyzw        0   TARGET     int   xyzw
++//
++ps_4_0
++dcl_resource_texture3d (sint,sint,sint,sint) t0
++dcl_input_ps linear v2.xyz
++dcl_output o0.xyzw
++dcl_temps 1
++resinfo_uint r0.xyzw, l(0), t0.xyzw
++utof r0.xyz, r0.xyzx
++mul r0.xyz, r0.xyzx, v2.xyzx
++ftoi r0.xyz, r0.xyzx
++mov r0.w, l(0)
++ld o0.xyzw, r0.xyzw, t0.xyzw
++ret 
++// Approximately 7 instruction slots used
++#endif
++
++const BYTE g_PS_PassthroughRGBA3DI[] =
++{
++     68,  88,  66,  67, 112, 154, 
++     25, 211, 170, 223,  11,  97, 
++     14,  10, 139, 203, 225, 190, 
++     33, 158,   1,   0,   0,   0, 
++    184,   2,   0,   0,   5,   0, 
++      0,   0,  52,   0,   0,   0, 
++    172,   0,   0,   0,  52,   1, 
++      0,   0, 104,   1,   0,   0, 
++     60,   2,   0,   0,  82,  68, 
++     69,  70, 112,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++     28,   0,   0,   0,   0,   4, 
++    255, 255,   0,   1,   0,   0, 
++     69,   0,   0,   0,  60,   0, 
++      0,   0,   2,   0,   0,   0, 
++      3,   0,   0,   0,   8,   0, 
++      0,   0, 255, 255, 255, 255, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,  13,   0,   0,   0, 
++     84, 101, 120, 116, 117, 114, 
++    101,  73,   0,  77, 105,  99, 
++    114, 111, 115, 111, 102, 116, 
++     32,  40,  82,  41,  32,  72, 
++     76,  83,  76,  32,  83, 104, 
++     97, 100, 101, 114,  32,  67, 
++    111, 109, 112, 105, 108, 101, 
++    114,  32,  49,  48,  46,  49, 
++      0, 171, 171, 171,  73,  83, 
++     71,  78, 128,   0,   0,   0, 
++      3,   0,   0,   0,   8,   0, 
++      0,   0,  80,   0,   0,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,   3,   0,   0,   0, 
++      0,   0,   0,   0,  15,   0, 
++      0,   0,  92,   0,   0,   0, 
++      0,   0,   0,   0,   4,   0, 
++      0,   0,   1,   0,   0,   0, 
++      1,   0,   0,   0,   1,   0, 
++      0,   0, 118,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   3,   0,   0,   0, 
++      2,   0,   0,   0,   7,   7, 
++      0,   0,  83,  86,  95,  80, 
++     79,  83,  73,  84,  73,  79, 
++     78,   0,  83,  86,  95,  82, 
++     69,  78,  68,  69,  82,  84, 
++     65,  82,  71,  69,  84,  65, 
++     82,  82,  65,  89,  73,  78, 
++     68,  69,  88,   0,  84,  69, 
++     88,  67,  79,  79,  82,  68, 
++      0, 171,  79,  83,  71,  78, 
++     44,   0,   0,   0,   1,   0, 
++      0,   0,   8,   0,   0,   0, 
++     32,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      2,   0,   0,   0,   0,   0, 
++      0,   0,  15,   0,   0,   0, 
++     83,  86,  95,  84,  65,  82, 
++     71,  69,  84,   0, 171, 171, 
++     83,  72,  68,  82, 204,   0, 
++      0,   0,  64,   0,   0,   0, 
++     51,   0,   0,   0,  88,  40, 
++      0,   4,   0, 112,  16,   0, 
++      0,   0,   0,   0,  51,  51, 
++      0,   0,  98,  16,   0,   3, 
++    114,  16,  16,   0,   2,   0, 
++      0,   0, 101,   0,   0,   3, 
++    242,  32,  16,   0,   0,   0, 
++      0,   0, 104,   0,   0,   2, 
++      1,   0,   0,   0,  61,  16, 
++      0,   7, 242,   0,  16,   0, 
++      0,   0,   0,   0,   1,  64, 
++      0,   0,   0,   0,   0,   0, 
++     70, 126,  16,   0,   0,   0, 
++      0,   0,  86,   0,   0,   5, 
++    114,   0,  16,   0,   0,   0, 
++      0,   0,  70,   2,  16,   0, 
++      0,   0,   0,   0,  56,   0, 
++      0,   7, 114,   0,  16,   0, 
++      0,   0,   0,   0,  70,   2, 
++     16,   0,   0,   0,   0,   0, 
++     70,  18,  16,   0,   2,   0, 
++      0,   0,  27,   0,   0,   5, 
++    114,   0,  16,   0,   0,   0, 
++      0,   0,  70,   2,  16,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   5, 130,   0,  16,   0, 
++      0,   0,   0,   0,   1,  64, 
++      0,   0,   0,   0,   0,   0, 
++     45,   0,   0,   7, 242,  32, 
++     16,   0,   0,   0,   0,   0, 
++     70,  14,  16,   0,   0,   0, 
++      0,   0,  70, 126,  16,   0, 
++      0,   0,   0,   0,  62,   0, 
++      0,   1,  83,  84,  65,  84, 
++    116,   0,   0,   0,   7,   0, 
++      0,   0,   1,   0,   0,   0, 
++      0,   0,   0,   0,   2,   0, 
++      0,   0,   1,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++      0,   0,   0,   0,   2,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0
++};
+diff --git a/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughrgba3dui11ps.h b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughrgba3dui11ps.h
+new file mode 100644
+index 00000000..4e169820
+--- /dev/null
++++ b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/passthroughrgba3dui11ps.h
+@@ -0,0 +1,162 @@
++#if 0
++//
++// Generated by Microsoft (R) HLSL Shader Compiler 10.1
++//
++//
++// Resource Bindings:
++//
++// Name                                 Type  Format         Dim      HLSL Bind  Count
++// ------------------------------ ---------- ------- ----------- -------------- ------
++// TextureUI                         texture   uint4          3d             t0      1 
++//
++//
++//
++// Input signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_POSITION              0   xyzw        0      POS   float       
++// SV_RENDERTARGETARRAYINDEX     0   x           1  RTINDEX    uint       
++// TEXCOORD                 0   xyz         2     NONE   float   xyz 
++//
++//
++// Output signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_TARGET                0   xyzw        0   TARGET    uint   xyzw
++//
++ps_4_0
++dcl_resource_texture3d (uint,uint,uint,uint) t0
++dcl_input_ps linear v2.xyz
++dcl_output o0.xyzw
++dcl_temps 1
++resinfo_uint r0.xyzw, l(0), t0.xyzw
++utof r0.xyz, r0.xyzx
++mul r0.xyz, r0.xyzx, v2.xyzx
++ftoi r0.xyz, r0.xyzx
++mov r0.w, l(0)
++ld o0.xyzw, r0.xyzw, t0.xyzw
++ret 
++// Approximately 7 instruction slots used
++#endif
++
++const BYTE g_PS_PassthroughRGBA3DUI[] =
++{
++     68,  88,  66,  67, 136,  72, 
++    192, 109, 253,  59, 232,  36, 
++     69,  34, 127, 153,  17,  12, 
++    205, 209,   1,   0,   0,   0, 
++    184,   2,   0,   0,   5,   0, 
++      0,   0,  52,   0,   0,   0, 
++    172,   0,   0,   0,  52,   1, 
++      0,   0, 104,   1,   0,   0, 
++     60,   2,   0,   0,  82,  68, 
++     69,  70, 112,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++     28,   0,   0,   0,   0,   4, 
++    255, 255,   0,   1,   0,   0, 
++     70,   0,   0,   0,  60,   0, 
++      0,   0,   2,   0,   0,   0, 
++      4,   0,   0,   0,   8,   0, 
++      0,   0, 255, 255, 255, 255, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,  13,   0,   0,   0, 
++     84, 101, 120, 116, 117, 114, 
++    101,  85,  73,   0,  77, 105, 
++     99, 114, 111, 115, 111, 102, 
++    116,  32,  40,  82,  41,  32, 
++     72,  76,  83,  76,  32,  83, 
++    104,  97, 100, 101, 114,  32, 
++     67, 111, 109, 112, 105, 108, 
++    101, 114,  32,  49,  48,  46, 
++     49,   0, 171, 171,  73,  83, 
++     71,  78, 128,   0,   0,   0, 
++      3,   0,   0,   0,   8,   0, 
++      0,   0,  80,   0,   0,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,   3,   0,   0,   0, 
++      0,   0,   0,   0,  15,   0, 
++      0,   0,  92,   0,   0,   0, 
++      0,   0,   0,   0,   4,   0, 
++      0,   0,   1,   0,   0,   0, 
++      1,   0,   0,   0,   1,   0, 
++      0,   0, 118,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   3,   0,   0,   0, 
++      2,   0,   0,   0,   7,   7, 
++      0,   0,  83,  86,  95,  80, 
++     79,  83,  73,  84,  73,  79, 
++     78,   0,  83,  86,  95,  82, 
++     69,  78,  68,  69,  82,  84, 
++     65,  82,  71,  69,  84,  65, 
++     82,  82,  65,  89,  73,  78, 
++     68,  69,  88,   0,  84,  69, 
++     88,  67,  79,  79,  82,  68, 
++      0, 171,  79,  83,  71,  78, 
++     44,   0,   0,   0,   1,   0, 
++      0,   0,   8,   0,   0,   0, 
++     32,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0,  15,   0,   0,   0, 
++     83,  86,  95,  84,  65,  82, 
++     71,  69,  84,   0, 171, 171, 
++     83,  72,  68,  82, 204,   0, 
++      0,   0,  64,   0,   0,   0, 
++     51,   0,   0,   0,  88,  40, 
++      0,   4,   0, 112,  16,   0, 
++      0,   0,   0,   0,  68,  68, 
++      0,   0,  98,  16,   0,   3, 
++    114,  16,  16,   0,   2,   0, 
++      0,   0, 101,   0,   0,   3, 
++    242,  32,  16,   0,   0,   0, 
++      0,   0, 104,   0,   0,   2, 
++      1,   0,   0,   0,  61,  16, 
++      0,   7, 242,   0,  16,   0, 
++      0,   0,   0,   0,   1,  64, 
++      0,   0,   0,   0,   0,   0, 
++     70, 126,  16,   0,   0,   0, 
++      0,   0,  86,   0,   0,   5, 
++    114,   0,  16,   0,   0,   0, 
++      0,   0,  70,   2,  16,   0, 
++      0,   0,   0,   0,  56,   0, 
++      0,   7, 114,   0,  16,   0, 
++      0,   0,   0,   0,  70,   2, 
++     16,   0,   0,   0,   0,   0, 
++     70,  18,  16,   0,   2,   0, 
++      0,   0,  27,   0,   0,   5, 
++    114,   0,  16,   0,   0,   0, 
++      0,   0,  70,   2,  16,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   5, 130,   0,  16,   0, 
++      0,   0,   0,   0,   1,  64, 
++      0,   0,   0,   0,   0,   0, 
++     45,   0,   0,   7, 242,  32, 
++     16,   0,   0,   0,   0,   0, 
++     70,  14,  16,   0,   0,   0, 
++      0,   0,  70, 126,  16,   0, 
++      0,   0,   0,   0,  62,   0, 
++      0,   1,  83,  84,  65,  84, 
++    116,   0,   0,   0,   7,   0, 
++      0,   0,   1,   0,   0,   0, 
++      0,   0,   0,   0,   2,   0, 
++      0,   0,   1,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++      0,   0,   0,   0,   2,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0
++};
+diff --git a/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/swizzlef2darrayps.h b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/swizzlef2darrayps.h
+new file mode 100644
+index 00000000..0cca2c3f
+--- /dev/null
++++ b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/swizzlef2darrayps.h
+@@ -0,0 +1,276 @@
++#if 0
++//
++// Generated by Microsoft (R) HLSL Shader Compiler 10.1
++//
++//
++// Buffer Definitions: 
++//
++// cbuffer SwizzleProperties
++// {
++//
++//   uint4 SwizzleIndices;              // Offset:    0 Size:    16
++//
++// }
++//
++//
++// Resource Bindings:
++//
++// Name                                 Type  Format         Dim      HLSL Bind  Count
++// ------------------------------ ---------- ------- ----------- -------------- ------
++// Sampler                           sampler      NA          NA             s0      1 
++// TextureF2DArray                   texture  float4     2darray             t0      1 
++// SwizzleProperties                 cbuffer      NA          NA            cb0      1 
++//
++//
++//
++// Input signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_POSITION              0   xyzw        0      POS   float       
++// SV_RENDERTARGETARRAYINDEX     0   x           1  RTINDEX    uint   x   
++// TEXCOORD                 0   xyz         2     NONE   float   xy  
++//
++//
++// Output signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_TARGET                0   xyzw        0   TARGET   float   xyzw
++//
++ps_4_0
++dcl_constantbuffer CB0[1], immediateIndexed
++dcl_sampler s0, mode_default
++dcl_resource_texture2darray (float,float,float,float) t0
++dcl_input_ps_siv constant v1.x, rendertarget_array_index
++dcl_input_ps linear v2.xy
++dcl_output o0.xyzw
++dcl_temps 1
++dcl_indexableTemp x0[6], 4
++utof r0.z, v1.x
++mov r0.xy, v2.xyxx
++sample r0.xyzw, r0.xyzx, t0.xyzw, s0
++mov x0[0].x, r0.x
++mov x0[1].x, r0.y
++mov x0[2].x, r0.z
++mov x0[3].x, r0.w
++mov x0[4].x, l(0)
++mov x0[5].x, l(1.000000)
++mov r0.x, cb0[0].x
++mov o0.x, x0[r0.x + 0].x
++mov r0.x, cb0[0].y
++mov o0.y, x0[r0.x + 0].x
++mov r0.x, cb0[0].z
++mov o0.z, x0[r0.x + 0].x
++mov r0.x, cb0[0].w
++mov o0.w, x0[r0.x + 0].x
++ret 
++// Approximately 18 instruction slots used
++#endif
++
++const BYTE g_PS_SwizzleF2DArray[] =
++{
++     68,  88,  66,  67,  43, 191, 
++    227, 129,  77,  88, 223, 209, 
++     64,  17, 168,  91,  78, 216, 
++    210, 134,   1,   0,   0,   0, 
++    192,   4,   0,   0,   5,   0, 
++      0,   0,  52,   0,   0,   0, 
++     92,   1,   0,   0, 228,   1, 
++      0,   0,  24,   2,   0,   0, 
++     68,   4,   0,   0,  82,  68, 
++     69,  70,  32,   1,   0,   0, 
++      1,   0,   0,   0, 168,   0, 
++      0,   0,   3,   0,   0,   0, 
++     28,   0,   0,   0,   0,   4, 
++    255, 255,   0,   1,   0,   0, 
++    248,   0,   0,   0, 124,   0, 
++      0,   0,   3,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,   1,   0,   0,   0, 
++    132,   0,   0,   0,   2,   0, 
++      0,   0,   5,   0,   0,   0, 
++      5,   0,   0,   0, 255, 255, 
++    255, 255,   0,   0,   0,   0, 
++      1,   0,   0,   0,  13,   0, 
++      0,   0, 148,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++      1,   0,   0,   0,  83,  97, 
++    109, 112, 108, 101, 114,   0, 
++     84, 101, 120, 116, 117, 114, 
++    101,  70,  50,  68,  65, 114, 
++    114,  97, 121,   0,  83, 119, 
++    105, 122, 122, 108, 101,  80, 
++    114, 111, 112, 101, 114, 116, 
++    105, 101, 115,   0, 171, 171, 
++    148,   0,   0,   0,   1,   0, 
++      0,   0, 192,   0,   0,   0, 
++     16,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++    216,   0,   0,   0,   0,   0, 
++      0,   0,  16,   0,   0,   0, 
++      2,   0,   0,   0, 232,   0, 
++      0,   0,   0,   0,   0,   0, 
++     83, 119, 105, 122, 122, 108, 
++    101,  73, 110, 100, 105,  99, 
++    101, 115,   0, 171,   1,   0, 
++     19,   0,   1,   0,   4,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,  77, 105,  99, 114, 
++    111, 115, 111, 102, 116,  32, 
++     40,  82,  41,  32,  72,  76, 
++     83,  76,  32,  83, 104,  97, 
++    100, 101, 114,  32,  67, 111, 
++    109, 112, 105, 108, 101, 114, 
++     32,  49,  48,  46,  49,   0, 
++     73,  83,  71,  78, 128,   0, 
++      0,   0,   3,   0,   0,   0, 
++      8,   0,   0,   0,  80,   0, 
++      0,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0,   3,   0, 
++      0,   0,   0,   0,   0,   0, 
++     15,   0,   0,   0,  92,   0, 
++      0,   0,   0,   0,   0,   0, 
++      4,   0,   0,   0,   1,   0, 
++      0,   0,   1,   0,   0,   0, 
++      1,   1,   0,   0, 118,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   3,   0, 
++      0,   0,   2,   0,   0,   0, 
++      7,   3,   0,   0,  83,  86, 
++     95,  80,  79,  83,  73,  84, 
++     73,  79,  78,   0,  83,  86, 
++     95,  82,  69,  78,  68,  69, 
++     82,  84,  65,  82,  71,  69, 
++     84,  65,  82,  82,  65,  89, 
++     73,  78,  68,  69,  88,   0, 
++     84,  69,  88,  67,  79,  79, 
++     82,  68,   0, 171,  79,  83, 
++     71,  78,  44,   0,   0,   0, 
++      1,   0,   0,   0,   8,   0, 
++      0,   0,  32,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   3,   0,   0,   0, 
++      0,   0,   0,   0,  15,   0, 
++      0,   0,  83,  86,  95,  84, 
++     65,  82,  71,  69,  84,   0, 
++    171, 171,  83,  72,  68,  82, 
++     36,   2,   0,   0,  64,   0, 
++      0,   0, 137,   0,   0,   0, 
++     89,   0,   0,   4,  70, 142, 
++     32,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0,  90,   0, 
++      0,   3,   0,  96,  16,   0, 
++      0,   0,   0,   0,  88,  64, 
++      0,   4,   0, 112,  16,   0, 
++      0,   0,   0,   0,  85,  85, 
++      0,   0, 100,   8,   0,   4, 
++     18,  16,  16,   0,   1,   0, 
++      0,   0,   4,   0,   0,   0, 
++     98,  16,   0,   3,  50,  16, 
++     16,   0,   2,   0,   0,   0, 
++    101,   0,   0,   3, 242,  32, 
++     16,   0,   0,   0,   0,   0, 
++    104,   0,   0,   2,   1,   0, 
++      0,   0, 105,   0,   0,   4, 
++      0,   0,   0,   0,   6,   0, 
++      0,   0,   4,   0,   0,   0, 
++     86,   0,   0,   5,  66,   0, 
++     16,   0,   0,   0,   0,   0, 
++     10,  16,  16,   0,   1,   0, 
++      0,   0,  54,   0,   0,   5, 
++     50,   0,  16,   0,   0,   0, 
++      0,   0,  70,  16,  16,   0, 
++      2,   0,   0,   0,  69,   0, 
++      0,   9, 242,   0,  16,   0, 
++      0,   0,   0,   0,  70,   2, 
++     16,   0,   0,   0,   0,   0, 
++     70, 126,  16,   0,   0,   0, 
++      0,   0,   0,  96,  16,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   6,  18,  48,  32,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,  10,   0,  16,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   6,  18,  48,  32,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,  26,   0,  16,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   6,  18,  48,  32,   0, 
++      0,   0,   0,   0,   2,   0, 
++      0,   0,  42,   0,  16,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   6,  18,  48,  32,   0, 
++      0,   0,   0,   0,   3,   0, 
++      0,   0,  58,   0,  16,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   6,  18,  48,  32,   0, 
++      0,   0,   0,   0,   4,   0, 
++      0,   0,   1,  64,   0,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   6,  18,  48,  32,   0, 
++      0,   0,   0,   0,   5,   0, 
++      0,   0,   1,  64,   0,   0, 
++      0,   0, 128,  63,  54,   0, 
++      0,   6,  18,   0,  16,   0, 
++      0,   0,   0,   0,  10, 128, 
++     32,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   7,  18,  32,  16,   0, 
++      0,   0,   0,   0,  10,  48, 
++     32,   4,   0,   0,   0,   0, 
++     10,   0,  16,   0,   0,   0, 
++      0,   0,  54,   0,   0,   6, 
++     18,   0,  16,   0,   0,   0, 
++      0,   0,  26, 128,  32,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,  54,   0,   0,   7, 
++     34,  32,  16,   0,   0,   0, 
++      0,   0,  10,  48,  32,   4, 
++      0,   0,   0,   0,  10,   0, 
++     16,   0,   0,   0,   0,   0, 
++     54,   0,   0,   6,  18,   0, 
++     16,   0,   0,   0,   0,   0, 
++     42, 128,  32,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++     54,   0,   0,   7,  66,  32, 
++     16,   0,   0,   0,   0,   0, 
++     10,  48,  32,   4,   0,   0, 
++      0,   0,  10,   0,  16,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   6,  18,   0,  16,   0, 
++      0,   0,   0,   0,  58, 128, 
++     32,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   7, 130,  32,  16,   0, 
++      0,   0,   0,   0,  10,  48, 
++     32,   4,   0,   0,   0,   0, 
++     10,   0,  16,   0,   0,   0, 
++      0,   0,  62,   0,   0,   1, 
++     83,  84,  65,  84, 116,   0, 
++      0,   0,  18,   0,   0,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0,   3,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      6,   0,   0,   0,  10,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      5,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0
++};
+diff --git a/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/swizzlef2dps.h b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/swizzlef2dps.h
+new file mode 100644
+index 00000000..181b5135
+--- /dev/null
++++ b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/swizzlef2dps.h
+@@ -0,0 +1,254 @@
++#if 0
++//
++// Generated by Microsoft (R) HLSL Shader Compiler 10.1
++//
++//
++// Buffer Definitions: 
++//
++// cbuffer SwizzleProperties
++// {
++//
++//   uint4 SwizzleIndices;              // Offset:    0 Size:    16
++//
++// }
++//
++//
++// Resource Bindings:
++//
++// Name                                 Type  Format         Dim      HLSL Bind  Count
++// ------------------------------ ---------- ------- ----------- -------------- ------
++// Sampler                           sampler      NA          NA             s0      1 
++// TextureF2D                        texture  float4          2d             t0      1 
++// SwizzleProperties                 cbuffer      NA          NA            cb0      1 
++//
++//
++//
++// Input signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_POSITION              0   xyzw        0      POS   float       
++// TEXCOORD                 0   xy          1     NONE   float   xy  
++//
++//
++// Output signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_TARGET                0   xyzw        0   TARGET   float   xyzw
++//
++ps_4_0
++dcl_constantbuffer CB0[1], immediateIndexed
++dcl_sampler s0, mode_default
++dcl_resource_texture2d (float,float,float,float) t0
++dcl_input_ps linear v1.xy
++dcl_output o0.xyzw
++dcl_temps 1
++dcl_indexableTemp x0[6], 4
++sample r0.xyzw, v1.xyxx, t0.xyzw, s0
++mov x0[0].x, r0.x
++mov x0[1].x, r0.y
++mov x0[2].x, r0.z
++mov x0[3].x, r0.w
++mov x0[4].x, l(0)
++mov x0[5].x, l(1.000000)
++mov r0.x, cb0[0].x
++mov o0.x, x0[r0.x + 0].x
++mov r0.x, cb0[0].y
++mov o0.y, x0[r0.x + 0].x
++mov r0.x, cb0[0].z
++mov o0.z, x0[r0.x + 0].x
++mov r0.x, cb0[0].w
++mov o0.w, x0[r0.x + 0].x
++ret 
++// Approximately 16 instruction slots used
++#endif
++
++const BYTE g_PS_SwizzleF2D[] =
++{
++     68,  88,  66,  67, 221,  55, 
++    186,  66, 171, 208,  86, 211, 
++     37, 150,  98, 209, 236,  60, 
++    108,  41,   1,   0,   0,   0, 
++     84,   4,   0,   0,   5,   0, 
++      0,   0,  52,   0,   0,   0, 
++     88,   1,   0,   0, 176,   1, 
++      0,   0, 228,   1,   0,   0, 
++    216,   3,   0,   0,  82,  68, 
++     69,  70,  28,   1,   0,   0, 
++      1,   0,   0,   0, 164,   0, 
++      0,   0,   3,   0,   0,   0, 
++     28,   0,   0,   0,   0,   4, 
++    255, 255,   0,   1,   0,   0, 
++    244,   0,   0,   0, 124,   0, 
++      0,   0,   3,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,   1,   0,   0,   0, 
++    132,   0,   0,   0,   2,   0, 
++      0,   0,   5,   0,   0,   0, 
++      4,   0,   0,   0, 255, 255, 
++    255, 255,   0,   0,   0,   0, 
++      1,   0,   0,   0,  13,   0, 
++      0,   0, 143,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++      1,   0,   0,   0,  83,  97, 
++    109, 112, 108, 101, 114,   0, 
++     84, 101, 120, 116, 117, 114, 
++    101,  70,  50,  68,   0,  83, 
++    119, 105, 122, 122, 108, 101, 
++     80, 114, 111, 112, 101, 114, 
++    116, 105, 101, 115,   0, 171, 
++    171, 171, 143,   0,   0,   0, 
++      1,   0,   0,   0, 188,   0, 
++      0,   0,  16,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0, 212,   0,   0,   0, 
++      0,   0,   0,   0,  16,   0, 
++      0,   0,   2,   0,   0,   0, 
++    228,   0,   0,   0,   0,   0, 
++      0,   0,  83, 119, 105, 122, 
++    122, 108, 101,  73, 110, 100, 
++    105,  99, 101, 115,   0, 171, 
++      1,   0,  19,   0,   1,   0, 
++      4,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,  77, 105, 
++     99, 114, 111, 115, 111, 102, 
++    116,  32,  40,  82,  41,  32, 
++     72,  76,  83,  76,  32,  83, 
++    104,  97, 100, 101, 114,  32, 
++     67, 111, 109, 112, 105, 108, 
++    101, 114,  32,  49,  48,  46, 
++     49,   0,  73,  83,  71,  78, 
++     80,   0,   0,   0,   2,   0, 
++      0,   0,   8,   0,   0,   0, 
++     56,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++      3,   0,   0,   0,   0,   0, 
++      0,   0,  15,   0,   0,   0, 
++     68,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      3,   0,   0,   0,   1,   0, 
++      0,   0,   3,   3,   0,   0, 
++     83,  86,  95,  80,  79,  83, 
++     73,  84,  73,  79,  78,   0, 
++     84,  69,  88,  67,  79,  79, 
++     82,  68,   0, 171, 171, 171, 
++     79,  83,  71,  78,  44,   0, 
++      0,   0,   1,   0,   0,   0, 
++      8,   0,   0,   0,  32,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   3,   0, 
++      0,   0,   0,   0,   0,   0, 
++     15,   0,   0,   0,  83,  86, 
++     95,  84,  65,  82,  71,  69, 
++     84,   0, 171, 171,  83,  72, 
++     68,  82, 236,   1,   0,   0, 
++     64,   0,   0,   0, 123,   0, 
++      0,   0,  89,   0,   0,   4, 
++     70, 142,  32,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++     90,   0,   0,   3,   0,  96, 
++     16,   0,   0,   0,   0,   0, 
++     88,  24,   0,   4,   0, 112, 
++     16,   0,   0,   0,   0,   0, 
++     85,  85,   0,   0,  98,  16, 
++      0,   3,  50,  16,  16,   0, 
++      1,   0,   0,   0, 101,   0, 
++      0,   3, 242,  32,  16,   0, 
++      0,   0,   0,   0, 104,   0, 
++      0,   2,   1,   0,   0,   0, 
++    105,   0,   0,   4,   0,   0, 
++      0,   0,   6,   0,   0,   0, 
++      4,   0,   0,   0,  69,   0, 
++      0,   9, 242,   0,  16,   0, 
++      0,   0,   0,   0,  70,  16, 
++     16,   0,   1,   0,   0,   0, 
++     70, 126,  16,   0,   0,   0, 
++      0,   0,   0,  96,  16,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   6,  18,  48,  32,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,  10,   0,  16,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   6,  18,  48,  32,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,  26,   0,  16,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   6,  18,  48,  32,   0, 
++      0,   0,   0,   0,   2,   0, 
++      0,   0,  42,   0,  16,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   6,  18,  48,  32,   0, 
++      0,   0,   0,   0,   3,   0, 
++      0,   0,  58,   0,  16,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   6,  18,  48,  32,   0, 
++      0,   0,   0,   0,   4,   0, 
++      0,   0,   1,  64,   0,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   6,  18,  48,  32,   0, 
++      0,   0,   0,   0,   5,   0, 
++      0,   0,   1,  64,   0,   0, 
++      0,   0, 128,  63,  54,   0, 
++      0,   6,  18,   0,  16,   0, 
++      0,   0,   0,   0,  10, 128, 
++     32,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   7,  18,  32,  16,   0, 
++      0,   0,   0,   0,  10,  48, 
++     32,   4,   0,   0,   0,   0, 
++     10,   0,  16,   0,   0,   0, 
++      0,   0,  54,   0,   0,   6, 
++     18,   0,  16,   0,   0,   0, 
++      0,   0,  26, 128,  32,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,  54,   0,   0,   7, 
++     34,  32,  16,   0,   0,   0, 
++      0,   0,  10,  48,  32,   4, 
++      0,   0,   0,   0,  10,   0, 
++     16,   0,   0,   0,   0,   0, 
++     54,   0,   0,   6,  18,   0, 
++     16,   0,   0,   0,   0,   0, 
++     42, 128,  32,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++     54,   0,   0,   7,  66,  32, 
++     16,   0,   0,   0,   0,   0, 
++     10,  48,  32,   4,   0,   0, 
++      0,   0,  10,   0,  16,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   6,  18,   0,  16,   0, 
++      0,   0,   0,   0,  58, 128, 
++     32,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   7, 130,  32,  16,   0, 
++      0,   0,   0,   0,  10,  48, 
++     32,   4,   0,   0,   0,   0, 
++     10,   0,  16,   0,   0,   0, 
++      0,   0,  62,   0,   0,   1, 
++     83,  84,  65,  84, 116,   0, 
++      0,   0,  16,   0,   0,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0,   2,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      6,   0,   0,   0,  10,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      4,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0
++};
+diff --git a/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/swizzlef3dps.h b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/swizzlef3dps.h
+new file mode 100644
+index 00000000..87156c90
+--- /dev/null
++++ b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/swizzlef3dps.h
+@@ -0,0 +1,263 @@
++#if 0
++//
++// Generated by Microsoft (R) HLSL Shader Compiler 10.1
++//
++//
++// Buffer Definitions: 
++//
++// cbuffer SwizzleProperties
++// {
++//
++//   uint4 SwizzleIndices;              // Offset:    0 Size:    16
++//
++// }
++//
++//
++// Resource Bindings:
++//
++// Name                                 Type  Format         Dim      HLSL Bind  Count
++// ------------------------------ ---------- ------- ----------- -------------- ------
++// Sampler                           sampler      NA          NA             s0      1 
++// TextureF3D                        texture  float4          3d             t0      1 
++// SwizzleProperties                 cbuffer      NA          NA            cb0      1 
++//
++//
++//
++// Input signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_POSITION              0   xyzw        0      POS   float       
++// SV_RENDERTARGETARRAYINDEX     0   x           1  RTINDEX    uint       
++// TEXCOORD                 0   xyz         2     NONE   float   xyz 
++//
++//
++// Output signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_TARGET                0   xyzw        0   TARGET   float   xyzw
++//
++ps_4_0
++dcl_constantbuffer CB0[1], immediateIndexed
++dcl_sampler s0, mode_default
++dcl_resource_texture3d (float,float,float,float) t0
++dcl_input_ps linear v2.xyz
++dcl_output o0.xyzw
++dcl_temps 1
++dcl_indexableTemp x0[6], 4
++sample r0.xyzw, v2.xyzx, t0.xyzw, s0
++mov x0[0].x, r0.x
++mov x0[1].x, r0.y
++mov x0[2].x, r0.z
++mov x0[3].x, r0.w
++mov x0[4].x, l(0)
++mov x0[5].x, l(1.000000)
++mov r0.x, cb0[0].x
++mov o0.x, x0[r0.x + 0].x
++mov r0.x, cb0[0].y
++mov o0.y, x0[r0.x + 0].x
++mov r0.x, cb0[0].z
++mov o0.z, x0[r0.x + 0].x
++mov r0.x, cb0[0].w
++mov o0.w, x0[r0.x + 0].x
++ret 
++// Approximately 16 instruction slots used
++#endif
++
++const BYTE g_PS_SwizzleF3D[] =
++{
++     68,  88,  66,  67,  73, 214, 
++     47, 221, 178, 220, 225,  86, 
++    113,  45, 198,  41, 129, 110, 
++    186,  79,   1,   0,   0,   0, 
++    132,   4,   0,   0,   5,   0, 
++      0,   0,  52,   0,   0,   0, 
++     88,   1,   0,   0, 224,   1, 
++      0,   0,  20,   2,   0,   0, 
++      8,   4,   0,   0,  82,  68, 
++     69,  70,  28,   1,   0,   0, 
++      1,   0,   0,   0, 164,   0, 
++      0,   0,   3,   0,   0,   0, 
++     28,   0,   0,   0,   0,   4, 
++    255, 255,   0,   1,   0,   0, 
++    244,   0,   0,   0, 124,   0, 
++      0,   0,   3,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,   1,   0,   0,   0, 
++    132,   0,   0,   0,   2,   0, 
++      0,   0,   5,   0,   0,   0, 
++      8,   0,   0,   0, 255, 255, 
++    255, 255,   0,   0,   0,   0, 
++      1,   0,   0,   0,  13,   0, 
++      0,   0, 143,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++      1,   0,   0,   0,  83,  97, 
++    109, 112, 108, 101, 114,   0, 
++     84, 101, 120, 116, 117, 114, 
++    101,  70,  51,  68,   0,  83, 
++    119, 105, 122, 122, 108, 101, 
++     80, 114, 111, 112, 101, 114, 
++    116, 105, 101, 115,   0, 171, 
++    171, 171, 143,   0,   0,   0, 
++      1,   0,   0,   0, 188,   0, 
++      0,   0,  16,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0, 212,   0,   0,   0, 
++      0,   0,   0,   0,  16,   0, 
++      0,   0,   2,   0,   0,   0, 
++    228,   0,   0,   0,   0,   0, 
++      0,   0,  83, 119, 105, 122, 
++    122, 108, 101,  73, 110, 100, 
++    105,  99, 101, 115,   0, 171, 
++      1,   0,  19,   0,   1,   0, 
++      4,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,  77, 105, 
++     99, 114, 111, 115, 111, 102, 
++    116,  32,  40,  82,  41,  32, 
++     72,  76,  83,  76,  32,  83, 
++    104,  97, 100, 101, 114,  32, 
++     67, 111, 109, 112, 105, 108, 
++    101, 114,  32,  49,  48,  46, 
++     49,   0,  73,  83,  71,  78, 
++    128,   0,   0,   0,   3,   0, 
++      0,   0,   8,   0,   0,   0, 
++     80,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++      3,   0,   0,   0,   0,   0, 
++      0,   0,  15,   0,   0,   0, 
++     92,   0,   0,   0,   0,   0, 
++      0,   0,   4,   0,   0,   0, 
++      1,   0,   0,   0,   1,   0, 
++      0,   0,   1,   0,   0,   0, 
++    118,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      3,   0,   0,   0,   2,   0, 
++      0,   0,   7,   7,   0,   0, 
++     83,  86,  95,  80,  79,  83, 
++     73,  84,  73,  79,  78,   0, 
++     83,  86,  95,  82,  69,  78, 
++     68,  69,  82,  84,  65,  82, 
++     71,  69,  84,  65,  82,  82, 
++     65,  89,  73,  78,  68,  69, 
++     88,   0,  84,  69,  88,  67, 
++     79,  79,  82,  68,   0, 171, 
++     79,  83,  71,  78,  44,   0, 
++      0,   0,   1,   0,   0,   0, 
++      8,   0,   0,   0,  32,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   3,   0, 
++      0,   0,   0,   0,   0,   0, 
++     15,   0,   0,   0,  83,  86, 
++     95,  84,  65,  82,  71,  69, 
++     84,   0, 171, 171,  83,  72, 
++     68,  82, 236,   1,   0,   0, 
++     64,   0,   0,   0, 123,   0, 
++      0,   0,  89,   0,   0,   4, 
++     70, 142,  32,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++     90,   0,   0,   3,   0,  96, 
++     16,   0,   0,   0,   0,   0, 
++     88,  40,   0,   4,   0, 112, 
++     16,   0,   0,   0,   0,   0, 
++     85,  85,   0,   0,  98,  16, 
++      0,   3, 114,  16,  16,   0, 
++      2,   0,   0,   0, 101,   0, 
++      0,   3, 242,  32,  16,   0, 
++      0,   0,   0,   0, 104,   0, 
++      0,   2,   1,   0,   0,   0, 
++    105,   0,   0,   4,   0,   0, 
++      0,   0,   6,   0,   0,   0, 
++      4,   0,   0,   0,  69,   0, 
++      0,   9, 242,   0,  16,   0, 
++      0,   0,   0,   0,  70,  18, 
++     16,   0,   2,   0,   0,   0, 
++     70, 126,  16,   0,   0,   0, 
++      0,   0,   0,  96,  16,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   6,  18,  48,  32,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,  10,   0,  16,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   6,  18,  48,  32,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,  26,   0,  16,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   6,  18,  48,  32,   0, 
++      0,   0,   0,   0,   2,   0, 
++      0,   0,  42,   0,  16,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   6,  18,  48,  32,   0, 
++      0,   0,   0,   0,   3,   0, 
++      0,   0,  58,   0,  16,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   6,  18,  48,  32,   0, 
++      0,   0,   0,   0,   4,   0, 
++      0,   0,   1,  64,   0,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   6,  18,  48,  32,   0, 
++      0,   0,   0,   0,   5,   0, 
++      0,   0,   1,  64,   0,   0, 
++      0,   0, 128,  63,  54,   0, 
++      0,   6,  18,   0,  16,   0, 
++      0,   0,   0,   0,  10, 128, 
++     32,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   7,  18,  32,  16,   0, 
++      0,   0,   0,   0,  10,  48, 
++     32,   4,   0,   0,   0,   0, 
++     10,   0,  16,   0,   0,   0, 
++      0,   0,  54,   0,   0,   6, 
++     18,   0,  16,   0,   0,   0, 
++      0,   0,  26, 128,  32,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,  54,   0,   0,   7, 
++     34,  32,  16,   0,   0,   0, 
++      0,   0,  10,  48,  32,   4, 
++      0,   0,   0,   0,  10,   0, 
++     16,   0,   0,   0,   0,   0, 
++     54,   0,   0,   6,  18,   0, 
++     16,   0,   0,   0,   0,   0, 
++     42, 128,  32,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++     54,   0,   0,   7,  66,  32, 
++     16,   0,   0,   0,   0,   0, 
++     10,  48,  32,   4,   0,   0, 
++      0,   0,  10,   0,  16,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   6,  18,   0,  16,   0, 
++      0,   0,   0,   0,  58, 128, 
++     32,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   7, 130,  32,  16,   0, 
++      0,   0,   0,   0,  10,  48, 
++     32,   4,   0,   0,   0,   0, 
++     10,   0,  16,   0,   0,   0, 
++      0,   0,  62,   0,   0,   1, 
++     83,  84,  65,  84, 116,   0, 
++      0,   0,  16,   0,   0,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0,   2,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      6,   0,   0,   0,  10,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      4,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0
++};
+diff --git a/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/swizzlei2darrayps.h b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/swizzlei2darrayps.h
+new file mode 100644
+index 00000000..40aa3bf9
+--- /dev/null
++++ b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/swizzlei2darrayps.h
+@@ -0,0 +1,284 @@
++#if 0
++//
++// Generated by Microsoft (R) HLSL Shader Compiler 10.1
++//
++//
++// Buffer Definitions: 
++//
++// cbuffer SwizzleProperties
++// {
++//
++//   uint4 SwizzleIndices;              // Offset:    0 Size:    16
++//
++// }
++//
++//
++// Resource Bindings:
++//
++// Name                                 Type  Format         Dim      HLSL Bind  Count
++// ------------------------------ ---------- ------- ----------- -------------- ------
++// TextureI2DArray                   texture   sint4     2darray             t0      1 
++// SwizzleProperties                 cbuffer      NA          NA            cb0      1 
++//
++//
++//
++// Input signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_POSITION              0   xyzw        0      POS   float       
++// SV_RENDERTARGETARRAYINDEX     0   x           1  RTINDEX    uint   x   
++// TEXCOORD                 0   xyz         2     NONE   float   xy  
++//
++//
++// Output signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_TARGET                0   xyzw        0   TARGET     int   xyzw
++//
++ps_4_0
++dcl_constantbuffer CB0[1], immediateIndexed
++dcl_resource_texture2darray (sint,sint,sint,sint) t0
++dcl_input_ps_siv constant v1.x, rendertarget_array_index
++dcl_input_ps linear v2.xy
++dcl_output o0.xyzw
++dcl_temps 1
++dcl_indexableTemp x0[6], 4
++resinfo_uint r0.xyzw, l(0), t0.xyzw
++utof r0.xy, r0.xyxx
++mul r0.xy, r0.xyxx, v2.xyxx
++ftoi r0.xy, r0.xyxx
++mov r0.z, v1.x
++mov r0.w, l(0)
++ld r0.xyzw, r0.xyzw, t0.xyzw
++mov x0[0].x, r0.x
++mov x0[1].x, r0.y
++mov x0[2].x, r0.z
++mov x0[3].x, r0.w
++mov x0[4].x, l(0)
++mov x0[5].x, l(1)
++mov r0.x, cb0[0].x
++mov o0.x, x0[r0.x + 0].x
++mov r0.x, cb0[0].y
++mov o0.y, x0[r0.x + 0].x
++mov r0.x, cb0[0].z
++mov o0.z, x0[r0.x + 0].x
++mov r0.x, cb0[0].w
++mov o0.w, x0[r0.x + 0].x
++ret 
++// Approximately 22 instruction slots used
++#endif
++
++const BYTE g_PS_SwizzleI2DArray[] =
++{
++     68,  88,  66,  67, 212, 163, 
++    121, 141,  10, 113, 132, 178, 
++     58, 176, 145,  98,  43, 111, 
++    211,  61,   1,   0,   0,   0, 
++    228,   4,   0,   0,   5,   0, 
++      0,   0,  52,   0,   0,   0, 
++     52,   1,   0,   0, 188,   1, 
++      0,   0, 240,   1,   0,   0, 
++    104,   4,   0,   0,  82,  68, 
++     69,  70, 248,   0,   0,   0, 
++      1,   0,   0,   0, 128,   0, 
++      0,   0,   2,   0,   0,   0, 
++     28,   0,   0,   0,   0,   4, 
++    255, 255,   0,   1,   0,   0, 
++    208,   0,   0,   0,  92,   0, 
++      0,   0,   2,   0,   0,   0, 
++      3,   0,   0,   0,   5,   0, 
++      0,   0, 255, 255, 255, 255, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,  13,   0,   0,   0, 
++    108,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0,   1,   0, 
++      0,   0,  84, 101, 120, 116, 
++    117, 114, 101,  73,  50,  68, 
++     65, 114, 114,  97, 121,   0, 
++     83, 119, 105, 122, 122, 108, 
++    101,  80, 114, 111, 112, 101, 
++    114, 116, 105, 101, 115,   0, 
++    171, 171, 108,   0,   0,   0, 
++      1,   0,   0,   0, 152,   0, 
++      0,   0,  16,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0, 176,   0,   0,   0, 
++      0,   0,   0,   0,  16,   0, 
++      0,   0,   2,   0,   0,   0, 
++    192,   0,   0,   0,   0,   0, 
++      0,   0,  83, 119, 105, 122, 
++    122, 108, 101,  73, 110, 100, 
++    105,  99, 101, 115,   0, 171, 
++      1,   0,  19,   0,   1,   0, 
++      4,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,  77, 105, 
++     99, 114, 111, 115, 111, 102, 
++    116,  32,  40,  82,  41,  32, 
++     72,  76,  83,  76,  32,  83, 
++    104,  97, 100, 101, 114,  32, 
++     67, 111, 109, 112, 105, 108, 
++    101, 114,  32,  49,  48,  46, 
++     49,   0,  73,  83,  71,  78, 
++    128,   0,   0,   0,   3,   0, 
++      0,   0,   8,   0,   0,   0, 
++     80,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++      3,   0,   0,   0,   0,   0, 
++      0,   0,  15,   0,   0,   0, 
++     92,   0,   0,   0,   0,   0, 
++      0,   0,   4,   0,   0,   0, 
++      1,   0,   0,   0,   1,   0, 
++      0,   0,   1,   1,   0,   0, 
++    118,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      3,   0,   0,   0,   2,   0, 
++      0,   0,   7,   3,   0,   0, 
++     83,  86,  95,  80,  79,  83, 
++     73,  84,  73,  79,  78,   0, 
++     83,  86,  95,  82,  69,  78, 
++     68,  69,  82,  84,  65,  82, 
++     71,  69,  84,  65,  82,  82, 
++     65,  89,  73,  78,  68,  69, 
++     88,   0,  84,  69,  88,  67, 
++     79,  79,  82,  68,   0, 171, 
++     79,  83,  71,  78,  44,   0, 
++      0,   0,   1,   0,   0,   0, 
++      8,   0,   0,   0,  32,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   2,   0, 
++      0,   0,   0,   0,   0,   0, 
++     15,   0,   0,   0,  83,  86, 
++     95,  84,  65,  82,  71,  69, 
++     84,   0, 171, 171,  83,  72, 
++     68,  82, 112,   2,   0,   0, 
++     64,   0,   0,   0, 156,   0, 
++      0,   0,  89,   0,   0,   4, 
++     70, 142,  32,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++     88,  64,   0,   4,   0, 112, 
++     16,   0,   0,   0,   0,   0, 
++     51,  51,   0,   0, 100,   8, 
++      0,   4,  18,  16,  16,   0, 
++      1,   0,   0,   0,   4,   0, 
++      0,   0,  98,  16,   0,   3, 
++     50,  16,  16,   0,   2,   0, 
++      0,   0, 101,   0,   0,   3, 
++    242,  32,  16,   0,   0,   0, 
++      0,   0, 104,   0,   0,   2, 
++      1,   0,   0,   0, 105,   0, 
++      0,   4,   0,   0,   0,   0, 
++      6,   0,   0,   0,   4,   0, 
++      0,   0,  61,  16,   0,   7, 
++    242,   0,  16,   0,   0,   0, 
++      0,   0,   1,  64,   0,   0, 
++      0,   0,   0,   0,  70, 126, 
++     16,   0,   0,   0,   0,   0, 
++     86,   0,   0,   5,  50,   0, 
++     16,   0,   0,   0,   0,   0, 
++     70,   0,  16,   0,   0,   0, 
++      0,   0,  56,   0,   0,   7, 
++     50,   0,  16,   0,   0,   0, 
++      0,   0,  70,   0,  16,   0, 
++      0,   0,   0,   0,  70,  16, 
++     16,   0,   2,   0,   0,   0, 
++     27,   0,   0,   5,  50,   0, 
++     16,   0,   0,   0,   0,   0, 
++     70,   0,  16,   0,   0,   0, 
++      0,   0,  54,   0,   0,   5, 
++     66,   0,  16,   0,   0,   0, 
++      0,   0,  10,  16,  16,   0, 
++      1,   0,   0,   0,  54,   0, 
++      0,   5, 130,   0,  16,   0, 
++      0,   0,   0,   0,   1,  64, 
++      0,   0,   0,   0,   0,   0, 
++     45,   0,   0,   7, 242,   0, 
++     16,   0,   0,   0,   0,   0, 
++     70,  14,  16,   0,   0,   0, 
++      0,   0,  70, 126,  16,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   6,  18,  48,  32,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,  10,   0,  16,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   6,  18,  48,  32,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,  26,   0,  16,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   6,  18,  48,  32,   0, 
++      0,   0,   0,   0,   2,   0, 
++      0,   0,  42,   0,  16,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   6,  18,  48,  32,   0, 
++      0,   0,   0,   0,   3,   0, 
++      0,   0,  58,   0,  16,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   6,  18,  48,  32,   0, 
++      0,   0,   0,   0,   4,   0, 
++      0,   0,   1,  64,   0,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   6,  18,  48,  32,   0, 
++      0,   0,   0,   0,   5,   0, 
++      0,   0,   1,  64,   0,   0, 
++      1,   0,   0,   0,  54,   0, 
++      0,   6,  18,   0,  16,   0, 
++      0,   0,   0,   0,  10, 128, 
++     32,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   7,  18,  32,  16,   0, 
++      0,   0,   0,   0,  10,  48, 
++     32,   4,   0,   0,   0,   0, 
++     10,   0,  16,   0,   0,   0, 
++      0,   0,  54,   0,   0,   6, 
++     18,   0,  16,   0,   0,   0, 
++      0,   0,  26, 128,  32,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,  54,   0,   0,   7, 
++     34,  32,  16,   0,   0,   0, 
++      0,   0,  10,  48,  32,   4, 
++      0,   0,   0,   0,  10,   0, 
++     16,   0,   0,   0,   0,   0, 
++     54,   0,   0,   6,  18,   0, 
++     16,   0,   0,   0,   0,   0, 
++     42, 128,  32,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++     54,   0,   0,   7,  66,  32, 
++     16,   0,   0,   0,   0,   0, 
++     10,  48,  32,   4,   0,   0, 
++      0,   0,  10,   0,  16,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   6,  18,   0,  16,   0, 
++      0,   0,   0,   0,  58, 128, 
++     32,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   7, 130,  32,  16,   0, 
++      0,   0,   0,   0,  10,  48, 
++     32,   4,   0,   0,   0,   0, 
++     10,   0,  16,   0,   0,   0, 
++      0,   0,  62,   0,   0,   1, 
++     83,  84,  65,  84, 116,   0, 
++      0,   0,  22,   0,   0,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0,   3,   0,   0,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      6,   0,   0,   0,  10,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      6,   0,   0,   0,   0,   0, 
++      0,   0,   2,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0
++};
+diff --git a/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/swizzlei2dps.h b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/swizzlei2dps.h
+new file mode 100644
+index 00000000..7defee2e
+--- /dev/null
++++ b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/swizzlei2dps.h
+@@ -0,0 +1,268 @@
++#if 0
++//
++// Generated by Microsoft (R) HLSL Shader Compiler 10.1
++//
++//
++// Buffer Definitions: 
++//
++// cbuffer SwizzleProperties
++// {
++//
++//   uint4 SwizzleIndices;              // Offset:    0 Size:    16
++//
++// }
++//
++//
++// Resource Bindings:
++//
++// Name                                 Type  Format         Dim      HLSL Bind  Count
++// ------------------------------ ---------- ------- ----------- -------------- ------
++// TextureI2D                        texture   sint4          2d             t0      1 
++// SwizzleProperties                 cbuffer      NA          NA            cb0      1 
++//
++//
++//
++// Input signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_POSITION              0   xyzw        0      POS   float       
++// TEXCOORD                 0   xy          1     NONE   float   xy  
++//
++//
++// Output signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_TARGET                0   xyzw        0   TARGET     int   xyzw
++//
++ps_4_0
++dcl_constantbuffer CB0[1], immediateIndexed
++dcl_resource_texture2d (sint,sint,sint,sint) t0
++dcl_input_ps linear v1.xy
++dcl_output o0.xyzw
++dcl_temps 1
++dcl_indexableTemp x0[6], 4
++resinfo_uint r0.xyzw, l(0), t0.xyzw
++utof r0.xy, r0.xyxx
++mul r0.xy, r0.xyxx, v1.xyxx
++ftoi r0.xy, r0.xyxx
++mov r0.zw, l(0,0,0,0)
++ld r0.xyzw, r0.xyzw, t0.xyzw
++mov x0[0].x, r0.x
++mov x0[1].x, r0.y
++mov x0[2].x, r0.z
++mov x0[3].x, r0.w
++mov x0[4].x, l(0)
++mov x0[5].x, l(1)
++mov r0.x, cb0[0].x
++mov o0.x, x0[r0.x + 0].x
++mov r0.x, cb0[0].y
++mov o0.y, x0[r0.x + 0].x
++mov r0.x, cb0[0].z
++mov o0.z, x0[r0.x + 0].x
++mov r0.x, cb0[0].w
++mov o0.w, x0[r0.x + 0].x
++ret 
++// Approximately 21 instruction slots used
++#endif
++
++const BYTE g_PS_SwizzleI2D[] =
++{
++     68,  88,  66,  67, 177,  45, 
++    190, 185, 217, 208,  59,  28, 
++    232, 250, 124, 179,  32, 246, 
++     26, 206,   1,   0,   0,   0, 
++    152,   4,   0,   0,   5,   0, 
++      0,   0,  52,   0,   0,   0, 
++     48,   1,   0,   0, 136,   1, 
++      0,   0, 188,   1,   0,   0, 
++     28,   4,   0,   0,  82,  68, 
++     69,  70, 244,   0,   0,   0, 
++      1,   0,   0,   0, 124,   0, 
++      0,   0,   2,   0,   0,   0, 
++     28,   0,   0,   0,   0,   4, 
++    255, 255,   0,   1,   0,   0, 
++    204,   0,   0,   0,  92,   0, 
++      0,   0,   2,   0,   0,   0, 
++      3,   0,   0,   0,   4,   0, 
++      0,   0, 255, 255, 255, 255, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,  13,   0,   0,   0, 
++    103,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0,   1,   0, 
++      0,   0,  84, 101, 120, 116, 
++    117, 114, 101,  73,  50,  68, 
++      0,  83, 119, 105, 122, 122, 
++    108, 101,  80, 114, 111, 112, 
++    101, 114, 116, 105, 101, 115, 
++      0, 171, 171, 171, 103,   0, 
++      0,   0,   1,   0,   0,   0, 
++    148,   0,   0,   0,  16,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0, 172,   0, 
++      0,   0,   0,   0,   0,   0, 
++     16,   0,   0,   0,   2,   0, 
++      0,   0, 188,   0,   0,   0, 
++      0,   0,   0,   0,  83, 119, 
++    105, 122, 122, 108, 101,  73, 
++    110, 100, 105,  99, 101, 115, 
++      0, 171,   1,   0,  19,   0, 
++      1,   0,   4,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++     77, 105,  99, 114, 111, 115, 
++    111, 102, 116,  32,  40,  82, 
++     41,  32,  72,  76,  83,  76, 
++     32,  83, 104,  97, 100, 101, 
++    114,  32,  67, 111, 109, 112, 
++    105, 108, 101, 114,  32,  49, 
++     48,  46,  49,   0,  73,  83, 
++     71,  78,  80,   0,   0,   0, 
++      2,   0,   0,   0,   8,   0, 
++      0,   0,  56,   0,   0,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,   3,   0,   0,   0, 
++      0,   0,   0,   0,  15,   0, 
++      0,   0,  68,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   3,   0,   0,   0, 
++      1,   0,   0,   0,   3,   3, 
++      0,   0,  83,  86,  95,  80, 
++     79,  83,  73,  84,  73,  79, 
++     78,   0,  84,  69,  88,  67, 
++     79,  79,  82,  68,   0, 171, 
++    171, 171,  79,  83,  71,  78, 
++     44,   0,   0,   0,   1,   0, 
++      0,   0,   8,   0,   0,   0, 
++     32,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      2,   0,   0,   0,   0,   0, 
++      0,   0,  15,   0,   0,   0, 
++     83,  86,  95,  84,  65,  82, 
++     71,  69,  84,   0, 171, 171, 
++     83,  72,  68,  82,  88,   2, 
++      0,   0,  64,   0,   0,   0, 
++    150,   0,   0,   0,  89,   0, 
++      0,   4,  70, 142,  32,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,  88,  24,   0,   4, 
++      0, 112,  16,   0,   0,   0, 
++      0,   0,  51,  51,   0,   0, 
++     98,  16,   0,   3,  50,  16, 
++     16,   0,   1,   0,   0,   0, 
++    101,   0,   0,   3, 242,  32, 
++     16,   0,   0,   0,   0,   0, 
++    104,   0,   0,   2,   1,   0, 
++      0,   0, 105,   0,   0,   4, 
++      0,   0,   0,   0,   6,   0, 
++      0,   0,   4,   0,   0,   0, 
++     61,  16,   0,   7, 242,   0, 
++     16,   0,   0,   0,   0,   0, 
++      1,  64,   0,   0,   0,   0, 
++      0,   0,  70, 126,  16,   0, 
++      0,   0,   0,   0,  86,   0, 
++      0,   5,  50,   0,  16,   0, 
++      0,   0,   0,   0,  70,   0, 
++     16,   0,   0,   0,   0,   0, 
++     56,   0,   0,   7,  50,   0, 
++     16,   0,   0,   0,   0,   0, 
++     70,   0,  16,   0,   0,   0, 
++      0,   0,  70,  16,  16,   0, 
++      1,   0,   0,   0,  27,   0, 
++      0,   5,  50,   0,  16,   0, 
++      0,   0,   0,   0,  70,   0, 
++     16,   0,   0,   0,   0,   0, 
++     54,   0,   0,   8, 194,   0, 
++     16,   0,   0,   0,   0,   0, 
++      2,  64,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,  45,   0,   0,   7, 
++    242,   0,  16,   0,   0,   0, 
++      0,   0,  70,  14,  16,   0, 
++      0,   0,   0,   0,  70, 126, 
++     16,   0,   0,   0,   0,   0, 
++     54,   0,   0,   6,  18,  48, 
++     32,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,  10,   0, 
++     16,   0,   0,   0,   0,   0, 
++     54,   0,   0,   6,  18,  48, 
++     32,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0,  26,   0, 
++     16,   0,   0,   0,   0,   0, 
++     54,   0,   0,   6,  18,  48, 
++     32,   0,   0,   0,   0,   0, 
++      2,   0,   0,   0,  42,   0, 
++     16,   0,   0,   0,   0,   0, 
++     54,   0,   0,   6,  18,  48, 
++     32,   0,   0,   0,   0,   0, 
++      3,   0,   0,   0,  58,   0, 
++     16,   0,   0,   0,   0,   0, 
++     54,   0,   0,   6,  18,  48, 
++     32,   0,   0,   0,   0,   0, 
++      4,   0,   0,   0,   1,  64, 
++      0,   0,   0,   0,   0,   0, 
++     54,   0,   0,   6,  18,  48, 
++     32,   0,   0,   0,   0,   0, 
++      5,   0,   0,   0,   1,  64, 
++      0,   0,   1,   0,   0,   0, 
++     54,   0,   0,   6,  18,   0, 
++     16,   0,   0,   0,   0,   0, 
++     10, 128,  32,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++     54,   0,   0,   7,  18,  32, 
++     16,   0,   0,   0,   0,   0, 
++     10,  48,  32,   4,   0,   0, 
++      0,   0,  10,   0,  16,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   6,  18,   0,  16,   0, 
++      0,   0,   0,   0,  26, 128, 
++     32,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   7,  34,  32,  16,   0, 
++      0,   0,   0,   0,  10,  48, 
++     32,   4,   0,   0,   0,   0, 
++     10,   0,  16,   0,   0,   0, 
++      0,   0,  54,   0,   0,   6, 
++     18,   0,  16,   0,   0,   0, 
++      0,   0,  42, 128,  32,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,  54,   0,   0,   7, 
++     66,  32,  16,   0,   0,   0, 
++      0,   0,  10,  48,  32,   4, 
++      0,   0,   0,   0,  10,   0, 
++     16,   0,   0,   0,   0,   0, 
++     54,   0,   0,   6,  18,   0, 
++     16,   0,   0,   0,   0,   0, 
++     58, 128,  32,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++     54,   0,   0,   7, 130,  32, 
++     16,   0,   0,   0,   0,   0, 
++     10,  48,  32,   4,   0,   0, 
++      0,   0,  10,   0,  16,   0, 
++      0,   0,   0,   0,  62,   0, 
++      0,   1,  83,  84,  65,  84, 
++    116,   0,   0,   0,  21,   0, 
++      0,   0,   1,   0,   0,   0, 
++      0,   0,   0,   0,   2,   0, 
++      0,   0,   1,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   6,   0,   0,   0, 
++     10,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   5,   0,   0,   0, 
++      0,   0,   0,   0,   2,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0
++};
+diff --git a/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/swizzlei3dps.h b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/swizzlei3dps.h
+new file mode 100644
+index 00000000..d93931b1
+--- /dev/null
++++ b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/swizzlei3dps.h
+@@ -0,0 +1,275 @@
++#if 0
++//
++// Generated by Microsoft (R) HLSL Shader Compiler 10.1
++//
++//
++// Buffer Definitions: 
++//
++// cbuffer SwizzleProperties
++// {
++//
++//   uint4 SwizzleIndices;              // Offset:    0 Size:    16
++//
++// }
++//
++//
++// Resource Bindings:
++//
++// Name                                 Type  Format         Dim      HLSL Bind  Count
++// ------------------------------ ---------- ------- ----------- -------------- ------
++// TextureI3D                        texture   sint4          3d             t0      1 
++// SwizzleProperties                 cbuffer      NA          NA            cb0      1 
++//
++//
++//
++// Input signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_POSITION              0   xyzw        0      POS   float       
++// SV_RENDERTARGETARRAYINDEX     0   x           1  RTINDEX    uint       
++// TEXCOORD                 0   xyz         2     NONE   float   xyz 
++//
++//
++// Output signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_TARGET                0   xyzw        0   TARGET     int   xyzw
++//
++ps_4_0
++dcl_constantbuffer CB0[1], immediateIndexed
++dcl_resource_texture3d (sint,sint,sint,sint) t0
++dcl_input_ps linear v2.xyz
++dcl_output o0.xyzw
++dcl_temps 1
++dcl_indexableTemp x0[6], 4
++resinfo_uint r0.xyzw, l(0), t0.xyzw
++utof r0.xyz, r0.xyzx
++mul r0.xyz, r0.xyzx, v2.xyzx
++ftoi r0.xyz, r0.xyzx
++mov r0.w, l(0)
++ld r0.xyzw, r0.xyzw, t0.xyzw
++mov x0[0].x, r0.x
++mov x0[1].x, r0.y
++mov x0[2].x, r0.z
++mov x0[3].x, r0.w
++mov x0[4].x, l(0)
++mov x0[5].x, l(1)
++mov r0.x, cb0[0].x
++mov o0.x, x0[r0.x + 0].x
++mov r0.x, cb0[0].y
++mov o0.y, x0[r0.x + 0].x
++mov r0.x, cb0[0].z
++mov o0.z, x0[r0.x + 0].x
++mov r0.x, cb0[0].w
++mov o0.w, x0[r0.x + 0].x
++ret 
++// Approximately 21 instruction slots used
++#endif
++
++const BYTE g_PS_SwizzleI3D[] =
++{
++     68,  88,  66,  67, 239, 203, 
++     72,  66,  58,  92, 169, 191, 
++    239,  77, 187,  21, 109, 161, 
++     64,  95,   1,   0,   0,   0, 
++    188,   4,   0,   0,   5,   0, 
++      0,   0,  52,   0,   0,   0, 
++     48,   1,   0,   0, 184,   1, 
++      0,   0, 236,   1,   0,   0, 
++     64,   4,   0,   0,  82,  68, 
++     69,  70, 244,   0,   0,   0, 
++      1,   0,   0,   0, 124,   0, 
++      0,   0,   2,   0,   0,   0, 
++     28,   0,   0,   0,   0,   4, 
++    255, 255,   0,   1,   0,   0, 
++    204,   0,   0,   0,  92,   0, 
++      0,   0,   2,   0,   0,   0, 
++      3,   0,   0,   0,   8,   0, 
++      0,   0, 255, 255, 255, 255, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,  13,   0,   0,   0, 
++    103,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0,   1,   0, 
++      0,   0,  84, 101, 120, 116, 
++    117, 114, 101,  73,  51,  68, 
++      0,  83, 119, 105, 122, 122, 
++    108, 101,  80, 114, 111, 112, 
++    101, 114, 116, 105, 101, 115, 
++      0, 171, 171, 171, 103,   0, 
++      0,   0,   1,   0,   0,   0, 
++    148,   0,   0,   0,  16,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0, 172,   0, 
++      0,   0,   0,   0,   0,   0, 
++     16,   0,   0,   0,   2,   0, 
++      0,   0, 188,   0,   0,   0, 
++      0,   0,   0,   0,  83, 119, 
++    105, 122, 122, 108, 101,  73, 
++    110, 100, 105,  99, 101, 115, 
++      0, 171,   1,   0,  19,   0, 
++      1,   0,   4,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++     77, 105,  99, 114, 111, 115, 
++    111, 102, 116,  32,  40,  82, 
++     41,  32,  72,  76,  83,  76, 
++     32,  83, 104,  97, 100, 101, 
++    114,  32,  67, 111, 109, 112, 
++    105, 108, 101, 114,  32,  49, 
++     48,  46,  49,   0,  73,  83, 
++     71,  78, 128,   0,   0,   0, 
++      3,   0,   0,   0,   8,   0, 
++      0,   0,  80,   0,   0,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,   3,   0,   0,   0, 
++      0,   0,   0,   0,  15,   0, 
++      0,   0,  92,   0,   0,   0, 
++      0,   0,   0,   0,   4,   0, 
++      0,   0,   1,   0,   0,   0, 
++      1,   0,   0,   0,   1,   0, 
++      0,   0, 118,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   3,   0,   0,   0, 
++      2,   0,   0,   0,   7,   7, 
++      0,   0,  83,  86,  95,  80, 
++     79,  83,  73,  84,  73,  79, 
++     78,   0,  83,  86,  95,  82, 
++     69,  78,  68,  69,  82,  84, 
++     65,  82,  71,  69,  84,  65, 
++     82,  82,  65,  89,  73,  78, 
++     68,  69,  88,   0,  84,  69, 
++     88,  67,  79,  79,  82,  68, 
++      0, 171,  79,  83,  71,  78, 
++     44,   0,   0,   0,   1,   0, 
++      0,   0,   8,   0,   0,   0, 
++     32,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      2,   0,   0,   0,   0,   0, 
++      0,   0,  15,   0,   0,   0, 
++     83,  86,  95,  84,  65,  82, 
++     71,  69,  84,   0, 171, 171, 
++     83,  72,  68,  82,  76,   2, 
++      0,   0,  64,   0,   0,   0, 
++    147,   0,   0,   0,  89,   0, 
++      0,   4,  70, 142,  32,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,  88,  40,   0,   4, 
++      0, 112,  16,   0,   0,   0, 
++      0,   0,  51,  51,   0,   0, 
++     98,  16,   0,   3, 114,  16, 
++     16,   0,   2,   0,   0,   0, 
++    101,   0,   0,   3, 242,  32, 
++     16,   0,   0,   0,   0,   0, 
++    104,   0,   0,   2,   1,   0, 
++      0,   0, 105,   0,   0,   4, 
++      0,   0,   0,   0,   6,   0, 
++      0,   0,   4,   0,   0,   0, 
++     61,  16,   0,   7, 242,   0, 
++     16,   0,   0,   0,   0,   0, 
++      1,  64,   0,   0,   0,   0, 
++      0,   0,  70, 126,  16,   0, 
++      0,   0,   0,   0,  86,   0, 
++      0,   5, 114,   0,  16,   0, 
++      0,   0,   0,   0,  70,   2, 
++     16,   0,   0,   0,   0,   0, 
++     56,   0,   0,   7, 114,   0, 
++     16,   0,   0,   0,   0,   0, 
++     70,   2,  16,   0,   0,   0, 
++      0,   0,  70,  18,  16,   0, 
++      2,   0,   0,   0,  27,   0, 
++      0,   5, 114,   0,  16,   0, 
++      0,   0,   0,   0,  70,   2, 
++     16,   0,   0,   0,   0,   0, 
++     54,   0,   0,   5, 130,   0, 
++     16,   0,   0,   0,   0,   0, 
++      1,  64,   0,   0,   0,   0, 
++      0,   0,  45,   0,   0,   7, 
++    242,   0,  16,   0,   0,   0, 
++      0,   0,  70,  14,  16,   0, 
++      0,   0,   0,   0,  70, 126, 
++     16,   0,   0,   0,   0,   0, 
++     54,   0,   0,   6,  18,  48, 
++     32,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,  10,   0, 
++     16,   0,   0,   0,   0,   0, 
++     54,   0,   0,   6,  18,  48, 
++     32,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0,  26,   0, 
++     16,   0,   0,   0,   0,   0, 
++     54,   0,   0,   6,  18,  48, 
++     32,   0,   0,   0,   0,   0, 
++      2,   0,   0,   0,  42,   0, 
++     16,   0,   0,   0,   0,   0, 
++     54,   0,   0,   6,  18,  48, 
++     32,   0,   0,   0,   0,   0, 
++      3,   0,   0,   0,  58,   0, 
++     16,   0,   0,   0,   0,   0, 
++     54,   0,   0,   6,  18,  48, 
++     32,   0,   0,   0,   0,   0, 
++      4,   0,   0,   0,   1,  64, 
++      0,   0,   0,   0,   0,   0, 
++     54,   0,   0,   6,  18,  48, 
++     32,   0,   0,   0,   0,   0, 
++      5,   0,   0,   0,   1,  64, 
++      0,   0,   1,   0,   0,   0, 
++     54,   0,   0,   6,  18,   0, 
++     16,   0,   0,   0,   0,   0, 
++     10, 128,  32,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++     54,   0,   0,   7,  18,  32, 
++     16,   0,   0,   0,   0,   0, 
++     10,  48,  32,   4,   0,   0, 
++      0,   0,  10,   0,  16,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   6,  18,   0,  16,   0, 
++      0,   0,   0,   0,  26, 128, 
++     32,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   7,  34,  32,  16,   0, 
++      0,   0,   0,   0,  10,  48, 
++     32,   4,   0,   0,   0,   0, 
++     10,   0,  16,   0,   0,   0, 
++      0,   0,  54,   0,   0,   6, 
++     18,   0,  16,   0,   0,   0, 
++      0,   0,  42, 128,  32,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,  54,   0,   0,   7, 
++     66,  32,  16,   0,   0,   0, 
++      0,   0,  10,  48,  32,   4, 
++      0,   0,   0,   0,  10,   0, 
++     16,   0,   0,   0,   0,   0, 
++     54,   0,   0,   6,  18,   0, 
++     16,   0,   0,   0,   0,   0, 
++     58, 128,  32,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++     54,   0,   0,   7, 130,  32, 
++     16,   0,   0,   0,   0,   0, 
++     10,  48,  32,   4,   0,   0, 
++      0,   0,  10,   0,  16,   0, 
++      0,   0,   0,   0,  62,   0, 
++      0,   1,  83,  84,  65,  84, 
++    116,   0,   0,   0,  21,   0, 
++      0,   0,   1,   0,   0,   0, 
++      0,   0,   0,   0,   2,   0, 
++      0,   0,   1,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   6,   0,   0,   0, 
++     10,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   5,   0,   0,   0, 
++      0,   0,   0,   0,   2,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0
++};
+diff --git a/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/swizzleui2darrayps.h b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/swizzleui2darrayps.h
+new file mode 100644
+index 00000000..ba4609dd
+--- /dev/null
++++ b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/swizzleui2darrayps.h
+@@ -0,0 +1,284 @@
++#if 0
++//
++// Generated by Microsoft (R) HLSL Shader Compiler 10.1
++//
++//
++// Buffer Definitions: 
++//
++// cbuffer SwizzleProperties
++// {
++//
++//   uint4 SwizzleIndices;              // Offset:    0 Size:    16
++//
++// }
++//
++//
++// Resource Bindings:
++//
++// Name                                 Type  Format         Dim      HLSL Bind  Count
++// ------------------------------ ---------- ------- ----------- -------------- ------
++// TextureUI2DArray                  texture   uint4     2darray             t0      1 
++// SwizzleProperties                 cbuffer      NA          NA            cb0      1 
++//
++//
++//
++// Input signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_POSITION              0   xyzw        0      POS   float       
++// SV_RENDERTARGETARRAYINDEX     0   x           1  RTINDEX    uint   x   
++// TEXCOORD                 0   xyz         2     NONE   float   xy  
++//
++//
++// Output signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_TARGET                0   xyzw        0   TARGET    uint   xyzw
++//
++ps_4_0
++dcl_constantbuffer CB0[1], immediateIndexed
++dcl_resource_texture2darray (uint,uint,uint,uint) t0
++dcl_input_ps_siv constant v1.x, rendertarget_array_index
++dcl_input_ps linear v2.xy
++dcl_output o0.xyzw
++dcl_temps 1
++dcl_indexableTemp x0[6], 4
++resinfo_uint r0.xyzw, l(0), t0.xyzw
++utof r0.xy, r0.xyxx
++mul r0.xy, r0.xyxx, v2.xyxx
++ftoi r0.xy, r0.xyxx
++mov r0.z, v1.x
++mov r0.w, l(0)
++ld r0.xyzw, r0.xyzw, t0.xyzw
++mov x0[0].x, r0.x
++mov x0[1].x, r0.y
++mov x0[2].x, r0.z
++mov x0[3].x, r0.w
++mov x0[4].x, l(0)
++mov x0[5].x, l(1)
++mov r0.x, cb0[0].x
++mov o0.x, x0[r0.x + 0].x
++mov r0.x, cb0[0].y
++mov o0.y, x0[r0.x + 0].x
++mov r0.x, cb0[0].z
++mov o0.z, x0[r0.x + 0].x
++mov r0.x, cb0[0].w
++mov o0.w, x0[r0.x + 0].x
++ret 
++// Approximately 22 instruction slots used
++#endif
++
++const BYTE g_PS_SwizzleUI2DArray[] =
++{
++     68,  88,  66,  67, 116, 247, 
++    215, 129,   4,  49,  47, 120, 
++    164,  87, 225, 112,  75,  76, 
++    233,  53,   1,   0,   0,   0, 
++    228,   4,   0,   0,   5,   0, 
++      0,   0,  52,   0,   0,   0, 
++     52,   1,   0,   0, 188,   1, 
++      0,   0, 240,   1,   0,   0, 
++    104,   4,   0,   0,  82,  68, 
++     69,  70, 248,   0,   0,   0, 
++      1,   0,   0,   0, 128,   0, 
++      0,   0,   2,   0,   0,   0, 
++     28,   0,   0,   0,   0,   4, 
++    255, 255,   0,   1,   0,   0, 
++    208,   0,   0,   0,  92,   0, 
++      0,   0,   2,   0,   0,   0, 
++      4,   0,   0,   0,   5,   0, 
++      0,   0, 255, 255, 255, 255, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,  13,   0,   0,   0, 
++    109,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0,   1,   0, 
++      0,   0,  84, 101, 120, 116, 
++    117, 114, 101,  85,  73,  50, 
++     68,  65, 114, 114,  97, 121, 
++      0,  83, 119, 105, 122, 122, 
++    108, 101,  80, 114, 111, 112, 
++    101, 114, 116, 105, 101, 115, 
++      0, 171, 109,   0,   0,   0, 
++      1,   0,   0,   0, 152,   0, 
++      0,   0,  16,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0, 176,   0,   0,   0, 
++      0,   0,   0,   0,  16,   0, 
++      0,   0,   2,   0,   0,   0, 
++    192,   0,   0,   0,   0,   0, 
++      0,   0,  83, 119, 105, 122, 
++    122, 108, 101,  73, 110, 100, 
++    105,  99, 101, 115,   0, 171, 
++      1,   0,  19,   0,   1,   0, 
++      4,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,  77, 105, 
++     99, 114, 111, 115, 111, 102, 
++    116,  32,  40,  82,  41,  32, 
++     72,  76,  83,  76,  32,  83, 
++    104,  97, 100, 101, 114,  32, 
++     67, 111, 109, 112, 105, 108, 
++    101, 114,  32,  49,  48,  46, 
++     49,   0,  73,  83,  71,  78, 
++    128,   0,   0,   0,   3,   0, 
++      0,   0,   8,   0,   0,   0, 
++     80,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++      3,   0,   0,   0,   0,   0, 
++      0,   0,  15,   0,   0,   0, 
++     92,   0,   0,   0,   0,   0, 
++      0,   0,   4,   0,   0,   0, 
++      1,   0,   0,   0,   1,   0, 
++      0,   0,   1,   1,   0,   0, 
++    118,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      3,   0,   0,   0,   2,   0, 
++      0,   0,   7,   3,   0,   0, 
++     83,  86,  95,  80,  79,  83, 
++     73,  84,  73,  79,  78,   0, 
++     83,  86,  95,  82,  69,  78, 
++     68,  69,  82,  84,  65,  82, 
++     71,  69,  84,  65,  82,  82, 
++     65,  89,  73,  78,  68,  69, 
++     88,   0,  84,  69,  88,  67, 
++     79,  79,  82,  68,   0, 171, 
++     79,  83,  71,  78,  44,   0, 
++      0,   0,   1,   0,   0,   0, 
++      8,   0,   0,   0,  32,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,   0,   0,   0,   0, 
++     15,   0,   0,   0,  83,  86, 
++     95,  84,  65,  82,  71,  69, 
++     84,   0, 171, 171,  83,  72, 
++     68,  82, 112,   2,   0,   0, 
++     64,   0,   0,   0, 156,   0, 
++      0,   0,  89,   0,   0,   4, 
++     70, 142,  32,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++     88,  64,   0,   4,   0, 112, 
++     16,   0,   0,   0,   0,   0, 
++     68,  68,   0,   0, 100,   8, 
++      0,   4,  18,  16,  16,   0, 
++      1,   0,   0,   0,   4,   0, 
++      0,   0,  98,  16,   0,   3, 
++     50,  16,  16,   0,   2,   0, 
++      0,   0, 101,   0,   0,   3, 
++    242,  32,  16,   0,   0,   0, 
++      0,   0, 104,   0,   0,   2, 
++      1,   0,   0,   0, 105,   0, 
++      0,   4,   0,   0,   0,   0, 
++      6,   0,   0,   0,   4,   0, 
++      0,   0,  61,  16,   0,   7, 
++    242,   0,  16,   0,   0,   0, 
++      0,   0,   1,  64,   0,   0, 
++      0,   0,   0,   0,  70, 126, 
++     16,   0,   0,   0,   0,   0, 
++     86,   0,   0,   5,  50,   0, 
++     16,   0,   0,   0,   0,   0, 
++     70,   0,  16,   0,   0,   0, 
++      0,   0,  56,   0,   0,   7, 
++     50,   0,  16,   0,   0,   0, 
++      0,   0,  70,   0,  16,   0, 
++      0,   0,   0,   0,  70,  16, 
++     16,   0,   2,   0,   0,   0, 
++     27,   0,   0,   5,  50,   0, 
++     16,   0,   0,   0,   0,   0, 
++     70,   0,  16,   0,   0,   0, 
++      0,   0,  54,   0,   0,   5, 
++     66,   0,  16,   0,   0,   0, 
++      0,   0,  10,  16,  16,   0, 
++      1,   0,   0,   0,  54,   0, 
++      0,   5, 130,   0,  16,   0, 
++      0,   0,   0,   0,   1,  64, 
++      0,   0,   0,   0,   0,   0, 
++     45,   0,   0,   7, 242,   0, 
++     16,   0,   0,   0,   0,   0, 
++     70,  14,  16,   0,   0,   0, 
++      0,   0,  70, 126,  16,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   6,  18,  48,  32,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,  10,   0,  16,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   6,  18,  48,  32,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,  26,   0,  16,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   6,  18,  48,  32,   0, 
++      0,   0,   0,   0,   2,   0, 
++      0,   0,  42,   0,  16,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   6,  18,  48,  32,   0, 
++      0,   0,   0,   0,   3,   0, 
++      0,   0,  58,   0,  16,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   6,  18,  48,  32,   0, 
++      0,   0,   0,   0,   4,   0, 
++      0,   0,   1,  64,   0,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   6,  18,  48,  32,   0, 
++      0,   0,   0,   0,   5,   0, 
++      0,   0,   1,  64,   0,   0, 
++      1,   0,   0,   0,  54,   0, 
++      0,   6,  18,   0,  16,   0, 
++      0,   0,   0,   0,  10, 128, 
++     32,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   7,  18,  32,  16,   0, 
++      0,   0,   0,   0,  10,  48, 
++     32,   4,   0,   0,   0,   0, 
++     10,   0,  16,   0,   0,   0, 
++      0,   0,  54,   0,   0,   6, 
++     18,   0,  16,   0,   0,   0, 
++      0,   0,  26, 128,  32,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,  54,   0,   0,   7, 
++     34,  32,  16,   0,   0,   0, 
++      0,   0,  10,  48,  32,   4, 
++      0,   0,   0,   0,  10,   0, 
++     16,   0,   0,   0,   0,   0, 
++     54,   0,   0,   6,  18,   0, 
++     16,   0,   0,   0,   0,   0, 
++     42, 128,  32,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++     54,   0,   0,   7,  66,  32, 
++     16,   0,   0,   0,   0,   0, 
++     10,  48,  32,   4,   0,   0, 
++      0,   0,  10,   0,  16,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   6,  18,   0,  16,   0, 
++      0,   0,   0,   0,  58, 128, 
++     32,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   7, 130,  32,  16,   0, 
++      0,   0,   0,   0,  10,  48, 
++     32,   4,   0,   0,   0,   0, 
++     10,   0,  16,   0,   0,   0, 
++      0,   0,  62,   0,   0,   1, 
++     83,  84,  65,  84, 116,   0, 
++      0,   0,  22,   0,   0,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0,   3,   0,   0,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      6,   0,   0,   0,  10,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      6,   0,   0,   0,   0,   0, 
++      0,   0,   2,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0
++};
+diff --git a/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/swizzleui2dps.h b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/swizzleui2dps.h
+new file mode 100644
+index 00000000..d226d2e0
+--- /dev/null
++++ b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/swizzleui2dps.h
+@@ -0,0 +1,268 @@
++#if 0
++//
++// Generated by Microsoft (R) HLSL Shader Compiler 10.1
++//
++//
++// Buffer Definitions: 
++//
++// cbuffer SwizzleProperties
++// {
++//
++//   uint4 SwizzleIndices;              // Offset:    0 Size:    16
++//
++// }
++//
++//
++// Resource Bindings:
++//
++// Name                                 Type  Format         Dim      HLSL Bind  Count
++// ------------------------------ ---------- ------- ----------- -------------- ------
++// TextureUI2D                       texture   uint4          2d             t0      1 
++// SwizzleProperties                 cbuffer      NA          NA            cb0      1 
++//
++//
++//
++// Input signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_POSITION              0   xyzw        0      POS   float       
++// TEXCOORD                 0   xy          1     NONE   float   xy  
++//
++//
++// Output signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_TARGET                0   xyzw        0   TARGET    uint   xyzw
++//
++ps_4_0
++dcl_constantbuffer CB0[1], immediateIndexed
++dcl_resource_texture2d (uint,uint,uint,uint) t0
++dcl_input_ps linear v1.xy
++dcl_output o0.xyzw
++dcl_temps 1
++dcl_indexableTemp x0[6], 4
++resinfo_uint r0.xyzw, l(0), t0.xyzw
++utof r0.xy, r0.xyxx
++mul r0.xy, r0.xyxx, v1.xyxx
++ftoi r0.xy, r0.xyxx
++mov r0.zw, l(0,0,0,0)
++ld r0.xyzw, r0.xyzw, t0.xyzw
++mov x0[0].x, r0.x
++mov x0[1].x, r0.y
++mov x0[2].x, r0.z
++mov x0[3].x, r0.w
++mov x0[4].x, l(0)
++mov x0[5].x, l(1)
++mov r0.x, cb0[0].x
++mov o0.x, x0[r0.x + 0].x
++mov r0.x, cb0[0].y
++mov o0.y, x0[r0.x + 0].x
++mov r0.x, cb0[0].z
++mov o0.z, x0[r0.x + 0].x
++mov r0.x, cb0[0].w
++mov o0.w, x0[r0.x + 0].x
++ret 
++// Approximately 21 instruction slots used
++#endif
++
++const BYTE g_PS_SwizzleUI2D[] =
++{
++     68,  88,  66,  67,   5, 230, 
++    100,  22, 104,  28, 143,  55, 
++     98, 102,  32, 210, 129,   6, 
++     68, 183,   1,   0,   0,   0, 
++    152,   4,   0,   0,   5,   0, 
++      0,   0,  52,   0,   0,   0, 
++     48,   1,   0,   0, 136,   1, 
++      0,   0, 188,   1,   0,   0, 
++     28,   4,   0,   0,  82,  68, 
++     69,  70, 244,   0,   0,   0, 
++      1,   0,   0,   0, 124,   0, 
++      0,   0,   2,   0,   0,   0, 
++     28,   0,   0,   0,   0,   4, 
++    255, 255,   0,   1,   0,   0, 
++    204,   0,   0,   0,  92,   0, 
++      0,   0,   2,   0,   0,   0, 
++      4,   0,   0,   0,   4,   0, 
++      0,   0, 255, 255, 255, 255, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,  13,   0,   0,   0, 
++    104,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0,   1,   0, 
++      0,   0,  84, 101, 120, 116, 
++    117, 114, 101,  85,  73,  50, 
++     68,   0,  83, 119, 105, 122, 
++    122, 108, 101,  80, 114, 111, 
++    112, 101, 114, 116, 105, 101, 
++    115,   0, 171, 171, 104,   0, 
++      0,   0,   1,   0,   0,   0, 
++    148,   0,   0,   0,  16,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0, 172,   0, 
++      0,   0,   0,   0,   0,   0, 
++     16,   0,   0,   0,   2,   0, 
++      0,   0, 188,   0,   0,   0, 
++      0,   0,   0,   0,  83, 119, 
++    105, 122, 122, 108, 101,  73, 
++    110, 100, 105,  99, 101, 115, 
++      0, 171,   1,   0,  19,   0, 
++      1,   0,   4,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++     77, 105,  99, 114, 111, 115, 
++    111, 102, 116,  32,  40,  82, 
++     41,  32,  72,  76,  83,  76, 
++     32,  83, 104,  97, 100, 101, 
++    114,  32,  67, 111, 109, 112, 
++    105, 108, 101, 114,  32,  49, 
++     48,  46,  49,   0,  73,  83, 
++     71,  78,  80,   0,   0,   0, 
++      2,   0,   0,   0,   8,   0, 
++      0,   0,  56,   0,   0,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,   3,   0,   0,   0, 
++      0,   0,   0,   0,  15,   0, 
++      0,   0,  68,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   3,   0,   0,   0, 
++      1,   0,   0,   0,   3,   3, 
++      0,   0,  83,  86,  95,  80, 
++     79,  83,  73,  84,  73,  79, 
++     78,   0,  84,  69,  88,  67, 
++     79,  79,  82,  68,   0, 171, 
++    171, 171,  79,  83,  71,  78, 
++     44,   0,   0,   0,   1,   0, 
++      0,   0,   8,   0,   0,   0, 
++     32,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0,  15,   0,   0,   0, 
++     83,  86,  95,  84,  65,  82, 
++     71,  69,  84,   0, 171, 171, 
++     83,  72,  68,  82,  88,   2, 
++      0,   0,  64,   0,   0,   0, 
++    150,   0,   0,   0,  89,   0, 
++      0,   4,  70, 142,  32,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,  88,  24,   0,   4, 
++      0, 112,  16,   0,   0,   0, 
++      0,   0,  68,  68,   0,   0, 
++     98,  16,   0,   3,  50,  16, 
++     16,   0,   1,   0,   0,   0, 
++    101,   0,   0,   3, 242,  32, 
++     16,   0,   0,   0,   0,   0, 
++    104,   0,   0,   2,   1,   0, 
++      0,   0, 105,   0,   0,   4, 
++      0,   0,   0,   0,   6,   0, 
++      0,   0,   4,   0,   0,   0, 
++     61,  16,   0,   7, 242,   0, 
++     16,   0,   0,   0,   0,   0, 
++      1,  64,   0,   0,   0,   0, 
++      0,   0,  70, 126,  16,   0, 
++      0,   0,   0,   0,  86,   0, 
++      0,   5,  50,   0,  16,   0, 
++      0,   0,   0,   0,  70,   0, 
++     16,   0,   0,   0,   0,   0, 
++     56,   0,   0,   7,  50,   0, 
++     16,   0,   0,   0,   0,   0, 
++     70,   0,  16,   0,   0,   0, 
++      0,   0,  70,  16,  16,   0, 
++      1,   0,   0,   0,  27,   0, 
++      0,   5,  50,   0,  16,   0, 
++      0,   0,   0,   0,  70,   0, 
++     16,   0,   0,   0,   0,   0, 
++     54,   0,   0,   8, 194,   0, 
++     16,   0,   0,   0,   0,   0, 
++      2,  64,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,  45,   0,   0,   7, 
++    242,   0,  16,   0,   0,   0, 
++      0,   0,  70,  14,  16,   0, 
++      0,   0,   0,   0,  70, 126, 
++     16,   0,   0,   0,   0,   0, 
++     54,   0,   0,   6,  18,  48, 
++     32,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,  10,   0, 
++     16,   0,   0,   0,   0,   0, 
++     54,   0,   0,   6,  18,  48, 
++     32,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0,  26,   0, 
++     16,   0,   0,   0,   0,   0, 
++     54,   0,   0,   6,  18,  48, 
++     32,   0,   0,   0,   0,   0, 
++      2,   0,   0,   0,  42,   0, 
++     16,   0,   0,   0,   0,   0, 
++     54,   0,   0,   6,  18,  48, 
++     32,   0,   0,   0,   0,   0, 
++      3,   0,   0,   0,  58,   0, 
++     16,   0,   0,   0,   0,   0, 
++     54,   0,   0,   6,  18,  48, 
++     32,   0,   0,   0,   0,   0, 
++      4,   0,   0,   0,   1,  64, 
++      0,   0,   0,   0,   0,   0, 
++     54,   0,   0,   6,  18,  48, 
++     32,   0,   0,   0,   0,   0, 
++      5,   0,   0,   0,   1,  64, 
++      0,   0,   1,   0,   0,   0, 
++     54,   0,   0,   6,  18,   0, 
++     16,   0,   0,   0,   0,   0, 
++     10, 128,  32,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++     54,   0,   0,   7,  18,  32, 
++     16,   0,   0,   0,   0,   0, 
++     10,  48,  32,   4,   0,   0, 
++      0,   0,  10,   0,  16,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   6,  18,   0,  16,   0, 
++      0,   0,   0,   0,  26, 128, 
++     32,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   7,  34,  32,  16,   0, 
++      0,   0,   0,   0,  10,  48, 
++     32,   4,   0,   0,   0,   0, 
++     10,   0,  16,   0,   0,   0, 
++      0,   0,  54,   0,   0,   6, 
++     18,   0,  16,   0,   0,   0, 
++      0,   0,  42, 128,  32,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,  54,   0,   0,   7, 
++     66,  32,  16,   0,   0,   0, 
++      0,   0,  10,  48,  32,   4, 
++      0,   0,   0,   0,  10,   0, 
++     16,   0,   0,   0,   0,   0, 
++     54,   0,   0,   6,  18,   0, 
++     16,   0,   0,   0,   0,   0, 
++     58, 128,  32,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++     54,   0,   0,   7, 130,  32, 
++     16,   0,   0,   0,   0,   0, 
++     10,  48,  32,   4,   0,   0, 
++      0,   0,  10,   0,  16,   0, 
++      0,   0,   0,   0,  62,   0, 
++      0,   1,  83,  84,  65,  84, 
++    116,   0,   0,   0,  21,   0, 
++      0,   0,   1,   0,   0,   0, 
++      0,   0,   0,   0,   2,   0, 
++      0,   0,   1,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   6,   0,   0,   0, 
++     10,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   5,   0,   0,   0, 
++      0,   0,   0,   0,   2,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0
++};
+diff --git a/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/swizzleui3dps.h b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/swizzleui3dps.h
+new file mode 100644
+index 00000000..b91c3553
+--- /dev/null
++++ b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d11/shaders/compiled/swizzleui3dps.h
+@@ -0,0 +1,275 @@
++#if 0
++//
++// Generated by Microsoft (R) HLSL Shader Compiler 10.1
++//
++//
++// Buffer Definitions: 
++//
++// cbuffer SwizzleProperties
++// {
++//
++//   uint4 SwizzleIndices;              // Offset:    0 Size:    16
++//
++// }
++//
++//
++// Resource Bindings:
++//
++// Name                                 Type  Format         Dim      HLSL Bind  Count
++// ------------------------------ ---------- ------- ----------- -------------- ------
++// TextureUI3D                       texture   uint4          3d             t0      1 
++// SwizzleProperties                 cbuffer      NA          NA            cb0      1 
++//
++//
++//
++// Input signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_POSITION              0   xyzw        0      POS   float       
++// SV_RENDERTARGETARRAYINDEX     0   x           1  RTINDEX    uint       
++// TEXCOORD                 0   xyz         2     NONE   float   xyz 
++//
++//
++// Output signature:
++//
++// Name                 Index   Mask Register SysValue  Format   Used
++// -------------------- ----- ------ -------- -------- ------- ------
++// SV_TARGET                0   xyzw        0   TARGET    uint   xyzw
++//
++ps_4_0
++dcl_constantbuffer CB0[1], immediateIndexed
++dcl_resource_texture3d (uint,uint,uint,uint) t0
++dcl_input_ps linear v2.xyz
++dcl_output o0.xyzw
++dcl_temps 1
++dcl_indexableTemp x0[6], 4
++resinfo_uint r0.xyzw, l(0), t0.xyzw
++utof r0.xyz, r0.xyzx
++mul r0.xyz, r0.xyzx, v2.xyzx
++ftoi r0.xyz, r0.xyzx
++mov r0.w, l(0)
++ld r0.xyzw, r0.xyzw, t0.xyzw
++mov x0[0].x, r0.x
++mov x0[1].x, r0.y
++mov x0[2].x, r0.z
++mov x0[3].x, r0.w
++mov x0[4].x, l(0)
++mov x0[5].x, l(1)
++mov r0.x, cb0[0].x
++mov o0.x, x0[r0.x + 0].x
++mov r0.x, cb0[0].y
++mov o0.y, x0[r0.x + 0].x
++mov r0.x, cb0[0].z
++mov o0.z, x0[r0.x + 0].x
++mov r0.x, cb0[0].w
++mov o0.w, x0[r0.x + 0].x
++ret 
++// Approximately 21 instruction slots used
++#endif
++
++const BYTE g_PS_SwizzleUI3D[] =
++{
++     68,  88,  66,  67, 234, 128, 
++    119, 252,  97, 217, 113, 192, 
++    202,  15,  92, 121, 106,  82, 
++     46, 102,   1,   0,   0,   0, 
++    188,   4,   0,   0,   5,   0, 
++      0,   0,  52,   0,   0,   0, 
++     48,   1,   0,   0, 184,   1, 
++      0,   0, 236,   1,   0,   0, 
++     64,   4,   0,   0,  82,  68, 
++     69,  70, 244,   0,   0,   0, 
++      1,   0,   0,   0, 124,   0, 
++      0,   0,   2,   0,   0,   0, 
++     28,   0,   0,   0,   0,   4, 
++    255, 255,   0,   1,   0,   0, 
++    204,   0,   0,   0,  92,   0, 
++      0,   0,   2,   0,   0,   0, 
++      4,   0,   0,   0,   8,   0, 
++      0,   0, 255, 255, 255, 255, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,  13,   0,   0,   0, 
++    104,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0,   1,   0, 
++      0,   0,  84, 101, 120, 116, 
++    117, 114, 101,  85,  73,  51, 
++     68,   0,  83, 119, 105, 122, 
++    122, 108, 101,  80, 114, 111, 
++    112, 101, 114, 116, 105, 101, 
++    115,   0, 171, 171, 104,   0, 
++      0,   0,   1,   0,   0,   0, 
++    148,   0,   0,   0,  16,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0, 172,   0, 
++      0,   0,   0,   0,   0,   0, 
++     16,   0,   0,   0,   2,   0, 
++      0,   0, 188,   0,   0,   0, 
++      0,   0,   0,   0,  83, 119, 
++    105, 122, 122, 108, 101,  73, 
++    110, 100, 105,  99, 101, 115, 
++      0, 171,   1,   0,  19,   0, 
++      1,   0,   4,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++     77, 105,  99, 114, 111, 115, 
++    111, 102, 116,  32,  40,  82, 
++     41,  32,  72,  76,  83,  76, 
++     32,  83, 104,  97, 100, 101, 
++    114,  32,  67, 111, 109, 112, 
++    105, 108, 101, 114,  32,  49, 
++     48,  46,  49,   0,  73,  83, 
++     71,  78, 128,   0,   0,   0, 
++      3,   0,   0,   0,   8,   0, 
++      0,   0,  80,   0,   0,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,   3,   0,   0,   0, 
++      0,   0,   0,   0,  15,   0, 
++      0,   0,  92,   0,   0,   0, 
++      0,   0,   0,   0,   4,   0, 
++      0,   0,   1,   0,   0,   0, 
++      1,   0,   0,   0,   1,   0, 
++      0,   0, 118,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   3,   0,   0,   0, 
++      2,   0,   0,   0,   7,   7, 
++      0,   0,  83,  86,  95,  80, 
++     79,  83,  73,  84,  73,  79, 
++     78,   0,  83,  86,  95,  82, 
++     69,  78,  68,  69,  82,  84, 
++     65,  82,  71,  69,  84,  65, 
++     82,  82,  65,  89,  73,  78, 
++     68,  69,  88,   0,  84,  69, 
++     88,  67,  79,  79,  82,  68, 
++      0, 171,  79,  83,  71,  78, 
++     44,   0,   0,   0,   1,   0, 
++      0,   0,   8,   0,   0,   0, 
++     32,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0,  15,   0,   0,   0, 
++     83,  86,  95,  84,  65,  82, 
++     71,  69,  84,   0, 171, 171, 
++     83,  72,  68,  82,  76,   2, 
++      0,   0,  64,   0,   0,   0, 
++    147,   0,   0,   0,  89,   0, 
++      0,   4,  70, 142,  32,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,  88,  40,   0,   4, 
++      0, 112,  16,   0,   0,   0, 
++      0,   0,  68,  68,   0,   0, 
++     98,  16,   0,   3, 114,  16, 
++     16,   0,   2,   0,   0,   0, 
++    101,   0,   0,   3, 242,  32, 
++     16,   0,   0,   0,   0,   0, 
++    104,   0,   0,   2,   1,   0, 
++      0,   0, 105,   0,   0,   4, 
++      0,   0,   0,   0,   6,   0, 
++      0,   0,   4,   0,   0,   0, 
++     61,  16,   0,   7, 242,   0, 
++     16,   0,   0,   0,   0,   0, 
++      1,  64,   0,   0,   0,   0, 
++      0,   0,  70, 126,  16,   0, 
++      0,   0,   0,   0,  86,   0, 
++      0,   5, 114,   0,  16,   0, 
++      0,   0,   0,   0,  70,   2, 
++     16,   0,   0,   0,   0,   0, 
++     56,   0,   0,   7, 114,   0, 
++     16,   0,   0,   0,   0,   0, 
++     70,   2,  16,   0,   0,   0, 
++      0,   0,  70,  18,  16,   0, 
++      2,   0,   0,   0,  27,   0, 
++      0,   5, 114,   0,  16,   0, 
++      0,   0,   0,   0,  70,   2, 
++     16,   0,   0,   0,   0,   0, 
++     54,   0,   0,   5, 130,   0, 
++     16,   0,   0,   0,   0,   0, 
++      1,  64,   0,   0,   0,   0, 
++      0,   0,  45,   0,   0,   7, 
++    242,   0,  16,   0,   0,   0, 
++      0,   0,  70,  14,  16,   0, 
++      0,   0,   0,   0,  70, 126, 
++     16,   0,   0,   0,   0,   0, 
++     54,   0,   0,   6,  18,  48, 
++     32,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,  10,   0, 
++     16,   0,   0,   0,   0,   0, 
++     54,   0,   0,   6,  18,  48, 
++     32,   0,   0,   0,   0,   0, 
++      1,   0,   0,   0,  26,   0, 
++     16,   0,   0,   0,   0,   0, 
++     54,   0,   0,   6,  18,  48, 
++     32,   0,   0,   0,   0,   0, 
++      2,   0,   0,   0,  42,   0, 
++     16,   0,   0,   0,   0,   0, 
++     54,   0,   0,   6,  18,  48, 
++     32,   0,   0,   0,   0,   0, 
++      3,   0,   0,   0,  58,   0, 
++     16,   0,   0,   0,   0,   0, 
++     54,   0,   0,   6,  18,  48, 
++     32,   0,   0,   0,   0,   0, 
++      4,   0,   0,   0,   1,  64, 
++      0,   0,   0,   0,   0,   0, 
++     54,   0,   0,   6,  18,  48, 
++     32,   0,   0,   0,   0,   0, 
++      5,   0,   0,   0,   1,  64, 
++      0,   0,   1,   0,   0,   0, 
++     54,   0,   0,   6,  18,   0, 
++     16,   0,   0,   0,   0,   0, 
++     10, 128,  32,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++     54,   0,   0,   7,  18,  32, 
++     16,   0,   0,   0,   0,   0, 
++     10,  48,  32,   4,   0,   0, 
++      0,   0,  10,   0,  16,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   6,  18,   0,  16,   0, 
++      0,   0,   0,   0,  26, 128, 
++     32,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,  54,   0, 
++      0,   7,  34,  32,  16,   0, 
++      0,   0,   0,   0,  10,  48, 
++     32,   4,   0,   0,   0,   0, 
++     10,   0,  16,   0,   0,   0, 
++      0,   0,  54,   0,   0,   6, 
++     18,   0,  16,   0,   0,   0, 
++      0,   0,  42, 128,  32,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,  54,   0,   0,   7, 
++     66,  32,  16,   0,   0,   0, 
++      0,   0,  10,  48,  32,   4, 
++      0,   0,   0,   0,  10,   0, 
++     16,   0,   0,   0,   0,   0, 
++     54,   0,   0,   6,  18,   0, 
++     16,   0,   0,   0,   0,   0, 
++     58, 128,  32,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++     54,   0,   0,   7, 130,  32, 
++     16,   0,   0,   0,   0,   0, 
++     10,  48,  32,   4,   0,   0, 
++      0,   0,  10,   0,  16,   0, 
++      0,   0,   0,   0,  62,   0, 
++      0,   1,  83,  84,  65,  84, 
++    116,   0,   0,   0,  21,   0, 
++      0,   0,   1,   0,   0,   0, 
++      0,   0,   0,   0,   2,   0, 
++      0,   0,   1,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   1,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   6,   0,   0,   0, 
++     10,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   1,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   5,   0,   0,   0, 
++      0,   0,   0,   0,   2,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,   0,   0,   0,   0
++};
+diff --git a/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d9/shaders/compiled/componentmaskps.h b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d9/shaders/compiled/componentmaskps.h
+new file mode 100644
+index 00000000..950f8dde
+--- /dev/null
++++ b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d9/shaders/compiled/componentmaskps.h
+@@ -0,0 +1,82 @@
++#if 0
++//
++// Generated by Microsoft (R) HLSL Shader Compiler 10.1
++//
++// Parameters:
++//
++//   float4 add;
++//   float4 mult;
++//   sampler2D tex;
++//
++//
++// Registers:
++//
++//   Name         Reg   Size
++//   ------------ ----- ----
++//   mult         c0       1
++//   add          c1       1
++//   tex          s0       1
++//
++
++    ps_2_0
++    dcl t0.xy
++    dcl_2d s0
++    texld r0, t0, s0
++    mov r1, c0
++    mad r0, r0, r1, c1
++    mov oC0, r0
++
++// approximately 4 instruction slots used (1 texture, 3 arithmetic)
++#endif
++
++const BYTE g_ps20_componentmaskps[] =
++{
++      0,   2, 255, 255, 254, 255, 
++     47,   0,  67,  84,  65,  66, 
++     28,   0,   0,   0, 143,   0, 
++      0,   0,   0,   2, 255, 255, 
++      3,   0,   0,   0,  28,   0, 
++      0,   0,   0,   1,   0,   0, 
++    136,   0,   0,   0,  88,   0, 
++      0,   0,   2,   0,   1,   0, 
++      1,   0,   0,   0,  92,   0, 
++      0,   0,   0,   0,   0,   0, 
++    108,   0,   0,   0,   2,   0, 
++      0,   0,   1,   0,   0,   0, 
++     92,   0,   0,   0,   0,   0, 
++      0,   0, 113,   0,   0,   0, 
++      3,   0,   0,   0,   1,   0, 
++      0,   0, 120,   0,   0,   0, 
++      0,   0,   0,   0,  97, 100, 
++    100,   0,   1,   0,   3,   0, 
++      1,   0,   4,   0,   1,   0, 
++      0,   0,   0,   0,   0,   0, 
++    109, 117, 108, 116,   0, 116, 
++    101, 120,   0, 171, 171, 171, 
++      4,   0,  12,   0,   1,   0, 
++      1,   0,   1,   0,   0,   0, 
++      0,   0,   0,   0, 112, 115, 
++     95,  50,  95,  48,   0,  77, 
++    105,  99, 114, 111, 115, 111, 
++    102, 116,  32,  40,  82,  41, 
++     32,  72,  76,  83,  76,  32, 
++     83, 104,  97, 100, 101, 114, 
++     32,  67, 111, 109, 112, 105, 
++    108, 101, 114,  32,  49,  48, 
++     46,  49,   0, 171,  31,   0, 
++      0,   2,   0,   0,   0, 128, 
++      0,   0,   3, 176,  31,   0, 
++      0,   2,   0,   0,   0, 144, 
++      0,   8,  15, 160,  66,   0, 
++      0,   3,   0,   0,  15, 128, 
++      0,   0, 228, 176,   0,   8, 
++    228, 160,   1,   0,   0,   2, 
++      1,   0,  15, 128,   0,   0, 
++    228, 160,   4,   0,   0,   4, 
++      0,   0,  15, 128,   0,   0, 
++    228, 128,   1,   0, 228, 128, 
++      1,   0, 228, 160,   1,   0, 
++      0,   2,   0,   8,  15, 128, 
++      0,   0, 228, 128, 255, 255, 
++      0,   0
++};
+diff --git a/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d9/shaders/compiled/flipyvs.h b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d9/shaders/compiled/flipyvs.h
+new file mode 100644
+index 00000000..3d8aa757
+--- /dev/null
++++ b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d9/shaders/compiled/flipyvs.h
+@@ -0,0 +1,64 @@
++#if 0
++//
++// Generated by Microsoft (R) HLSL Shader Compiler 10.1
++//
++// Parameters:
++//
++//   float4 halfPixelSize;
++//
++//
++// Registers:
++//
++//   Name          Reg   Size
++//   ------------- ----- ----
++//   halfPixelSize c0       1
++//
++
++    vs_2_0
++    def c1, 0.5, 1, 0, 0
++    dcl_position v0
++    add oPos, v0, c0
++    mad oT0, v0, c1.xxyy, c1.xxzz
++
++// approximately 2 instruction slots used
++#endif
++
++const BYTE g_vs20_flipyvs[] =
++{
++      0,   2, 254, 255, 254, 255, 
++     33,   0,  67,  84,  65,  66, 
++     28,   0,   0,   0,  87,   0, 
++      0,   0,   0,   2, 254, 255, 
++      1,   0,   0,   0,  28,   0, 
++      0,   0,   0,   1,   0,   0, 
++     80,   0,   0,   0,  48,   0, 
++      0,   0,   2,   0,   0,   0, 
++      1,   0,   0,   0,  64,   0, 
++      0,   0,   0,   0,   0,   0, 
++    104,  97, 108, 102,  80, 105, 
++    120, 101, 108,  83, 105, 122, 
++    101,   0, 171, 171,   1,   0, 
++      3,   0,   1,   0,   4,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0, 118, 115,  95,  50, 
++     95,  48,   0,  77, 105,  99, 
++    114, 111, 115, 111, 102, 116, 
++     32,  40,  82,  41,  32,  72, 
++     76,  83,  76,  32,  83, 104, 
++     97, 100, 101, 114,  32,  67, 
++    111, 109, 112, 105, 108, 101, 
++    114,  32,  49,  48,  46,  49, 
++      0, 171,  81,   0,   0,   5, 
++      1,   0,  15, 160,   0,   0, 
++      0,  63,   0,   0, 128,  63, 
++      0,   0,   0,   0,   0,   0, 
++      0,   0,  31,   0,   0,   2, 
++      0,   0,   0, 128,   0,   0, 
++     15, 144,   2,   0,   0,   3, 
++      0,   0,  15, 192,   0,   0, 
++    228, 144,   0,   0, 228, 160, 
++      4,   0,   0,   4,   0,   0, 
++     15, 224,   0,   0, 228, 144, 
++      1,   0,  80, 160,   1,   0, 
++    160, 160, 255, 255,   0,   0
++};
+diff --git a/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d9/shaders/compiled/luminanceps.h b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d9/shaders/compiled/luminanceps.h
+new file mode 100644
+index 00000000..be23224d
+--- /dev/null
++++ b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d9/shaders/compiled/luminanceps.h
+@@ -0,0 +1,92 @@
++#if 0
++//
++// Generated by Microsoft (R) HLSL Shader Compiler 10.1
++//
++// Parameters:
++//
++//   float4 add;
++//   float4 mult;
++//   sampler2D tex;
++//
++//
++// Registers:
++//
++//   Name         Reg   Size
++//   ------------ ----- ----
++//   mult         c0       1
++//   add          c1       1
++//   tex          s0       1
++//
++
++    ps_2_0
++    dcl t0.xy
++    dcl_2d s0
++    texld r0, t0, s0
++    mov r1.xw, c0
++    mad r0.x, r0.x, r1.x, c1.x
++    mad r0.y, r0.w, r1.w, c1.w
++    mov r1.xyz, r0.x
++    mov r1.w, r0.y
++    mov oC0, r1
++
++// approximately 7 instruction slots used (1 texture, 6 arithmetic)
++#endif
++
++const BYTE g_ps20_luminanceps[] =
++{
++      0,   2, 255, 255, 254, 255, 
++     47,   0,  67,  84,  65,  66, 
++     28,   0,   0,   0, 143,   0, 
++      0,   0,   0,   2, 255, 255, 
++      3,   0,   0,   0,  28,   0, 
++      0,   0,   0,   1,   0,   0, 
++    136,   0,   0,   0,  88,   0, 
++      0,   0,   2,   0,   1,   0, 
++      1,   0,   0,   0,  92,   0, 
++      0,   0,   0,   0,   0,   0, 
++    108,   0,   0,   0,   2,   0, 
++      0,   0,   1,   0,   0,   0, 
++     92,   0,   0,   0,   0,   0, 
++      0,   0, 113,   0,   0,   0, 
++      3,   0,   0,   0,   1,   0, 
++      0,   0, 120,   0,   0,   0, 
++      0,   0,   0,   0,  97, 100, 
++    100,   0,   1,   0,   3,   0, 
++      1,   0,   4,   0,   1,   0, 
++      0,   0,   0,   0,   0,   0, 
++    109, 117, 108, 116,   0, 116, 
++    101, 120,   0, 171, 171, 171, 
++      4,   0,  12,   0,   1,   0, 
++      1,   0,   1,   0,   0,   0, 
++      0,   0,   0,   0, 112, 115, 
++     95,  50,  95,  48,   0,  77, 
++    105,  99, 114, 111, 115, 111, 
++    102, 116,  32,  40,  82,  41, 
++     32,  72,  76,  83,  76,  32, 
++     83, 104,  97, 100, 101, 114, 
++     32,  67, 111, 109, 112, 105, 
++    108, 101, 114,  32,  49,  48, 
++     46,  49,   0, 171,  31,   0, 
++      0,   2,   0,   0,   0, 128, 
++      0,   0,   3, 176,  31,   0, 
++      0,   2,   0,   0,   0, 144, 
++      0,   8,  15, 160,  66,   0, 
++      0,   3,   0,   0,  15, 128, 
++      0,   0, 228, 176,   0,   8, 
++    228, 160,   1,   0,   0,   2, 
++      1,   0,   9, 128,   0,   0, 
++    228, 160,   4,   0,   0,   4, 
++      0,   0,   1, 128,   0,   0, 
++      0, 128,   1,   0,   0, 128, 
++      1,   0,   0, 160,   4,   0, 
++      0,   4,   0,   0,   2, 128, 
++      0,   0, 255, 128,   1,   0, 
++    255, 128,   1,   0, 255, 160, 
++      1,   0,   0,   2,   1,   0, 
++      7, 128,   0,   0,   0, 128, 
++      1,   0,   0,   2,   1,   0, 
++      8, 128,   0,   0,  85, 128, 
++      1,   0,   0,   2,   0,   8, 
++     15, 128,   1,   0, 228, 128, 
++    255, 255,   0,   0
++};
+diff --git a/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d9/shaders/compiled/passthroughps.h b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d9/shaders/compiled/passthroughps.h
+new file mode 100644
+index 00000000..45b3a8bb
+--- /dev/null
++++ b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d9/shaders/compiled/passthroughps.h
+@@ -0,0 +1,59 @@
++#if 0
++//
++// Generated by Microsoft (R) HLSL Shader Compiler 10.1
++//
++// Parameters:
++//
++//   sampler2D tex;
++//
++//
++// Registers:
++//
++//   Name         Reg   Size
++//   ------------ ----- ----
++//   tex          s0       1
++//
++
++    ps_2_0
++    dcl t0.xy
++    dcl_2d s0
++    texld r0, t0, s0
++    mov oC0, r0
++
++// approximately 2 instruction slots used (1 texture, 1 arithmetic)
++#endif
++
++const BYTE g_ps20_passthroughps[] =
++{
++      0,   2, 255, 255, 254, 255, 
++     30,   0,  67,  84,  65,  66, 
++     28,   0,   0,   0,  75,   0, 
++      0,   0,   0,   2, 255, 255, 
++      1,   0,   0,   0,  28,   0, 
++      0,   0,   0,   1,   0,   0, 
++     68,   0,   0,   0,  48,   0, 
++      0,   0,   3,   0,   0,   0, 
++      1,   0,   0,   0,  52,   0, 
++      0,   0,   0,   0,   0,   0, 
++    116, 101, 120,   0,   4,   0, 
++     12,   0,   1,   0,   1,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0, 112, 115,  95,  50, 
++     95,  48,   0,  77, 105,  99, 
++    114, 111, 115, 111, 102, 116, 
++     32,  40,  82,  41,  32,  72, 
++     76,  83,  76,  32,  83, 104, 
++     97, 100, 101, 114,  32,  67, 
++    111, 109, 112, 105, 108, 101, 
++    114,  32,  49,  48,  46,  49, 
++      0, 171,  31,   0,   0,   2, 
++      0,   0,   0, 128,   0,   0, 
++      3, 176,  31,   0,   0,   2, 
++      0,   0,   0, 144,   0,   8, 
++     15, 160,  66,   0,   0,   3, 
++      0,   0,  15, 128,   0,   0, 
++    228, 176,   0,   8, 228, 160, 
++      1,   0,   0,   2,   0,   8, 
++     15, 128,   0,   0, 228, 128, 
++    255, 255,   0,   0
++};
+diff --git a/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d9/shaders/compiled/standardvs.h b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d9/shaders/compiled/standardvs.h
+new file mode 100644
+index 00000000..9a29ab28
+--- /dev/null
++++ b/src/angle/src/QtANGLE/libANGLE/renderer/d3d/d3d9/shaders/compiled/standardvs.h
+@@ -0,0 +1,64 @@
++#if 0
++//
++// Generated by Microsoft (R) HLSL Shader Compiler 10.1
++//
++// Parameters:
++//
++//   float4 halfPixelSize;
++//
++//
++// Registers:
++//
++//   Name          Reg   Size
++//   ------------- ----- ----
++//   halfPixelSize c0       1
++//
++
++    vs_2_0
++    def c1, 0.5, -0.5, 1, 0
++    dcl_position v0
++    add oPos, v0, c0
++    mad oT0, v0, c1.xyzz, c1.xxww
++
++// approximately 2 instruction slots used
++#endif
++
++const BYTE g_vs20_standardvs[] =
++{
++      0,   2, 254, 255, 254, 255, 
++     33,   0,  67,  84,  65,  66, 
++     28,   0,   0,   0,  87,   0, 
++      0,   0,   0,   2, 254, 255, 
++      1,   0,   0,   0,  28,   0, 
++      0,   0,   0,   1,   0,   0, 
++     80,   0,   0,   0,  48,   0, 
++      0,   0,   2,   0,   0,   0, 
++      1,   0,   0,   0,  64,   0, 
++      0,   0,   0,   0,   0,   0, 
++    104,  97, 108, 102,  80, 105, 
++    120, 101, 108,  83, 105, 122, 
++    101,   0, 171, 171,   1,   0, 
++      3,   0,   1,   0,   4,   0, 
++      1,   0,   0,   0,   0,   0, 
++      0,   0, 118, 115,  95,  50, 
++     95,  48,   0,  77, 105,  99, 
++    114, 111, 115, 111, 102, 116, 
++     32,  40,  82,  41,  32,  72, 
++     76,  83,  76,  32,  83, 104, 
++     97, 100, 101, 114,  32,  67, 
++    111, 109, 112, 105, 108, 101, 
++    114,  32,  49,  48,  46,  49, 
++      0, 171,  81,   0,   0,   5, 
++      1,   0,  15, 160,   0,   0, 
++      0,  63,   0,   0,   0, 191, 
++      0,   0, 128,  63,   0,   0, 
++      0,   0,  31,   0,   0,   2, 
++      0,   0,   0, 128,   0,   0, 
++     15, 144,   2,   0,   0,   3, 
++      0,   0,  15, 192,   0,   0, 
++    228, 144,   0,   0, 228, 160, 
++      4,   0,   0,   4,   0,   0, 
++     15, 224,   0,   0, 228, 144, 
++      1,   0, 164, 160,   1,   0, 
++    240, 160, 255, 255,   0,   0
++};

--- a/src/qtbase.mk
+++ b/src/qtbase.mk
@@ -9,7 +9,7 @@ $(PKG)_CHECKSUM := fd5578cd320a13617c12cf2b19439386b203d6d45548e855f94e07be9829f
 $(PKG)_SUBDIR   := $(PKG)-everywhere-src-$($(PKG)_VERSION)
 $(PKG)_FILE     := $(PKG)-everywhere-src-$($(PKG)_VERSION).tar.xz
 $(PKG)_URL      := https://download.qt.io/official_releases/qt/5.10/$($(PKG)_VERSION)/submodules/$($(PKG)_FILE)
-$(PKG)_DEPS     := cc dbus fontconfig freetds freetype harfbuzz jpeg libmysqlclient libpng openssl pcre2 postgresql sqlite zlib
+$(PKG)_DEPS     := cc dbus fontconfig freetds freetype harfbuzz jpeg libmysqlclient libpng openssl pcre2 postgresql sqlite zlib mesa
 
 define $(PKG)_UPDATE
     $(WGET) -q -O- https://download.qt.io/official_releases/qt/5.8/ | \

--- a/src/qtbase.mk
+++ b/src/qtbase.mk
@@ -41,7 +41,8 @@ define $(PKG)_BUILD
             -static \
             -prefix '$(PREFIX)/$(TARGET)/qt5' \
             -no-icu \
-            -opengl desktop \
+            -opengl dynamic \
+            -angle \
             -no-glib \
             -accessibility \
             -nomake examples \

--- a/tools/generate-qt-angle-shaders.sh
+++ b/tools/generate-qt-angle-shaders.sh
@@ -1,0 +1,26 @@
+#! /bin/bash
+
+set -euo pipefail
+
+if [ "${FXC:-}" = "" ] || ! [ -f "$FXC" ]; then
+  echo "Specify path to fxc.exe in FXC variable. It is part of the directx SDK."
+  exit 1
+fi
+
+QT_SOURCE_PATH=$(echo ./gits/qtbase*)
+
+if ! [ -d "$QT_SOURCE_PATH" ]; then
+  echo "Can't find Qt source path. Run: make init-git-qtbase"
+  exit 1
+fi
+
+get_fxc_arguments() {
+  DXSDK_DIR=D qmake -o - | sed -n -e 's/^\s*"D.*fxc.exe"//p'
+}
+
+echo "Running fxc to generate the shaders"
+cd "${QT_SOURCE_PATH}/src/angle/src/QtANGLE"
+
+get_fxc_arguments | while read command; do
+  wine "$FXC" $command
+done


### PR DESCRIPTION
Hi,

As a hackathon project I have tried to crosscompile Qt with angle support.

The biggest disadventage I have stumbled across is that it seems to need fxc.exe from microsoft directx sdk (now windows sdk). This tool is used to generate some header files containing the compiled shaders as bytes. I did not found an opensource alternative (do you know any?), so I guess we could either
- run fxc.exe through wine... This has the disadventage that mxe users needs to install it manually, I guess it is not legal to redistribute it in tar.gz format...
- I thought it would be a better option to provide some simple script to generate the headers it would create, and add them as patch, so during the build no fxc.exe would be needed.

Additionally it seems to need opengl32.dll from mesa to work with software rasterizer, so I have added a target for that. It would be much better if it could use d3d, but that still needs some magic.

I have also changed "-opengl desktop" to "-opengl dynamic" which results in that it tries to run the opengl backend and if fails, tries the angle one, and finally falls back to software mode.

Do you think this could/should be part of mxe in some way? Any feedback is welcome, I am no expert on this.