### PR TITLE
libdvdread: force absolute path to accomplish library build

### DIFF
--- a/src/libdvdread.mk
+++ b/src/libdvdread.mk
@@ -22,6 +22,8 @@ define $(PKG)_UPDATE
 endef
 
 define $(PKG)_BUILD
+    # sed modification to force absolute path to the file
+    $(SED) -i "s~../msvc~$(SOURCE_DIR)/msvc/msvc~g" $(SOURCE_DIR)/src/dvd_input.c
     # build and install the library
     cd '$(BUILD_DIR)' && $(SOURCE_DIR)/configure \
         $(MXE_CONFIGURE_OPTS)


### PR DESCRIPTION
```
$ ~/MPVCROSS/mxe-trunk/tmp-libdvdread-x86_64-w64-mingw32.static/libdvdread-6.0.0/src/dvd_input.c:56:133: 
fatal error: /home/user/MPVCROSS/mxe-trunk/tmp-libdvdread-x86_64-w64-mingw32.static/libdvdread-6.0.0/msvc/contrib/dlfcn.c: No such file or directory
compilation terminated.
```
The import  path needs to be forced otherwise the library won't build. This prevents the build of libdvdnav as well.
