### PR TITLE
Update taglib to follow github

### DIFF
--- a/src/taglib.mk
+++ b/src/taglib.mk
@@ -1,12 +1,12 @@
 # This file is part of MXE. See LICENSE.md for licensing information.
 
 PKG             := taglib
-$(PKG)_WEBSITE  := https://developer.kde.org/~wheeler/taglib.html
+$(PKG)_WEBSITE  := https://taglib.org/
 $(PKG)_DESCR    := TagLib
 $(PKG)_IGNORE   :=
-$(PKG)_VERSION  := 1.11.1
-$(PKG)_CHECKSUM := b6d1a5a610aae6ff39d93de5efd0fdc787aa9e9dc1e7026fa4c961b26563526b
-$(PKG)_GH_CONF  := taglib/taglib/tags,v
+$(PKG)_VERSION  := d8d56d3
+$(PKG)_CHECKSUM := eef49c9c2273f1b00299ef4fdcde2f1095cfa8ee4699365c6a6499b13cc3a072
+$(PKG)_GH_CONF  := taglib/taglib/branches/master
 $(PKG)_DEPS     := cc zlib
 
 define $(PKG)_BUILD


### PR DESCRIPTION
I'm updating taglib to the latest git revision because of a bug in the current release 1.11.1 (2 years old) corrupting ogg files, there is also new features such as detecting audio by content.
Also correcting the website url.
