### PR TITLE
Update source files fot qt5, and update qt4 overlays.

### DIFF
--- a/plugins/qt4/qt4-overlay.mk
+++ b/plugins/qt4/qt4-overlay.mk
@@ -9,3 +9,9 @@ $(PKG)_QT_VERSION := 4
 PKG               := qwt
 $(PKG)_DEPS       := cc qt
 $(PKG)_QT_DIR     := qt
+
+PKG               := poppler
+$(PKG)_DEPS       := $(filter-out qtbase ,$($(PKG)_DEPS)) qt
+
+PKG               := openscenegraph
+$(PKG)_DEPS       := $(filter-out qtbase ,$($(PKG)_DEPS)) qt

--- a/src/openscenegraph.mk
+++ b/src/openscenegraph.mk
@@ -12,7 +12,7 @@ $(PKG)_FILE     := OpenSceneGraph-$($(PKG)_VERSION).tar.gz
 $(PKG)_URL      := https://github.com/openscenegraph/OpenSceneGraph/archive/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc boost curl dcmtk freetype gdal giflib gstreamer \
                    gta jasper jpeg libpng openal openexr openthreads poppler \
-                   qt tiff zlib
+                   qtbase tiff zlib
 
 define $(PKG)_UPDATE
     $(WGET) -q -O- 'http://www.openscenegraph.org/index.php/download-section/stable-releases' | \


### PR DESCRIPTION
This patch makes openscenegraph build with qt5 (to match what some other libraries such as poppler are building with), and updates the qt4 overlay to include poppler and openscenegraph in that list. The qt5 build has been tested on the x86_64-w64-mingw32.static target.