### PR TITLE
add package xmlsec

### DIFF
--- a/src/xmlsec.mk
+++ b/src/xmlsec.mk
@@ -1,0 +1,22 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+PKG             := xmlsec
+$(PKG)_WEBSITE  := https://www.aleksey.com/xmlsec/
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 1.2.25
+$(PKG)_CHECKSUM := 5a2d400043ac5b2aa84b66b6b000704f0f147077afc6546d73181f5c71019985
+$(PKG)_GH_CONF  := lsh123/xmlsec/tags,xmlsec-,,,_
+$(PKG)_DEPS     := cc libltdl libxml2 libxslt openssl gnutls
+
+define $(PKG)_BUILD
+    cd '$(SOURCE_DIR)' && autoreconf -fi
+    cd '$(BUILD_DIR)' && $(SOURCE_DIR)/configure \
+        $(MXE_CONFIGURE_OPTS) \
+        --enable-docs=no \
+        --enable-apps=no \
+        --enable-shared=$(if $(BUILD_STATIC),no,yes) \
+        --enable-static=$(if $(BUILD_STATIC),yes,no)
+
+    $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)' VERBOSE=1 $(MXE_DISABLE_CRUFT)
+    $(MAKE) -C '$(BUILD_DIR)' -j 1 install VERBOSE=1 $(MXE_DISABLE_CRUFT)
+endef


### PR DESCRIPTION
A small lib implementing XML signing based on W3C Standard: XMLDSIG using libxml2 and changeable encyrption backends. We needed it for one of our projects and i thought it might be a good addition to mxe for others to use.

See:
-https://www.aleksey.com/xmlsec/
-https://www.w3.org/TR/xmldsig-core/
-https://github.com/Alexpux/MINGW-packages/blob/master/mingw-w64-xmlsec/PKGBUILD

I tested with i686, x64, shared and static.