### PR TITLE
scons use python2 when python3 is default python

### DIFF
--- a/src/nsis.mk
+++ b/src/nsis.mk
@@ -11,6 +11,12 @@ $(PKG)_FILE     := nsis-$($(PKG)_VERSION)-src.tar.bz2
 $(PKG)_URL      := https://$(SOURCEFORGE_MIRROR)/project/nsis/NSIS 3/$($(PKG)_VERSION)/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc
 
+define SCONSBIN
+   $(if $(findstring python2,`[ -e /usr/bin/python2 ] && echo python2`), \
+      cp /usr/bin/scons $(1)/ && sed -i s/python/python2/g $(1)/scons && ./scons, \
+      scons)
+endef
+
 define $(PKG)_UPDATE
     $(WGET) -q -O- 'https://nsis.sourceforge.io/Download' | \
     $(SED) -n 's,.*nsis-\([0-9.]\+\)-src.tar.*,\1,p' | \
@@ -21,7 +27,7 @@ define $(PKG)_BUILD
     $(if $(findstring x86_64-w64-mingw32,$(TARGET)),\
         $(SED) -i 's/pei-i386/pei-x86-64/' '$(1)/SCons/Config/linker_script' && \
         $(SED) -i 's/m_target_type=TARGET_X86ANSI/m_target_type=TARGET_AMD64/' '$(1)/Source/build.cpp')
-    cd '$(1)' && scons \
+    cd '$(1)' && $(SCONSBIN) \
         MINGW_CROSS_PREFIX='$(TARGET)-' \
         PREFIX='$(PREFIX)/$(TARGET)' \
         `[ -d /usr/local/include ] && echo APPEND_CPPPATH=/usr/local/include` \


### PR DESCRIPTION
scons is broken on systems where python3 is default python, like ubuntu18.  this breaks nsis since it depends on scons.

this is because scons is actually a script that begins with #! /usr/bin/python

what we do here, is quite frankly a kludge, as i am not overly familiar with the language of Makefile , but A. it works, B, i hope it inspires someone else to improve it.

basically, we detect whether the system has a 'python2' binary in /usr/bin, this is my quick n dirty version of determining if a system is one that likely has python3 as default, since most systems that have done this will retain python2 as its own binary. 

then this copies scons from /usr/bin to our build dir, then modifies this copy of the scons script itself to use # /usr/bin/python2 instead of usr/bin/python (which is likely python3 on such machines)

then instead of calling 'scons' we call 'builddir/scons' which runs scons with python2

Thanks