### PR TITLE
added package for Qt networkauth module

### DIFF
--- a/src/qtnetworkauth.mk
+++ b/src/qtnetworkauth.mk
@@ -1,0 +1,22 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+PKG             := qtnetworkauth
+$(PKG)_WEBSITE  := https://www.qt.io/
+$(PKG)_DESCR    := Qt
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION   = $(qtbase_VERSION)
+$(PKG)_CHECKSUM := 97231c319bd623d81eebaa1b5cdba4064bc4e69332c695a15cf8792b54b5dcdc
+$(PKG)_SUBDIR    = $(subst qtbase,qtnetworkauth,$(qtbase_SUBDIR))
+$(PKG)_FILE      = $(subst qtbase,qtnetworkauth,$(qtbase_FILE))
+$(PKG)_URL       = $(subst qtbase,qtnetworkauth,$(qtbase_URL))
+$(PKG)_DEPS     := cc qtbase
+
+define $(PKG)_UPDATE
+    echo $(qtbase_VERSION)
+endef
+
+define $(PKG)_BUILD
+    cd '$(1)' && '$(PREFIX)/$(TARGET)/qt5/bin/qmake'
+    $(MAKE) -C '$(1)' -j '$(JOBS)'
+    $(MAKE) -C '$(1)' -j 1 install
+endef


### PR DESCRIPTION
I followed the qwebsockets module closely, so this package should conform to all existing standards. It has also been tested to build against our software and is a simple extension to include the networkauth Qt package that is fairly new-ish as it's existed since Qt 5.8.
