### PR TITLE
sdl2: remove obsolete patch

### DIFF
--- a/src/sdl2-1-fixes.patch
+++ b/src/sdl2-1-fixes.patch
@@ -3,31 +3,9 @@ This file is part of MXE. See LICENSE.md for licensing information.
 Contains ad hoc patches for cross building.
 
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Robert Norris <rob@eatenbyagrue.org>
-Date: Sat, 28 Mar 2015 21:47:00 +0100
-Subject: [PATCH 1/4] disable DirectInput because of missing wbemcli.h
-
-This patch has been taken from:
-https://bugzilla.libsdl.org/show_bug.cgi?id=1739
-
-diff --git a/configure.in b/configure.in
-index 1111111..2222222 100644
---- a/configure.in
-+++ b/configure.in
-@@ -3020,7 +3020,7 @@ XINPUT_STATE_EX s1;
-         # FIXME: latest Cygwin finds dinput headers, but we die on other win32 headers.
-         # FIXME:  ...so force it off for now.
-         case "$host" in
--            *-*-cygwin*)
-+            *-*-cygwin* | *-pc-mingw32*)
-             have_dinput=false
-             ;;
-         esac
-
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tobias Gruetzmacher <tobias-git@23.gs>
 Date: Sat, 28 Mar 2015 21:47:32 +0100
-Subject: [PATCH 2/4] fix shared build, libtool
+Subject: [PATCH 1/3] fix shared build, libtool
 
 This patch is a combination of 2 patches from:
 https://bugzilla.libsdl.org/show_bug.cgi?id=1431
@@ -81,7 +59,7 @@ index 1111111..2222222 100644
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Charlemagne Lasse <charlemagnelasse@gmail.com>
 Date: Mon, 6 Nov 2017 11:04:46 +0100
-Subject: [PATCH 3/4] Revert "Don't use the system OpenGL headers, ever."
+Subject: [PATCH 2/3] Revert "Don't use the system OpenGL headers, ever."
 
 Bug-MXE: https://github.com/mxe/mxe/issues/1961
 Bug: https://bugzilla.libsdl.org/show_bug.cgi?id=3944
@@ -2283,7 +2261,7 @@ index 1111111..2222222 100644
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Andrei Alexeyev <0x416b617269@gmail.com>
 Date: Sat, 23 Dec 2017 03:38:56 +0200
-Subject: [PATCH 4/4] libsamplerate support for windows
+Subject: [PATCH 3/3] libsamplerate support for windows
 
 
 diff --git a/configure.in b/configure.in


### PR DESCRIPTION
The patch in question is supposed to disable dinput support, but in fact, it doesn't seem to do anything anymore. According to the logs, SDL2 successfully builds with dinput support, with or without the patch, and it works correctly too.