### PR TITLE
Add shaderc

### DIFF
--- a/src/glslang-src.mk
+++ b/src/glslang-src.mk
@@ -1,0 +1,12 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+PKG_BASENAME    := glslang
+PKG             := $(PKG_BASENAME)-src
+$(PKG)_WEBSITE  := https://github.com/KhronosGroup/glslang
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 7.9.2888
+$(PKG)_SUBDIR   := $(PKG_BASENAME)-$($(PKG)_VERSION)
+$(PKG)_CHECKSUM := cb66779d0e6b5f07f0445bd58289a24e56e12693e71d75c8fae3db31ffacaf8c
+# Not sure how to set this up properly
+$(PKG)_GH_CONF  := KhronosGroup/glslang/tags/7.9.2888
+$(PKG)_TYPE     := source-only

--- a/src/shaderc-1-fixes.patch
+++ b/src/shaderc-1-fixes.patch
@@ -1,0 +1,108 @@
+From 5c4c01b051e5d4000adc5d54536c4b4481619f13 Mon Sep 17 00:00:00 2001
+From: Andrei Alexeyev <0x416b617269@gmail.com>
+Date: Sun, 23 Sep 2018 23:08:14 +0300
+Subject: [PATCH] MXE fixes:
+
+    * Respect BUILD_SHARED/BUILD_STATIC
+    * Don't build glslc.exe and examples
+---
+ CMakeLists.txt            |  2 --
+ libshaderc/CMakeLists.txt | 26 ++++++++++++++++++++++----
+ 2 files changed, 22 insertions(+), 6 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b9bd0df..b5411c6 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -56,8 +56,6 @@ add_subdirectory(third_party)
+ 
+ add_subdirectory(libshaderc_util)
+ add_subdirectory(libshaderc)
+-add_subdirectory(glslc)
+-add_subdirectory(examples)
+ 
+ add_custom_target(build-version
+   ${PYTHON_EXE}
+diff --git a/libshaderc/CMakeLists.txt b/libshaderc/CMakeLists.txt
+index 14da8ce..1ef9545 100644
+--- a/libshaderc/CMakeLists.txt
++++ b/libshaderc/CMakeLists.txt
+@@ -14,6 +14,7 @@ add_library(shaderc STATIC ${SHADERC_SOURCES})
+ shaderc_default_compile_options(shaderc)
+ target_include_directories(shaderc PUBLIC include PRIVATE ${glslang_SOURCE_DIR})
+ 
++if(BUILD_SHARED)
+ add_library(shaderc_shared SHARED ${SHADERC_SOURCES})
+ shaderc_default_compile_options(shaderc_shared)
+ target_include_directories(shaderc_shared PUBLIC include PRIVATE ${glslang_SOURCE_DIR})
+@@ -21,6 +22,7 @@ target_compile_definitions(shaderc_shared
+     PRIVATE SHADERC_IMPLEMENTATION
+     PUBLIC SHADERC_SHAREDLIB
+ )
++endif()
+ 
+ if(SHADERC_ENABLE_INSTALL)
+   install(
+@@ -30,10 +32,15 @@ if(SHADERC_ENABLE_INSTALL)
+     DESTINATION
+       ${CMAKE_INSTALL_INCLUDEDIR}/shaderc)
+ 
+-  install(TARGETS shaderc shaderc_shared
+-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
++  if(BUILD_SHARED)
++    install(TARGETS shaderc_shared
++      LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
++      RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
++      ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
++  endif()
++
++  # Don't install the plain static library, it's basically useless.
++  # We'll install the _combined version that includes the vendored dependencies.
+ endif(SHADERC_ENABLE_INSTALL)
+ 
+ find_package(Threads)
+@@ -45,7 +52,10 @@ set(SHADERC_LIBS
+ )
+ 
+ target_link_libraries(shaderc PRIVATE ${SHADERC_LIBS})
++
++if(BUILD_SHARED)
+ target_link_libraries(shaderc_shared PRIVATE ${SHADERC_LIBS})
++endif(BUILD_SHARED)
+ 
+ shaderc_add_tests(
+   TEST_PREFIX shaderc
+@@ -57,6 +67,8 @@ shaderc_add_tests(
+     shaderc_cpp
+     shaderc_private)
+ 
++if(BUILD_SHARED)
++
+ shaderc_add_tests(
+   TEST_PREFIX shaderc_shared
+   LINK_LIBS shaderc_shared SPIRV-Tools
+@@ -67,6 +79,10 @@ shaderc_add_tests(
+     shaderc_cpp
+     shaderc_private)
+ 
++endif(BUILD_SHARED)
++
++if(BUILD_STATIC)
++
+ shaderc_combine_static_lib(shaderc_combined shaderc)
+ 
+ if(SHADERC_ENABLE_INSTALL)
+@@ -94,6 +110,8 @@ shaderc_add_tests(
+     shaderc
+     shaderc_cpp)
+ 
++endif(BUILD_STATIC)
++
+ if(${SHADERC_ENABLE_TESTS})
+   add_executable(shaderc_c_smoke_test ./src/shaderc_c_smoke_test.c)
+   shaderc_default_c_compile_options(shaderc_c_smoke_test)
+-- 
+2.19.0
+

--- a/src/shaderc.mk
+++ b/src/shaderc.mk
@@ -1,0 +1,32 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+PKG             := shaderc
+$(PKG)_WEBSITE  := https://github.com/google/shaderc
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 30af9f9
+$(PKG)_CHECKSUM := b20f1a7ed6b9f732d636a12d32f584304404d6dc1b02b58a28979b86d1c74b2d
+$(PKG)_GH_CONF  := google/shaderc/branches/master
+$(PKG)_DEPS     := cc spirv-tools-src spirv-headers-src glslang-src
+
+define $(PKG)_BUILD
+    # set up the third-party sources
+    $(call PREPARE_PKG_SOURCE,spirv-tools-src,$(SOURCE_DIR)/third_party)
+    mv '$(SOURCE_DIR)/third_party/$(spirv-tools-src_SUBDIR)' '$(SOURCE_DIR)/third_party/spirv-tools'
+    $(call PREPARE_PKG_SOURCE,spirv-headers-src,$(SOURCE_DIR)/third_party)
+    mv '$(SOURCE_DIR)/third_party/$(spirv-headers-src_SUBDIR)' '$(SOURCE_DIR)/third_party/spirv-headers'
+    $(call PREPARE_PKG_SOURCE,glslang-src,$(SOURCE_DIR)/third_party)
+    mv '$(SOURCE_DIR)/third_party/$(glslang-src_SUBDIR)' '$(SOURCE_DIR)/third_party/glslang'
+
+    # build and install the library
+    echo '"$($(PKG)_VERSION)"' > '$(SOURCE_DIR)'/glslc/src/build-version.inc
+    cd '$(BUILD_DIR)' && $(TARGET)-cmake '$(SOURCE_DIR)' \
+        -DSHADERC_SKIP_TESTS=ON \
+        -DENABLE_GLSLANG_BINARIES=OFF \
+        -DSKIP_GLSLANG_INSTALL=ON \
+        -DSKIP_SPIRV_TOOLS_INSTALL=ON \
+        -DSPIRV_SKIP_EXECUTABLES=ON \
+        -DSPIRV_BUILD_COMPRESSION=ON \
+        -DSPIRV_WERROR=OFF
+    $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)'
+    $(MAKE) -C '$(BUILD_DIR)' -j 1 install
+endef

--- a/src/spirv-headers-src.mk
+++ b/src/spirv-headers-src.mk
@@ -1,0 +1,10 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+PKG             := spirv-headers-src
+$(PKG)_WEBSITE  := https://github.com/KhronosGroup/SPIRV-Headers
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := d5b2e12
+$(PKG)_SUBDIR   := KhronosGroup-SPIRV-Headers-$($(PKG)_VERSION)
+$(PKG)_CHECKSUM := f88d0e61126a9b18d88ce04f2c0508e67769ddb2caa86760ec50ca42b34233e8
+$(PKG)_GH_CONF  := KhronosGroup/SPIRV-Headers/branches/master
+$(PKG)_TYPE     := source-only

--- a/src/spirv-tools-src.mk
+++ b/src/spirv-tools-src.mk
@@ -1,0 +1,10 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+PKG             := spirv-tools-src
+$(PKG)_WEBSITE  := https://github.com/KhronosGroup/SPIRV-Tools
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 2018.5
+$(PKG)_SUBDIR   := SPIRV-Tools-$($(PKG)_VERSION)
+$(PKG)_CHECKSUM := bc56f1b53827811095aad330e078604f06319c4b0648a4bbe183a4bfe5b3ef58
+$(PKG)_GH_CONF  := KhronosGroup/SPIRV-Tools/tags,v
+$(PKG)_TYPE     := source-only


### PR DESCRIPTION
Required for taisei-project/taisei#148. Forgive me if this is crude, I've tried my best, and I'm sick and tired of fighting with these broken and braindead build systems already. I might improve it later, but hey, it installs a static library, so that's good enough for now. Here are a couple of known issues:

 * No pkg-config files, because Khronos is oblivious and Google doesn't give a crap (google/shaderc#392). Projects that depend on those libraries don't expect to find them via pkg-config as a sad result of that, so I made no effort to generate one.
 * Neither shaderc nor glslang have a soversion, probably for the same reasons they don't have .pc files.
 * shaderc has different library names for static and shared builds, because Google is fucking evil I guess.
 * I have no idea how I'm supposed to handle versions of this bloody mess.
 * Shared targets are not tested at all.
 * Patch files were generated manually via git format-patch, because patch-tool-mxe refused to cooperate.