### PR TITLE
Fix -flto linking errors 

### DIFF
--- a/plugins/meson-wrapper/conf/mxe-crossfile.meson.in
+++ b/plugins/meson-wrapper/conf/mxe-crossfile.meson.in
@@ -3,8 +3,9 @@
 [binaries]
 c = '@PREFIX@/bin/@TARGET@-gcc'
 cpp = '@PREFIX@/bin/@TARGET@-g++'
-ar = '@PREFIX@/bin/@TARGET@-ar'
-ranlib = '@PREFIX@/bin/@TARGET@-ranlib'
+ar = '@PREFIX@/bin/@TARGET@-gcc-ar'
+nm = '@PREFIX@/bin/@TARGET@-gcc-nm'
+ranlib = '@PREFIX@/bin/@TARGET@-gcc-ranlib'
 ld = '@PREFIX@/bin/@TARGET@-ld'
 strip = '@PREFIX@/bin/@TARGET@-strip'
 windres = '@PREFIX@/bin/@TARGET@-windres'

--- a/src/binutils.mk
+++ b/src/binutils.mk
@@ -26,6 +26,7 @@ define $(PKG)_BUILD
         --prefix='$(PREFIX)' \
         --disable-multilib \
         --enable-deterministic-archives \
+        --enable-lto \
         --with-gcc \
         --with-gnu-ld \
         --with-gnu-as \

--- a/src/cmake/conf/mxe-conf.cmake.in
+++ b/src/cmake/conf/mxe-conf.cmake.in
@@ -55,6 +55,8 @@ set(CMAKE_C_COMPILER @PREFIX@/bin/@TARGET@-gcc)
 set(CMAKE_CXX_COMPILER @PREFIX@/bin/@TARGET@-g++)
 set(CMAKE_Fortran_COMPILER @PREFIX@/bin/@TARGET@-gfortran)
 set(CMAKE_RC_COMPILER @PREFIX@/bin/@TARGET@-windres)
+set(CMAKE_AR @PREFIX@/bin/@TARGET@-gcc-ar)
+set(CMAKE_RANLIB @PREFIX@/bin/@TARGET@-gcc-ranlib)
 # CMAKE_RC_COMPILE_OBJECT is defined in:
 #     <cmake root>/share/cmake-X.Y/Modules/Platform/Windows-windres.cmake
 set(CPACK_NSIS_EXECUTABLE @TARGET@-makensis)

--- a/src/cmake/conf/mxe-conf.cmake.in
+++ b/src/cmake/conf/mxe-conf.cmake.in
@@ -55,8 +55,12 @@ set(CMAKE_C_COMPILER @PREFIX@/bin/@TARGET@-gcc)
 set(CMAKE_CXX_COMPILER @PREFIX@/bin/@TARGET@-g++)
 set(CMAKE_Fortran_COMPILER @PREFIX@/bin/@TARGET@-gfortran)
 set(CMAKE_RC_COMPILER @PREFIX@/bin/@TARGET@-windres)
-set(CMAKE_AR @PREFIX@/bin/@TARGET@-gcc-ar)
-set(CMAKE_RANLIB @PREFIX@/bin/@TARGET@-gcc-ranlib)
+
+# These must be CACHED, otherwise C++ projects fail to configure for some reason.
+# https://stackoverflow.com/questions/43751132/cmake-3-8-0-generates-wrong-link-command-in-makefiles/43777707#43777707
+set(CMAKE_AR @PREFIX@/bin/@TARGET@-gcc-ar CACHE FILEPATH "ar" FORCE)
+set(CMAKE_RANLIB @PREFIX@/bin/@TARGET@-gcc-ranlib CACHE FILEPATH "ranlib" FORCE)
+
 # CMAKE_RC_COMPILE_OBJECT is defined in:
 #     <cmake root>/share/cmake-X.Y/Modules/Platform/Windows-windres.cmake
 set(CPACK_NSIS_EXECUTABLE @TARGET@-makensis)

--- a/src/gcc.mk
+++ b/src/gcc.mk
@@ -31,6 +31,7 @@ define $(PKG)_CONFIGURE
         --with-sysroot='$(PREFIX)/$(TARGET)' \
         --enable-languages='c,c++,objc,fortran' \
         --enable-version-specific-runtime-libs \
+        --enable-lto \
         --with-gcc \
         --with-gnu-ld \
         --with-gnu-as \


### PR DESCRIPTION
Without this, at very least static libraries that have objects compiled with `-flto` will not build correctly, and will fail to link. [Here's an example log.](https://0x0.st/suTf.txt) Snippet of particular interest:
```
/data/git/mxe/usr/bin/x86_64-w64-mingw32.static-ar: subprojects/cglm/cglm@@cglm@sta/src_affine.c.obj: plugin needed to handle lto object
/data/git/mxe/usr/bin/x86_64-w64-mingw32.static-ar: subprojects/cglm/cglm@@cglm@sta/src_box.c.obj: plugin needed to handle lto object
/data/git/mxe/usr/bin/x86_64-w64-mingw32.static-ar: subprojects/cglm/cglm@@cglm@sta/src_cam.c.obj: plugin needed to handle lto object
/data/git/mxe/usr/bin/x86_64-w64-mingw32.static-ar: subprojects/cglm/cglm@@cglm@sta/src_euler.c.obj: plugin needed to handle lto object
/data/git/mxe/usr/bin/x86_64-w64-mingw32.static-ar: subprojects/cglm/cglm@@cglm@sta/src_frustum.c.obj: plugin needed to handle lto object
/data/git/mxe/usr/bin/x86_64-w64-mingw32.static-ar: subprojects/cglm/cglm@@cglm@sta/src_io.c.obj: plugin needed to handle lto object
/data/git/mxe/usr/bin/x86_64-w64-mingw32.static-ar: subprojects/cglm/cglm@@cglm@sta/src_mat3.c.obj: plugin needed to handle lto object
/data/git/mxe/usr/bin/x86_64-w64-mingw32.static-ar: subprojects/cglm/cglm@@cglm@sta/src_mat4.c.obj: plugin needed to handle lto object
/data/git/mxe/usr/bin/x86_64-w64-mingw32.static-ar: subprojects/cglm/cglm@@cglm@sta/src_plane.c.obj: plugin needed to handle lto object
/data/git/mxe/usr/bin/x86_64-w64-mingw32.static-ar: subprojects/cglm/cglm@@cglm@sta/src_quat.c.obj: plugin needed to handle lto object
/data/git/mxe/usr/bin/x86_64-w64-mingw32.static-ar: subprojects/cglm/cglm@@cglm@sta/src_vec3.c.obj: plugin needed to handle lto object
/data/git/mxe/usr/bin/x86_64-w64-mingw32.static-ar: subprojects/cglm/cglm@@cglm@sta/src_vec4.c.obj: plugin needed to handle lto object
/data/git/mxe/usr/bin/x86_64-w64-mingw32.static-ar: subprojects/cglm/cglm@@cglm@sta/src_dllmain.c.obj: plugin needed to handle lto object
```

I've updated the Meson and CMake toolchain configs. Not sure how to integrate this with other build systems properly, or if it's even needed. Ideally, the `$target-ar` tool and friends should be LTO-aware by default, but I've failed to achieve that so far. Manually setting `AR=$mxe_prefix/bin/$target-gcc-ar`, etc. should suffice as a workaround for now.