### PR TITLE
use XGCC_W32_PREFIX for newer nsis

### DIFF
--- a/src/nsis.mk
+++ b/src/nsis.mk
@@ -23,6 +23,7 @@ define $(PKG)_BUILD
         $(SED) -i 's/m_target_type=TARGET_X86ANSI/m_target_type=TARGET_AMD64/' '$(1)/Source/build.cpp')
     cd '$(1)' && scons \
         MINGW_CROSS_PREFIX='$(TARGET)-' \
+        XGCC_W32_PREFIX='$(TARGET)-' \
         PREFIX='$(PREFIX)/$(TARGET)' \
         `[ -d /usr/local/include ] && echo APPEND_CPPPATH=/usr/local/include` \
         `[ -d /usr/local/lib ]     && echo APPEND_LIBPATH=/usr/local/lib` \


### PR DESCRIPTION
new versions of NSIS require XGCC_W32_PREFIX not MINGW_CROSS_PREFIX, see http://nsis.sourceforge.net/Docs/AppendixG.html

Thanks!
