### PR TITLE
Package `libbacktrace` added.

### DIFF
--- a/src/libbacktrace.mk
+++ b/src/libbacktrace.mk
@@ -1,0 +1,71 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+PKG             := libbacktrace
+$(PKG)_WEBSITE  := https://gcc.gnu.org/
+$(PKG)_DESCR    := GNU backtrace library
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 5a99ff7
+$(PKG)_CHECKSUM := 55802f72028a530ff6fd071ba25d80b5c18b1ea19f1eef2a99390837fbea991e
+$(PKG)_GH_CONF  := ianlancetaylor/libbacktrace/branches/master
+#$(PKG)_CHECKSUM := 55802f72028a530ff6fd071ba25d80b5c18b1ea19f1eef2a99390837fbea991e
+#$(PKG)_SUBDIR   := libbacktrace
+#$(PKG)_FILE     := libbacktrace
+#$(PKG)_URL      := https://github.com/ianlancetaylor/libbacktrace/archive/master.zip
+$(PKG)_DEPS     := cc
+
+define $(PKG)_CONFIGURE
+    # Configure
+	cd '$(BUILD_DIR)' && '$(SOURCE_DIR)/configure' \
+        $(MXE_DISABLE_DOC_OPTS) \
+		--host='$(TARGET)' \
+        --target='$(TARGET)' \
+        --build='$(BUILD)' \
+        --prefix='$(PREFIX)/$(TARGET)' \
+        --with-sysroot='$(PREFIX)/$(TARGET)' \
+        --disable-multilib \
+		--disable-shared \
+        --enable-threads=$(MXE_GCC_THREADS) \
+        --with-gcc \
+        --with-gnu-ld \
+        --with-gnu-as \
+        --with-as='$(PREFIX)/bin/$(TARGET)-as' \
+        --with-ld='$(PREFIX)/bin/$(TARGET)-ld' \
+        --with-nm='$(PREFIX)/bin/$(TARGET)-nm' \
+        $($(PKG)_CONFIGURE_OPTS)
+endef
+
+define $(PKG)_MAKE
+    # Build using its makefile
+	$(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)'
+	
+	# Install
+    $(MAKE) -C '$(BUILD_DIR)' -j 1 install
+endef
+
+define $(PKG)_POST_MAKE
+	# Create pkg-config file
+    $(INSTALL) -d '$(PREFIX)/$(TARGET)/lib/pkgconfig'
+    (echo 'Name: $(PKG)' \
+    ;echo 'Version: 0.0.0-$($(PKG)_VERSION)' \
+    ;echo 'Description: $(PKG)' \
+    ;echo 'Requires: ' \
+    ;echo 'Libs: -lbacktrace -lstdc++' \
+    ) > '$(PREFIX)/$(TARGET)/lib/pkgconfig/libbacktrace.pc'
+	
+	# Make shared libraries
+	$(if $(BUILD_SHARED),\
+        rm -f '$(PREFIX)/$(TARGET)/lib/libbacktrace.a' && \
+        $(MAKE_SHARED_FROM_STATIC) '$(BUILD_DIR)/.libs/libbacktrace.a' \
+		`$(TARGET)-pkg-config libbacktrace --libs-only-l | $(SED) 's/-lbacktrace//'` \
+    )
+	
+	# @todo . Create some tests :C
+	# These tests are build-time and prepared for Unix :/
+	$(MAKE) -d -C '$(BUILD_DIR)' -j '$(JOBS)' check-TESTS
+endef
+
+define $(PKG)_BUILD
+    $($(PKG)_CONFIGURE)
+	$($(PKG)_MAKE)
+	$($(PKG)_POST_MAKE)
+endef


### PR DESCRIPTION
I used version from [`IanLanceTaylor` Github](https://github.com/ianlancetaylor/libbacktrace), also as download source (by `GH_CONF`). 

I make it out without messing in Boost module, which use `libbacktrace` for alternative stacktrace debug infomation source for `Boost.Stacktrace` and it work :) 
```makefile
CXXFLAGS += -DBOOST_STACKTRACE_USE_BACKTRACE
LDFLAGS += -lbacktrace
```

Some info related to "new packages information" from template:
```
In particular, make sure that your build rules:
  * [x] install .pc file, -- it should work since its only -lbacktrace and -lstdc++; also half way tested by MAKE_SHARED_FROM_STATIC which use it ;f
  * [ ] install bin/test-pkg.exe compiled with flags by pkg-config, -- sorry, there is no test exe yet
  * [x] install .dll to bin/ and .a, .dll.a to lib/, -- dll done using MAKE_SHARED_FROM_STATIC 
  * [x] use $(TARGET)-cmake instead of cmake,
  * [x] build in `$(BUILD_DIR)` instead of `$(SOURCE_DIR)`,
  * [x] do not run target executables with Wine,
  * [x] do not download anything while building,
  * [x] do not install documentation, 
  * [ ] do not install .exe files except test and build systems, -- sorry, there is no test exe yet
```

By the way:
I added this library because I want to use it with `Boost.Stacktrace` which provide functionality, as name follows, to get nice stacktrace - with list of invoked functions, file names and line numbers. This is quite awesome, but it doesn't work with default ways with MXE, so that was my motivation to add this package. And this works, at least the `libbacktrace` relation with Boost...

But I still have one problem :(

`Mingw32-w64` (not basic `mingw32`) makes Boost to use `RtlCaptureStackBackTrace` from WinAPI to do the work with stacktrace. The function is imported to C++ land using `extern`, but it seems not work for MXE build of mingw :C 

The most fun, but disappointing thing is... That `libstacktrace` make Boost to get vaild stacktrace debug informations, but it doesn't work at all because of the `RtlCaptureStackBackTrace` so.... 
```
Call stack:
 0# boost::stacktrace::detail::this_thread_frames::collect(void const**, unsigned long long, unsigned long long) at /mnt/e/Libraries/MXE/mxe/usr/x86_64-w64-mingw32.static.posix/include/boost/stacktrace/detail/collect_msvc.ipp:27
 1# boost::stacktrace::basic_stacktrace<std::allocator<boost::stacktrace::frame> >::init(unsigned long long, unsigned long long) at /mnt/e/Libraries/MXE/mxe/usr/x86_64-w64-mingw32.static.posix/include/boost/stacktrace/stacktrace.hpp:75
[...]
```
>faceplam<

It fails inside its own implementation :|

Ehmm, maybe should I create another issue? 🤔 