### PR TITLE
Fixed `lua` copy executable command to source from `.exe`

### DIFF
--- a/src/lua.mk
+++ b/src/lua.mk
@@ -32,7 +32,7 @@ define $(PKG)_BUILD_COMMON
      echo 'Libs: -l$(PKG)';) \
      > '$(PREFIX)/$(TARGET)/lib/pkgconfig/$(PKG).pc'
 
-    cp '$(1)/src/lua' '$(PREFIX)/$(TARGET)/bin/lua.exe'
+    cp '$(1)/src/lua.exe' '$(PREFIX)/$(TARGET)/bin/lua.exe' || cp '$(1)/src/lua' '$(PREFIX)/$(TARGET)/bin/lua.exe'
 
     '$(TARGET)-gcc' \
         -W -Wall -Werror -ansi -pedantic \


### PR DESCRIPTION
Lua executable was built as a file of name `lua` with `.exe` extension into `src` directory, but copy command was pointing 'lua` without `.exe` to copy further. This commit makes it copy `lua.exe` instead of just `lua`.

Log before:
```
bash://PsychoX@PsychoX/mnt/e/Libraries/MXE/mxe
$ make lua
[git-log]   95a75e41 Patched `automake` - avoid deprecated syntax that fail.
[build]       lua                    x86_64-w64-mingw32.static.posix

Failed to build package lua for target x86_64-w64-mingw32.static.posix!
------------------------------------------------------------
(echo 'Name: lua'; echo 'Version: 5.3.3'; echo 'Description: lua'; echo 'Libs: -llua';) > '/mnt/e/Libraries/MXE/mxe/usr/x86_64-w64-mingw32.static.posix/lib/pkgconfig/lua.pc'
cp '/tmp/mxe-tmp/tmp-lua-x86_64-w64-mingw32.static.posix/lua-5.3.3/src/lua' '/mnt/e/Libraries/MXE/mxe/usr/x86_64-w64-mingw32.static.posix/bin/lua.exe'
cp: cannot stat '/tmp/mxe-tmp/tmp-lua-x86_64-w64-mingw32.static.posix/lua-5.3.3/src/lua': No such file or directory
Makefile:787: recipe for target 'build-only-lua_x86_64-w64-mingw32.static.posix' failed
make[1]: *** [build-only-lua_x86_64-w64-mingw32.static.posix] Error 1
make[1]: Leaving directory '/mnt/e/Libraries/MXE/mxe'
real    0m16.285s
user    0m16.750s
sys     0m10.109s
------------------------------------------------------------
[log]      /mnt/e/Libraries/MXE/mxe/log/lua_x86_64-w64-mingw32.static.posix

Makefile:787: recipe for target '/mnt/e/Libraries/MXE/mxe/usr/x86_64-w64-mingw32.static.posix/installed/lua' failed
make: *** [/mnt/e/Libraries/MXE/mxe/usr/x86_64-w64-mingw32.static.posix/installed/lua] Error 1
21:03:19@2018-06-11!877?2
```

Log after:
```
bash://PsychoX@PsychoX/mnt/e/Libraries/MXE/mxe
$ make lua
[build]       lua                    x86_64-w64-mingw32.static.posix
[done]        lua                    x86_64-w64-mingw32.static.posix                  3512 KiB       0m14.043s
[build]       lua                    x86_64-w64-mingw32.shared.posix
[done]        lua                    x86_64-w64-mingw32.shared.posix                  3888 KiB       0m14.415s
21:10:07@2018-06-11!879?0
```