### PR TITLE
Update build-pkg.lua dependencies

### DIFF
--- a/tools/build-pkg.lua
+++ b/tools/build-pkg.lua
@@ -6,7 +6,7 @@ This file is part of MXE. See LICENSE.md for licensing information.
 build-pkg, Build binary packages from MXE packages
 Instructions: http://pkg.mxe.cc
 
-Requirements: MXE, lua, fakeroot, dpkg-deb.
+Requirements: MXE, lua, fakeroot, dpkg-deb, dpkg-architecture.
 Usage: lua tools/build-pkg.lua
 Packages are written to `*.tar.xz` files.
 Debian packages are written to `*.deb` files.


### PR DESCRIPTION
build-pkg.lua uses `dpkg-architecture` to determine the architecture of a package in function `getArch`, however the program was not declared as dependency.

Fixes issue #2064
