### PR TITLE
openjpeg: explicitly enable pkg-config files

### DIFF
--- a/src/openjpeg.mk
+++ b/src/openjpeg.mk
@@ -13,7 +13,8 @@ $(PKG)_DEPS     := cc lcms libpng tiff zlib
 define $(PKG)_BUILD
     # build and install the library
     cd '$(BUILD_DIR)' && $(TARGET)-cmake '$(SOURCE_DIR)' \
-        -DBUILD_TESTING=FALSE
+        -DBUILD_PKGCONFIG_FILES=ON \
+        -DBUILD_TESTING=OFF
     $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)'
     $(MAKE) -C '$(BUILD_DIR)' -j 1 install
 endef


### PR DESCRIPTION
Running the native cmake automatically enables `BUILD_PKGCONFIG_FILES` but the cross-toolchain wrapper disables it.
Related to https://github.com/mxe/mxe/issues/1446