### PR TITLE
quazip: upgrade to 0.7.5 and to the new Github upstream

### DIFF
--- a/src/quazip-1-fixes.patch
+++ b/src/quazip-1-fixes.patch
@@ -1,75 +1,16 @@
-This file is part of MXE. See LICENSE.md for licensing information.
-
-Contains ad hoc patches for cross building.
-
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From 619a1ce43e43aafd0922a03d6778662927c54643 Mon Sep 17 00:00:00 2001
 From: Zoltan Gyarmati <mr.zoltan.gyarmati@gmail.com>
-Date: Sun, 4 Jun 2017 03:19:59 +0200
-Subject: [PATCH 1/3] add pkg-config generation to qmake build
-
-Sent to upstream: https://sourceforge.net/p/quazip/patches/31/
+Date: Sun, 20 May 2018 11:44:59 +0200
+Subject: [PATCH] explictly link to zlib
 
 Signed-off-by: Zoltan Gyarmati <mr.zoltan.gyarmati@gmail.com>
+---
+ quazip/quazip.pro | 2 ++
+ qztest/qztest.pro | 4 ++--
+ 2 files changed, 4 insertions(+), 2 deletions(-)
 
 diff --git a/quazip/quazip.pro b/quazip/quazip.pro
-index 1111111..2222222 100644
---- a/quazip/quazip.pro
-+++ b/quazip/quazip.pro
-@@ -2,6 +2,13 @@ TEMPLATE = lib
- CONFIG += qt warn_on
- QT -= gui
- 
-+# Creating pkgconfig .pc file
-+CONFIG += create_prl no_install_prl create_pc
-+
-+QMAKE_PKGCONFIG_PREFIX = $$PREFIX
-+QMAKE_PKGCONFIG_INCDIR = $$headers.path
-+QMAKE_PKGCONFIG_REQUIRES = Qt5Core
-+
- # The ABI version.
- 
- !win32:VERSION = 1.0.0
-@@ -43,6 +50,7 @@ unix:!symbian {
-     headers.path=$$PREFIX/include/quazip
-     headers.files=$$HEADERS
-     target.path=$$PREFIX/lib/$${LIB_ARCH}
-+    QMAKE_PKGCONFIG_DESTDIR = pkgconfig
-     INSTALLS += headers target
- 
- 	OBJECTS_DIR=.obj
-@@ -53,8 +61,21 @@ unix:!symbian {
- win32 {
-     headers.path=$$PREFIX/include/quazip
-     headers.files=$$HEADERS
--    target.path=$$PREFIX/lib
-     INSTALLS += headers target
-+    CONFIG(staticlib){
-+        target.path=$$PREFIX/lib
-+        QMAKE_PKGCONFIG_LIBDIR = $$PREFIX/lib/
-+    } else {
-+        target.path=$$PREFIX/bin
-+        QMAKE_PKGCONFIG_LIBDIR = $$PREFIX/bin/
-+    }
-+
-+    ## odd, this path seems to be relative to the
-+    ## target.path, so if we install the .dll into
-+    ## the 'bin' dir, the .pc will go there as well,
-+    ## unless have hack the needed path...
-+    ## TODO any nicer solution?
-+    QMAKE_PKGCONFIG_DESTDIR = ../lib/pkgconfig
-     # workaround for qdatetime.h macro bug
-     DEFINES += NOMINMAX
- }
-
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Zoltan Gyarmati <mr.zoltan.gyarmati@gmail.com>
-Date: Sun, 4 Jun 2017 03:22:13 +0200
-Subject: [PATCH 2/3] add -lz dir for win build
-
-Signed-off-by: Zoltan Gyarmati <mr.zoltan.gyarmati@gmail.com>
-
-diff --git a/quazip/quazip.pro b/quazip/quazip.pro
-index 1111111..2222222 100644
+index eb68954..ad0f915 100644
 --- a/quazip/quazip.pro
 +++ b/quazip/quazip.pro
 @@ -78,6 +78,8 @@ win32 {
@@ -82,7 +23,7 @@ index 1111111..2222222 100644
  
  
 diff --git a/qztest/qztest.pro b/qztest/qztest.pro
-index 1111111..2222222 100644
+index ef64051..61b4483 100644
 --- a/qztest/qztest.pro
 +++ b/qztest/qztest.pro
 @@ -40,8 +40,8 @@ testquazipfile.cpp \
@@ -93,29 +34,9 @@ index 1111111..2222222 100644
 -else:win32:CONFIG(debug, debug|release): LIBS += -L$$OUT_PWD/../quazip/debug/ -lquazipd
 +win32:CONFIG(release, debug|release): LIBS += -L$$OUT_PWD/../quazip/release/ -lquazip -lz
 +else:win32:CONFIG(debug, debug|release): LIBS += -L$$OUT_PWD/../quazip/debug/ -lquazipd -lz
- else:mac:CONFIG(debug, debug|release): LIBS += -L$$OUT_PWD/../quazip/debug/ -lquazip_debug
+ else:mac:CONFIG(debug, debug|release): LIBS += -L$$OUT_PWD/../quazip/ -lquazip_debug
  else:unix: LIBS += -L$$OUT_PWD/../quazip/ -lquazip
  
+-- 
+2.7.4
 
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Zoltan Gyarmati <mr.zoltan.gyarmati@gmail.com>
-Date: Sat, 3 Jun 2017 11:24:17 +0200
-Subject: [PATCH 3/3] use lowercase windows.h
-
-Sent to upstream: https://sourceforge.net/p/quazip/patches/30/
-
-Signed-off-by: Zoltan Gyarmati <mr.zoltan.gyarmati@gmail.com>
-
-diff --git a/qztest/testjlcompress.cpp b/qztest/testjlcompress.cpp
-index 1111111..2222222 100644
---- a/qztest/testjlcompress.cpp
-+++ b/qztest/testjlcompress.cpp
-@@ -34,7 +34,7 @@ see quazip/(un)zip.h files for details. Basically it's the zlib license.
- #include <quazip/JlCompress.h>
- 
- #ifdef Q_OS_WIN
--#include <Windows.h>
-+#include <windows.h>
- #endif
- 
- void TestJlCompress::compressFile_data()

--- a/src/quazip.mk
+++ b/src/quazip.mk
@@ -1,18 +1,19 @@
 # This file is part of MXE. See LICENSE.md for licensing information.
 
 PKG             := quazip
-$(PKG)_WEBSITE  := https://sourceforge.net/projects/quazip/
+$(PKG)_WEBSITE  := https://github.com/stachenov/quazip
 $(PKG)_IGNORE   :=
-$(PKG)_VERSION  := 0.7.3
-$(PKG)_CHECKSUM := 2ad4f354746e8260d46036cde1496c223ec79765041ea28eb920ced015e269b5
+$(PKG)_VERSION  := 0.7.5
+$(PKG)_CHECKSUM := f3a56647d4706c9daef411e40e3884702e2bd770e980145c3899321788ba8bb2
 $(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
 $(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.gz
-$(PKG)_URL      := http://$(SOURCEFORGE_MIRROR)/project/$(PKG)/$(PKG)/$($(PKG)_VERSION)/$($(PKG)_FILE)
+$(PKG)_GH_CONF  := stachenov/quazip/tags
 $(PKG)_DEPS     := cc qtbase zlib
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'http://sourceforge.net/projects/quazip/files/quazip/' | \
-    $(SED) -n 's,.*/projects/.*/.*/\([0-9][^"]*\)/".*,\1,p' | \
+    $(WGET) -q -O- 'https://github.com/stachenov/quazip/tags' | \
+    grep '<a href="/stachenov/quazip/archive/' | \
+    $(SED) -n 's,.*href="/stachenov/quazip/archive/\([0-9][^"_]*\)\.tar.*,\1,p' | \
     head -1
 endef
 


### PR DESCRIPTION
Also rework the patches as some of them was accepted in upstream
in the meantime

Please read http://mxe.cc/#creating-packages

In particular, make sure that your build rules:

  * install .pc file,
  * install bin/test-pkg.exe compiled with flags by pkg-config,
  * install .dll to bin/ and .a, .dll.a to lib/,
  * use $(TARGET)-cmake instead of cmake,
  * build in `$(BUILD_DIR)` instead of `$(SOURCE_DIR)`,
  * do not run target executables with Wine,
  * do not download anything while building,
  * do not install documentation,
  * do not install .exe files except test and build systems,

and .patch files are generated by tools/patch-tool-mxe.

If you add a package, you can use tool tools/skeleton.py.

Thanks!
