### PR TITLE
Fix OGG not working in SDL_mixer 1.2.12

### DIFF
--- a/src/sdl_mixer-2-fix-static-ogg-detection.patch
+++ b/src/sdl_mixer-2-fix-static-ogg-detection.patch
@@ -1,0 +1,55 @@
+This file is part of MXE. See LICENSE.md for licensing information.
+
+This patch has been taken from: https://hg.libsdl.org/SDL_mixer/rev/0aadc9b6daac
+
+Gabriel Jacobo 2012-09-20 16:01:32 PDT
+
+When --disable-music-ogg-shared the OGG tests fail when they should pass.
+Attached is a crude patch that gets them working (though the changes done to
+configure.in, inside AC_CHECK_LIB, will produce ugly status string such as
+"checking for ov_open_callbacks in -lvorbisidec -logg", which is mostly a
+aesthetic concern)
+
+Upstream bug: https://bugzilla.libsdl.org/show_bug.cgi?id=1604
+
+--- a/configure
++++ b/configure
+@@ -13339,7 +13339,7 @@
+   echo $ECHO_N "(cached) $ECHO_C" >&6
+ else
+   ac_check_lib_save_LIBS=$LIBS
+-LIBS="-lvorbisidec  $LIBS"
++LIBS="-lvorbisidec -logg $LIBS"
+ cat >conftest.$ac_ext <<_ACEOF
+ /* confdefs.h.  */
+ _ACEOF
+@@ -13570,7 +13570,7 @@
+   echo $ECHO_N "(cached) $ECHO_C" >&6
+ else
+   ac_check_lib_save_LIBS=$LIBS
+-LIBS="-lvorbisfile  $LIBS"
++LIBS="-lvorbisfile -lvorbis -logg -lm $LIBS"
+ cat >conftest.$ac_ext <<_ACEOF
+ /* confdefs.h.  */
+ _ACEOF
+
+--- a/configure.in
++++ b/configure.in
+@@ -429,7 +429,7 @@
+ if test x$enable_music_ogg = xyes; then
+     if test x$enable_music_ogg_tremor = xyes; then
+         AC_CHECK_HEADER([tremor/ivorbisfile.h], [have_tremor_hdr=yes])
+-        AC_CHECK_LIB([vorbisidec], [ov_open_callbacks], [have_tremor_lib=yes])
++        AC_CHECK_LIB([vorbisidec], [ov_open_callbacks], [have_tremor_lib=yes], [-logg])
+         if test x$have_tremor_hdr = xyes -a x$have_tremor_lib = xyes; then
+             case "$host" in
+                 *-*-darwin*)
+@@ -465,7 +465,7 @@
+         fi
+     else
+         AC_CHECK_HEADER([vorbis/vorbisfile.h], [have_ogg_hdr=yes])
+-        AC_CHECK_LIB([vorbisfile], [ov_open_callbacks], [have_ogg_lib=yes])
++        AC_CHECK_LIB([vorbisfile], [ov_open_callbacks], [have_ogg_lib=yes], [-lvorbis -logg -lm])
+         if test x$have_ogg_hdr = xyes -a x$have_ogg_lib = xyes; then
+             case "$host" in
+                 *-*-darwin*)


### PR DESCRIPTION
Due to a autoconf error, SDL_mixer 1.2.12 does not correctly detect the OGG Vorbis library when using BUILD_STATIC. This was probably missed because normally SDL_Mixer is built using shared libraries instead, and wasn't fixed until SDL_mixer 2.0.

However, since static building is the default for mxe, I thought it was important to carry this configuration fix over to the old version.