### PR TITLE
hamlib activities moving from SF to github

### DIFF
--- a/src/hamlib.mk
+++ b/src/hamlib.mk
@@ -10,22 +10,22 @@ $(PKG)_VERSION  := 3.1
 $(PKG)_CHECKSUM := 682304c3e88ff6ccfd6a5fc28b33bcc95d2d0a54321973fef015ff62570c994e
 $(PKG)_SUBDIR   := hamlib-$($(PKG)_VERSION)
 $(PKG)_FILE     := Hamlib-$($(PKG)_VERSION).tar.gz
-$(PKG)_URL      := https://$(SOURCEFORGE_MIRROR)/project/hamlib/hamlib/$($(PKG)_VERSION)/hamlib-$($(PKG)_VERSION).tar.gz
-$(PKG)_URL_2    := https://github.com/N0NB/$(PKG)/archive/$($(PKG)_VERSION).tar.gz
+$(PKG)_URL      := https://github.com/hamlib/$(PKG)/archive/$($(PKG)_VERSION).tar.gz
+$(PKG)_URL_2    := https://$(SOURCEFORGE_MIRROR)/project/hamlib/hamlib/$($(PKG)_VERSION)/hamlib-$($(PKG)_VERSION).tar.gz
 $(PKG)_DEPS     := cc libltdl libusb1 libxml2 pthreads
 
-# grabbing version from sourceforge
-# preferred by Nate N0NB
-define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://sourceforge.net/projects/hamlib/files/hamlib/' | \
-    $(SED) -n 's,.*/\([0-9][^"]*\)/".*,\1,p' | \
-    head -1
-endef
-
-## grabbing version from github via MXE
+## grabbing version from sourceforge
 #define $(PKG)_UPDATE
-#    $(call MXE_GET_GITHUB_TAGS, N0NB/hamlib)
+#    $(WGET) -q -O- 'https://sourceforge.net/projects/hamlib/files/hamlib/' | \
+#    $(SED) -n 's,.*/\([0-9][^"]*\)/".*,\1,p' | \
+#    head -1
 #endef
+
+# grabbing version from github via MXE
+# main activity on github since Feb/March 2018
+define $(PKG)_UPDATE
+    $(call MXE_GET_GITHUB_TAGS, hamlib/hamlib)
+endef
 
 define $(PKG)_BUILD
     cd '$(BUILD_DIR)' && '$(SOURCE_DIR)/configure' \


### PR DESCRIPTION
Dear all,

Nate announced that hamlib activities are moving from SF to github (mostly due to recent downtimes).
Here is the updated hamlib.mk file, tested on ubuntu and debian.

Best,
   Lars