### PR TITLE
Fix poppler Qt5 bindings

### DIFF
--- a/src/poppler.mk
+++ b/src/poppler.mk
@@ -52,7 +52,7 @@ define $(PKG)_BUILD
         --disable-gtk-doc-pdf \
         --with-font-configuration=win32 \
         PKG_CONFIG_PATH_$(subst .,_,$(subst -,_,$(TARGET)))='$(PREFIX)/$(TARGET)/qt/lib/pkgconfig' \
-        CXXFLAGS=-D_WIN32_WINNT=0x0500 \
+        CXXFLAGS="-D_WIN32_WINNT=0x0500 -std=c++11" \
         LIBTIFF_LIBS="`'$(TARGET)-pkg-config' libtiff-4 --libs`"
     PATH='$(PREFIX)/$(TARGET)/$(if $(filter qtbase,$($(PKG)_DEPS)),qt5,qt)/bin:$(PATH)' \
         $(MAKE) -C '$(1)' -j '$(JOBS)' $(MXE_DISABLE_CRUFT) HTML_DIR=

--- a/src/poppler.mk
+++ b/src/poppler.mk
@@ -22,7 +22,7 @@ define $(PKG)_BUILD
     #       because libtiff is not found, but because some references are
     #       undefined)
     cd '$(1)' \
-        && PATH='$(PREFIX)/$(TARGET)/qt/bin:$(PATH)' \
+        && PATH='$(PREFIX)/$(TARGET)/$(if $(filter qtbase,$($(PKG)_DEPS)),qt5,qt)/bin:$(PATH)' \
         ./configure \
         $(MXE_CONFIGURE_OPTS) \
         --disable-silent-rules \
@@ -54,7 +54,7 @@ define $(PKG)_BUILD
         PKG_CONFIG_PATH_$(subst .,_,$(subst -,_,$(TARGET)))='$(PREFIX)/$(TARGET)/qt/lib/pkgconfig' \
         CXXFLAGS=-D_WIN32_WINNT=0x0500 \
         LIBTIFF_LIBS="`'$(TARGET)-pkg-config' libtiff-4 --libs`"
-    PATH='$(PREFIX)/$(TARGET)/qt/bin:$(PATH)' \
+    PATH='$(PREFIX)/$(TARGET)/$(if $(filter qtbase,$($(PKG)_DEPS)),qt5,qt)/bin:$(PATH)' \
         $(MAKE) -C '$(1)' -j '$(JOBS)' $(MXE_DISABLE_CRUFT) HTML_DIR=
     $(MAKE) -C '$(1)' -j 1 install $(MXE_DISABLE_CRUFT) HTML_DIR=
 


### PR DESCRIPTION
Make poppler's Qt5 bindings compile by adding the Qt5 tools to $PATH, and use C++11 since the Qt5 header files require it now.