### PR TITLE
fix db-2-install.patch

### DIFF
--- a/src/db-2-install-exe.patch
+++ b/src/db-2-install-exe.patch
@@ -1,19 +1,6 @@
-This file is part of MXE. See LICENSE.md for licensing information.
-
-From 67a1bbc57a368efd2ebb81f771ef7ba794bac5a0 Mon Sep 17 00:00:00 2001
-From: Boris Nagaev <bnagaev@gmail.com>
-Date: Wed, 2 Sep 2015 20:18:30 +0300
-Subject: [PATCH] install executables with .exe
-
----
- dist/Makefile.in | 3 +--
- 1 file changed, 1 insertion(+), 2 deletions(-)
-
-diff --git a/dist/Makefile.in b/dist/Makefile.in
-index 8358e53..8839ea6 100644
---- a/dist/Makefile.in
-+++ b/dist/Makefile.in
-@@ -1150,8 +1150,7 @@ install_utilities:
+--- Makefile.in	2015-06-18 16:04:54.000000000 -0400
++++ Makefile_patch.in	2018-08-19 11:01:39.044928227 -0400
+@@ -1150,10 +1150,9 @@
  	    ($(MKDIR) -p $(DESTDIR)$(bindir) && \
  	    $(CHMOD) $(dmode) $(DESTDIR)$(bindir))
  	@for i in $(UTIL_PROGS); do \
@@ -21,8 +8,8 @@ index 8358e53..8839ea6 100644
 -		e=`echo $$i | $(SED) '$(transform)'`; \
 +		e=$$i.exe; \
  		$(RM) $(DESTDIR)$(bindir)/$$e; \
- 		$(INSTALLER) $$i $(DESTDIR)$(bindir)/$$e; \
+-		$(INSTALLER) $$i $(DESTDIR)$(bindir)/$$e; \
++		$(INSTALLER) $$e $(DESTDIR)$(bindir)/$$e; \
  		$(STRIP) $(DESTDIR)$(bindir)/$$e; \
--- 
-2.1.4
-
+ 		$(CHMOD) $(emode) $(DESTDIR)$(bindir)/$$e; \
+ 	done


### PR DESCRIPTION
Fixes db-2-install.patch

Incorrect variable defined in 
https://github.com/mxe/mxe/blob/13d6257891f94d539b29a786641cef60b0874233/src/db-2-install-exe.patch#L24	

Should be **$(INSTALLER) $$e** to match with 
```	
e=$$i.exe; \
```

Make any edits as necessary for successful commit please. @starius @tonytheodore 