### PR TITLE
ffmpeg: fix ffplay compilation by changing sdl dependency to sdl2

### DIFF
--- a/src/ffmpeg.mk
+++ b/src/ffmpeg.mk
@@ -9,7 +9,7 @@ $(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
 $(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.bz2
 $(PKG)_URL      := https://ffmpeg.org/releases/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc bzip2 gnutls lame libass libbluray libbs2b libcaca \
-                   libvpx opencore-amr opus sdl speex theora vidstab \
+                   libvpx opencore-amr opus sdl2 speex theora vidstab \
                    vo-amrwbenc vorbis x264 xvidcore yasm zlib
 
 # DO NOT ADD fdk-aac OR openssl SUPPORT.


### PR DESCRIPTION
ffmpeg updated to using sdl2 a while ago, but the dependency didn't get changed to that, so ffplay doesn't get compiled anymore. This should fix that.

Edit: Related to (or fixes) https://github.com/mxe/mxe/issues/1802.