### PR TITLE
Patched `automake` - avoid deprecated syntax that fail.

### DIFF
--- a/plugins/native/automake-1-avoids-deprecated-syntax.patch
+++ b/plugins/native/automake-1-avoids-deprecated-syntax.patch
@@ -1,0 +1,28 @@
+This file is part of MXE. See LICENSE.md for licensing information.
+
+Contains ad hoc patches for cross building.
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Patryk (PsychoX) Ludwikowski <psychoxivi@gmail.com>
+Date: Sun, 10 Jun 2018 06:49:41 +0000
+Subject: [PATCH 1/1] Avoids deprecated syntax that causes failure in newer versions of Perl.
+
+Contains patch for using too new Perl. Avoids deprecated syntax that causes failure in newer versions of Perl. More info at https://github.com/mxe/mxe/issues/2140
+
+Backported from:
+http://git.savannah.gnu.org/cgit/automake.git/commit/?id=13f00eb4493c217269b76614759e452d8302955e
+Original author: Paul Eggert <eggert@cs.ucla.edu>
+Signed-off-by: Adam Duskett <aduskett@gmail.com>
+
+diff --git a/bin/automake.in b/bin/automake.in
+index 1111111..2222222 100644
+--- a/bin/automake.in
++++ b/bin/automake.in
+@@ -3878,7 +3878,7 @@ sub substitute_ac_subst_variables_worker
+ sub substitute_ac_subst_variables
+ {
+   my ($text) = @_;
+-  $text =~ s/\${([^ \t=:+{}]+)}/substitute_ac_subst_variables_worker ($1)/ge;
++  $text =~ s/\$[{]([^ \t=:+{}]+)}/substitute_ac_subst_variables_worker ($1)/ge;
+   return $text;
+ }


### PR DESCRIPTION
Contains patch for `automake` from `native` plugin. That allows using newer version of Perl, by avoiding deprecated syntax that causes failure.

Solved thanks to comment of user `franzgl` from raspberrypi/noobs#470 that mentions:
> The error is with automake and perl v5.26.
> In perl v5.22, using a literal { in a regular expression was deprecated, and will emit a warning if it isn't escaped: {. In v5.26, this won't just warn, it'll cause a syntax error.

That solve an issue #2140