### PR TITLE
Sharing Kdenlive Windows build process

### DIFF
--- a/plugins/apps/kdenlive-distribute.sh
+++ b/plugins/apps/kdenlive-distribute.sh
@@ -1,0 +1,50 @@
+#!/bin/bash -xe
+# run from mxe root dir after "make kdenlive"
+# > plugins/apps/kdenlive-distribute.sh
+MXE_DIR=$PWD
+
+VERSION=$(sed -n 's/.*VERSION\s*:=\s*//p' $MXE_DIR/plugins/apps/kdenlive.mk)
+INSTALL_DIR=$MXE_DIR/../Kdenlive-$VERSION
+echo Installing to $INSTALL_DIR
+[ -d $INSTALL_DIR ] && echo "... already exists, delete?" && rm -rI $INSTALL_DIR
+mkdir -p $INSTALL_DIR/{lib,share,etc}
+
+MXE_BINDIR=$MXE_DIR/usr/x86_64-w64-mingw32.shared.posix
+cd $MXE_BINDIR
+
+echo Copying binaries
+cp *.dll *.exe $INSTALL_DIR
+cp bin/{*.dll,ff*.exe,kdenlive*.exe,kioslave.exe,dbus-daemon.exe,qtlogging.ini} $INSTALL_DIR
+rm $INSTALL_DIR/icu*5*.dll
+cp lib/libdl.dll.a $INSTALL_DIR
+cp qt5/bin/*.dll $INSTALL_DIR
+cp -r qt5/{plugins,qml} $INSTALL_DIR
+echo Copying data
+cp -r bin/data $INSTALL_DIR
+cp bin/data/icons/breeze/breeze-icons.rcc $INSTALL_DIR/data/icontheme.rcc
+rm -r $INSTALL_DIR/data/icons/
+# MLT looks for lib & share next to exe on windows
+cp -r share/{mlt,ffmpeg,dbus-1} $INSTALL_DIR/share
+cp -r etc/{dbus-1,xdg} $INSTALL_DIR/etc
+cp -r lib/{mlt,frei0r-1,ladspa} $INSTALL_DIR/lib
+printf "[Paths]\nPlugins=plugins\nQml2Imports=qml\n" > $INSTALL_DIR/qt.conf
+
+# Qt finds local data directly in /data, not in /data/kdenlive
+mv $INSTALL_DIR/data/kdenlive/* $INSTALL_DIR/data/
+rmdir $INSTALL_DIR/data/kdenlive
+
+# Copy KDE's color schemes from system
+cp -r /usr/share/color-schemes $INSTALL_DIR/data
+# MXE's libwinpthread is broken
+cp /usr/x86_64-w64-mingw32/lib/libwinpthread-1.dll $INSTALL_DIR
+
+cp $MXE_DIR/tmp-kdenlive*/kdenlive-*/{AUTHORS,COPYING,README} $INSTALL_DIR
+if [ -$1 == -z ]
+then
+    echo "Compressing"
+    cd $INSTALL_DIR/..
+    7z a $INSTALL_DIR-w64.7z $INSTALL_DIR
+    cd $MXE_BINDIR/bin
+    7z a $MXE_DIR/../Kdenlive-$VERSION-w64dbg.7z kdenlive.debug
+fi
+

--- a/plugins/apps/kdenlive.README
+++ b/plugins/apps/kdenlive.README
@@ -1,0 +1,16 @@
+I use the following mxe/settings.mk:
+
+kdenlive_SOURCE_TREE := /path/to/kdenlive/source
+MXE_TARGETS :=  x86_64-w64-mingw32.shared.posix
+override MXE_PLUGIN_DIRS += \
+	plugins/multimedia \
+	plugins/kdeframeworks \
+	plugins/apps
+# openssl recognition fails on Debian sid
+REQUIREMENTS := $(filter-out openssl ,$(REQUIREMENTS))
+
+then from mxe/ directory:
+
+make kdenlive
+plugins/apps/deploy_kdenlive.sh z
+

--- a/plugins/apps/kdenlive.mk
+++ b/plugins/apps/kdenlive.mk
@@ -1,0 +1,46 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+PKG             := kdenlive
+$(PKG)_VERSION  := 18.08.0
+$(PKG)_CHECKSUM := 43247d070e6898c26271235b915b45422ee8668e512f38f6df711e5571dca019
+$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.xz
+$(PKG)_HOME     := http://download.kde.org/stable/applications
+$(PKG)_URL      := $($(PKG)_HOME)/$($(PKG)_VERSION)/src/$($(PKG)_FILE)
+$(PKG)_DEPS     := \
+	ffmpeg mlt \
+	qtbase qtdeclarative qtquickcontrols \
+	breeze-icons karchive kconfig kcoreaddons kdbusaddons kguiaddons ki18n kitemviews kplotting kwidgetsaddons \
+	kcompletion kcrash kjobwidgets kdeclarative \
+	kbookmarks kconfigwidgets kiconthemes kio knewstuff knotifications knotifyconfig kservice ktextwidgets kxmlgui kinit
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- http://download.kde.org/stable/applications | \
+    $(SED) -n 's,[^0-9]*\([0-9]\+.[0-9]\+.[0-9]\+\)/.*,\1,p' | \
+	tail -1
+endef
+
+define $(PKG)_BUILD
+    mkdir -p "$(1)/build-mxe"
+    cd "$(1)/build-mxe" && \
+	PKG_CONFIG_LIBDIR=$(PREFIX)/$(TARGET)/lib/pkgconfig \
+	$(TARGET)-cmake .. \
+        -DKF5_HOST_TOOLING=/usr/lib/x86_64-linux-gnu/cmake \
+        -DKCONFIGCOMPILER_PATH=/usr/lib/x86_64-linux-gnu/cmake/KF5Config/KF5ConfigCompilerTargets.cmake \
+        -DTARGETSFILE=/usr/lib/x86_64-linux-gnu/cmake/KF5CoreAddons/KF5CoreAddonsToolingTargets.cmake \
+        -DCMAKE_DISABLE_FIND_PACKAGE_KF5Crash=TRUE \
+        -DCMAKE_DISABLE_FIND_PACKAGE_LibV4L2=TRUE \
+        -DMLT_MELTBIN=./melt.exe \
+        -DKDE_INSTALL_USE_QT_SYS_PATHS=ON \
+        -DKDE_L10N_AUTO_TRANSLATIONS=ON
+	$(SED) -i 's,MLT_PREFIX ".*",MLT_PREFIX ".",' "$(1)/build-mxe/config-kdenlive.h"
+	$(SED) -i 's,MLT_MELTBIN=[^ ]*,MLT_MELTBIN=\\"melt.exe\\",' "$(1)/build-mxe/src/CMakeFiles/kdenlive.dir/flags.make"
+    $(MAKE) -C "$(1)/build-mxe" -j $(JOBS) install
+	printf "[Rules]\n*.debug=false\norg.kde.multimedia.kdenlive=true\n" > $(PREFIX)/$(TARGET)/bin/qtlogging.ini
+
+    #-DCMAKE_BUILD_TYPE=Debug \
+	#cp $(1)/build-mxe/bin/kdenlive.exe $(PREFIX)/kdenlive.debug.exe
+	#$(TARGET)-objcopy --only-keep-debug $(PREFIX)/$(TARGET)/bin/kdenlive.exe $(PREFIX)/$(TARGET)/bin/kdenlive.debug
+	#$(TARGET)-strip --strip-debug --strip-unneeded $(PREFIX)/$(TARGET)/bin/kdenlive.exe
+	#$(TARGET)-objcopy --add-gnu-debuglink=$(PREFIX)/$(TARGET)/bin/kdenlive.debug $(PREFIX)/$(TARGET)/bin/kdenlive.exe
+endef

--- a/plugins/kdeframeworks/README.md
+++ b/plugins/kdeframeworks/README.md
@@ -1,0 +1,9 @@
+Some KDE Frameworks 5 used by Kdenlive
+
+An additional requirement on build system is qtbase-dev.
+
+To use these libraries, add in you settings.mk:
+override MXE_PLUGIN_DIRS += plugins/kdeframeworks
+
+To upgrade all frameworks in one shot:
+make $(for i in plugins/kdeframeworks/*.mk ; do i=${i##*/}; echo update-package-${i%%.mk} ; done)

--- a/plugins/kdeframeworks/attica.mk
+++ b/plugins/kdeframeworks/attica.mk
@@ -1,0 +1,25 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+PKG             := attica
+$(PKG)_VERSION  := 5.49.0
+$(PKG)_CHECKSUM := f60d6a737c5365de45eab19ada6413156123138528fff5a795fefba4a1a20cc7
+$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.xz
+$(PKG)_HOME     := http://download.kde.org/stable/frameworks
+$(PKG)_URL      := $($(PKG)_HOME)/$(basename $($(PKG)_VERSION))/$($(PKG)_FILE)
+$(PKG)_DEPS     := qtbase extra-cmake-modules
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- http://download.kde.org/stable/frameworks/ | \
+    $(SED) -n 's,.*\([0-9]\+\.[0-9]\+\)/.*,\1.0,p' | \
+	tail -1
+endef
+
+define $(PKG)_BUILD
+    mkdir "$(1)/build"
+    cd "$(1)/build" && cmake .. \
+        -DCMAKE_TOOLCHAIN_FILE="$(CMAKE_TOOLCHAIN_FILE)" \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DKDE_INSTALL_USE_QT_SYS_PATHS=ON -DKDE_L10N_AUTO_TRANSLATIONS=ON \
+        -DBUILD_TESTING=OFF
+    $(MAKE) -C "$(1)/build" -j $(JOBS) install
+endef

--- a/plugins/kdeframeworks/breeze-icons-1-Allow-cross-compiling-resource-file.patch
+++ b/plugins/kdeframeworks/breeze-icons-1-Allow-cross-compiling-resource-file.patch
@@ -1,0 +1,34 @@
+From ea3e3a9e7708968a761c6424c7c844536f60de3d Mon Sep 17 00:00:00 2001
+From: Vincent Pinon <vpinon@kde.org>
+Date: Tue, 4 Oct 2016 23:24:07 +0200
+Subject: [PATCH] Allow cross-compiling resource file
+
+---
+ CMakeLists.txt | 11 ++++++++---
+ 1 file changed, 8 insertions(+), 3 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 8b28ffd2..d2daa6c9 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -30,9 +30,14 @@ option(BINARY_ICONS_RESOURCE "Install Qt binary resource files containing breeze
+ option(SKIP_INSTALL_ICONS "Skip installing the icons files" OFF)
+ 
+ if(BINARY_ICONS_RESOURCE)
+-    find_package(Qt5 NO_MODULE REQUIRED Core)
+-    add_executable(qrcAlias qrcAlias.cpp)
+-    target_link_libraries(qrcAlias PUBLIC Qt5::Core)
++    if(CMAKE_CROSSCOMPILING AND QRCALIAS_EXECUTABLE)
++        add_executable(qrcAlias IMPORTED GLOBAL)
++        set_target_properties(qrcAlias PROPERTIES IMPORTED_LOCATION ${QRCALIAS_EXECUTABLE})
++    else()
++        find_package(Qt5 NO_MODULE REQUIRED Core)
++        add_executable(qrcAlias qrcAlias.cpp)
++        target_link_libraries(qrcAlias PUBLIC Qt5::Core)
++    endif()
+ 
+ function(generate_binary_resource target outfile)
+     set(RESOURCES_WORKING_DIR ${CMAKE_CURRENT_BINARY_DIR}/res)
+-- 
+2.14.2
+

--- a/plugins/kdeframeworks/breeze-icons.mk
+++ b/plugins/kdeframeworks/breeze-icons.mk
@@ -1,0 +1,28 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+PKG             := breeze-icons
+$(PKG)_VERSION  := 5.49.0
+$(PKG)_CHECKSUM  := f0b26f538905175ce763089b00c91d0be95278ac4b5085116d66530c2110069d
+$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.xz
+$(PKG)_HOME     := http://download.kde.org/stable/frameworks
+$(PKG)_URL      := $($(PKG)_HOME)/$(basename $($(PKG)_VERSION))/$($(PKG)_FILE)
+$(PKG)_DEPS     := qtbase extra-cmake-modules
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- http://download.kde.org/stable/frameworks/ | \
+    $(SED) -n 's,.*\([0-9]\+\.[0-9]\+\)/.*,\1.0,p' | \
+	tail -1
+endef
+
+define $(PKG)_BUILD
+	cd "$(1)" && $(BUILD_CXX) -std=c++11 qrcAlias.cpp -o $(PREFIX)/bin/qrcAlias -fPIC $(shell pkg-config --cflags Qt5Core --libs Qt5Core)
+    mkdir "$(1)/build"
+    cd "$(1)/build" && cmake .. \
+        -DCMAKE_TOOLCHAIN_FILE="$(CMAKE_TOOLCHAIN_FILE)" \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DKDE_INSTALL_USE_QT_SYS_PATHS=ON -DKDE_L10N_AUTO_TRANSLATIONS=ON \
+        -DBUILD_TESTING=OFF \
+        -DBINARY_ICONS_RESOURCE=ON \
+        -DQRCALIAS_EXECUTABLE=$(PREFIX)/bin/qrcAlias
+    $(MAKE) -C "$(1)/build" -j $(JOBS) install
+endef

--- a/plugins/kdeframeworks/extra-cmake-modules.mk
+++ b/plugins/kdeframeworks/extra-cmake-modules.mk
@@ -1,0 +1,25 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+PKG             := extra-cmake-modules
+$(PKG)_VERSION  := 5.49.0
+$(PKG)_CHECKSUM := c09fb851751f2e1c1231130dbce62d5dab396444fce7ed18662ada9ebd7ced1e
+$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.xz
+$(PKG)_HOME     := http://download.kde.org/stable/frameworks
+$(PKG)_URL      := $($(PKG)_HOME)/$(basename $($(PKG)_VERSION))/$($(PKG)_FILE)
+$(PKG)_DEPS     := qtbase
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- http://download.kde.org/stable/frameworks/ | \
+    $(SED) -n 's,.*\([0-9]\+\.[0-9]\+\)/.*,\1.0,p' | \
+	tail -1
+endef
+
+define $(PKG)_BUILD
+    mkdir "$(1)/build"
+    cd "$(1)/build" && cmake .. \
+        -DCMAKE_TOOLCHAIN_FILE="$(CMAKE_TOOLCHAIN_FILE)" \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DKDE_INSTALL_USE_QT_SYS_PATHS=ON -DKDE_L10N_AUTO_TRANSLATIONS=ON \
+        -DBUILD_TESTING=OFF
+    $(MAKE) -C "$(1)/build" -j $(JOBS) install
+endef

--- a/plugins/kdeframeworks/karchive.mk
+++ b/plugins/kdeframeworks/karchive.mk
@@ -1,0 +1,26 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+PKG             := karchive
+$(PKG)_VERSION  := 5.49.0
+$(PKG)_CHECKSUM := c0d6df96d86d2a8f21e3c3f67200755eabd5a86efc3d72b56f522fa11ae62fdc
+$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.xz
+$(PKG)_HOME     := http://download.kde.org/stable/frameworks
+$(PKG)_URL      := $($(PKG)_HOME)/$(basename $($(PKG)_VERSION))/$($(PKG)_FILE)
+$(PKG)_DEPS     := qtbase extra-cmake-modules
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- http://download.kde.org/stable/frameworks/ | \
+    $(SED) -n 's,.*\([0-9]\+\.[0-9]\+\)/.*,\1.0,p' | \
+	tail -1
+endef
+
+define $(PKG)_BUILD
+	cd $(1) && sed -i s'/Windows.h/windows.h/' autotests/karchivetest.cpp
+    mkdir "$(1)/build"
+    cd "$(1)/build" && cmake .. \
+        -DCMAKE_TOOLCHAIN_FILE="$(CMAKE_TOOLCHAIN_FILE)" \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DKDE_INSTALL_USE_QT_SYS_PATHS=ON -DKDE_L10N_AUTO_TRANSLATIONS=ON \
+        -DBUILD_TESTING=OFF
+    $(MAKE) -C "$(1)/build" -j $(JOBS) install
+endef

--- a/plugins/kdeframeworks/kauth.mk
+++ b/plugins/kdeframeworks/kauth.mk
@@ -1,0 +1,25 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+PKG             := kauth
+$(PKG)_VERSION  := 5.49.0
+$(PKG)_CHECKSUM  := c8029c6a3bdeb296e27eaf3791d269ebe88641ee9170bdabd5a2bb391effe361
+$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.xz
+$(PKG)_HOME     := http://download.kde.org/stable/frameworks
+$(PKG)_URL      := $($(PKG)_HOME)/$(basename $($(PKG)_VERSION))/$($(PKG)_FILE)
+$(PKG)_DEPS     := qtbase extra-cmake-modules kcoreaddons
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- http://download.kde.org/stable/frameworks/ | \
+    $(SED) -n 's,.*\([0-9]\+\.[0-9]\+\)/.*,\1.0,p' | \
+	tail -1
+endef
+
+define $(PKG)_BUILD
+    mkdir "$(1)/build"
+    cd "$(1)/build" && cmake .. \
+        -DCMAKE_TOOLCHAIN_FILE="$(CMAKE_TOOLCHAIN_FILE)" \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DKDE_INSTALL_USE_QT_SYS_PATHS=ON -DKDE_L10N_AUTO_TRANSLATIONS=ON \
+        -DBUILD_TESTING=OFF
+    $(MAKE) -C "$(1)/build" -j $(JOBS) install
+endef

--- a/plugins/kdeframeworks/kbookmarks.mk
+++ b/plugins/kdeframeworks/kbookmarks.mk
@@ -1,0 +1,25 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+PKG             := kbookmarks
+$(PKG)_VERSION  := 5.49.0
+$(PKG)_CHECKSUM  := a37c5632e361df36bcade0c31e1172cd284042474ebab5074689b9c058739532
+$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.xz
+$(PKG)_HOME     := http://download.kde.org/stable/frameworks
+$(PKG)_URL      := $($(PKG)_HOME)/$(basename $($(PKG)_VERSION))/$($(PKG)_FILE)
+$(PKG)_DEPS     := qtbase extra-cmake-modules kconfigwidgets kcoreaddons kiconthemes kwidgetsaddons kxmlgui
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- http://download.kde.org/stable/frameworks/ | \
+    $(SED) -n 's,.*\([0-9]\+\.[0-9]\+\)/.*,\1.0,p' | \
+	tail -1
+endef
+
+define $(PKG)_BUILD
+    mkdir "$(1)/build"
+    cd "$(1)/build" && cmake .. \
+        -DCMAKE_TOOLCHAIN_FILE="$(CMAKE_TOOLCHAIN_FILE)" \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DKDE_INSTALL_USE_QT_SYS_PATHS=ON -DKDE_L10N_AUTO_TRANSLATIONS=ON \
+        -DBUILD_TESTING=OFF
+    $(MAKE) -C "$(1)/build" -j $(JOBS) install
+endef

--- a/plugins/kdeframeworks/kcodecs.mk
+++ b/plugins/kdeframeworks/kcodecs.mk
@@ -1,0 +1,25 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+PKG             := kcodecs
+$(PKG)_VERSION  := 5.49.0
+$(PKG)_CHECKSUM := df0ed5de74ac1c0edd0fee75b4c7bafd7bce864891b69c142c2c4ba7df306a1f
+$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.xz
+$(PKG)_HOME     := http://download.kde.org/stable/frameworks
+$(PKG)_URL      := $($(PKG)_HOME)/$(basename $($(PKG)_VERSION))/$($(PKG)_FILE)
+$(PKG)_DEPS     := qtbase extra-cmake-modules qttools
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- http://download.kde.org/stable/frameworks/ | \
+    $(SED) -n 's,.*\([0-9]\+\.[0-9]\+\)/.*,\1.0,p' | \
+	tail -1
+endef
+
+define $(PKG)_BUILD
+    mkdir "$(1)/build"
+    cd "$(1)/build" && cmake .. \
+        -DCMAKE_TOOLCHAIN_FILE="$(CMAKE_TOOLCHAIN_FILE)" \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DKDE_INSTALL_USE_QT_SYS_PATHS=ON -DKDE_L10N_AUTO_TRANSLATIONS=ON \
+        -DBUILD_TESTING=OFF
+    $(MAKE) -C "$(1)/build" -j $(JOBS) install
+endef

--- a/plugins/kdeframeworks/kcompletion.mk
+++ b/plugins/kdeframeworks/kcompletion.mk
@@ -1,0 +1,25 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+PKG             := kcompletion
+$(PKG)_VERSION  := 5.49.0
+$(PKG)_CHECKSUM  := 715d5d1f75fdd64458aae6391ca288d743c2b98043d418c846b3d98f2d377999
+$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.xz
+$(PKG)_HOME     := http://download.kde.org/stable/frameworks
+$(PKG)_URL      := $($(PKG)_HOME)/$(basename $($(PKG)_VERSION))/$($(PKG)_FILE)
+$(PKG)_DEPS     := qtbase extra-cmake-modules kconfig
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- http://download.kde.org/stable/frameworks/ | \
+    $(SED) -n 's,.*\([0-9]\+\.[0-9]\+\)/.*,\1.0,p' | \
+	tail -1
+endef
+
+define $(PKG)_BUILD
+    mkdir "$(1)/build"
+    cd "$(1)/build" && cmake .. \
+        -DCMAKE_TOOLCHAIN_FILE="$(CMAKE_TOOLCHAIN_FILE)" \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DKDE_INSTALL_USE_QT_SYS_PATHS=ON -DKDE_L10N_AUTO_TRANSLATIONS=ON \
+        -DBUILD_TESTING=OFF
+    $(MAKE) -C "$(1)/build" -j $(JOBS) install
+endef

--- a/plugins/kdeframeworks/kconfig.mk
+++ b/plugins/kdeframeworks/kconfig.mk
@@ -1,0 +1,25 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+PKG             := kconfig
+$(PKG)_VERSION  := 5.49.0
+$(PKG)_CHECKSUM := 4e3f2b98fd15fa9c90763fe6fca79f75324f1aee6efa81af2d19a24c6d666331
+$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.xz
+$(PKG)_HOME     := http://download.kde.org/stable/frameworks
+$(PKG)_URL      := $($(PKG)_HOME)/$(basename $($(PKG)_VERSION))/$($(PKG)_FILE)
+$(PKG)_DEPS     := qtbase extra-cmake-modules qttools
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- http://download.kde.org/stable/frameworks/ | \
+    $(SED) -n 's,.*\([0-9]\+\.[0-9]\+\)/.*,\1.0,p' | \
+	tail -1
+endef
+
+define $(PKG)_BUILD
+    mkdir "$(1)/build"
+    cd "$(1)/build" && cmake .. \
+        -DCMAKE_TOOLCHAIN_FILE="$(CMAKE_TOOLCHAIN_FILE)" \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DKDE_INSTALL_USE_QT_SYS_PATHS=ON -DKDE_L10N_AUTO_TRANSLATIONS=ON \
+        -DBUILD_TESTING=OFF
+    $(MAKE) -C "$(1)/build" -j $(JOBS) install
+endef

--- a/plugins/kdeframeworks/kconfigwidgets.mk
+++ b/plugins/kdeframeworks/kconfigwidgets.mk
@@ -1,0 +1,25 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+PKG             := kconfigwidgets
+$(PKG)_VERSION  := 5.49.0
+$(PKG)_CHECKSUM  := 7fc65e3ccc3522a307d1e0baa4d51261c2d7d82fa40f9405de73d46332ce0cdb
+$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.xz
+$(PKG)_HOME     := http://download.kde.org/stable/frameworks
+$(PKG)_URL      := $($(PKG)_HOME)/$(basename $($(PKG)_VERSION))/$($(PKG)_FILE)
+$(PKG)_DEPS     := qtbase extra-cmake-modules kauth kcoreaddons kcodecs kconfig kguiaddons ki18n kwidgetsaddons
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- http://download.kde.org/stable/frameworks/ | \
+    $(SED) -n 's,.*\([0-9]\+\.[0-9]\+\)/.*,\1.0,p' | \
+	tail -1
+endef
+
+define $(PKG)_BUILD
+    mkdir "$(1)/build"
+    cd "$(1)/build" && cmake .. \
+        -DCMAKE_TOOLCHAIN_FILE="$(CMAKE_TOOLCHAIN_FILE)" \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DKDE_INSTALL_USE_QT_SYS_PATHS=ON -DKDE_L10N_AUTO_TRANSLATIONS=ON \
+        -DBUILD_TESTING=OFF
+    $(MAKE) -C "$(1)/build" -j $(JOBS) install
+endef

--- a/plugins/kdeframeworks/kcoreaddons-1-fix-using-desktoptojson_executable.patch
+++ b/plugins/kdeframeworks/kcoreaddons-1-fix-using-desktoptojson_executable.patch
@@ -1,0 +1,15 @@
+--- a/KF5CoreAddonsConfig.cmake.in	2017-03-23 16:42:26.597795068 +0100
++++ b/KF5CoreAddonsConfig.cmake.in	2017-03-23 16:46:46.384418763 +0100
+@@ -8,9 +8,10 @@
+     find_file(TARGETSFILE KF5CoreAddons/KF5CoreAddonsToolingTargets.cmake PATHS ${KF5_HOST_TOOLING} ${CMAKE_CURRENT_LIST_DIR} NO_DEFAULT_PATH)
+     include("${TARGETSFILE}")
+ else()
+-    include("${CMAKE_CURRENT_LIST_DIR}/KF5CoreAddonsToolingTargets.cmake")
++    #include("${CMAKE_CURRENT_LIST_DIR}/KF5CoreAddonsToolingTargets.cmake")
+     if(CMAKE_CROSSCOMPILING AND DESKTOPTOJSON_EXECUTABLE)
+-        set_target_properties(KF5::desktoptojson PROPERTIES IMPORTED_LOCATION_NONE ${DESKTOPTOJSON_EXECUTABLE})
++        #set_target_properties(KF5::desktoptojson PROPERTIES IMPORTED_LOCATION_NONE ${DESKTOPTOJSON_EXECUTABLE})
++        add_executable(KF5::desktoptojson IMPORTED GLOBAL)
+         set_target_properties(KF5::desktoptojson PROPERTIES IMPORTED_LOCATION ${DESKTOPTOJSON_EXECUTABLE})
+     endif()
+ endif()

--- a/plugins/kdeframeworks/kcoreaddons.mk
+++ b/plugins/kdeframeworks/kcoreaddons.mk
@@ -1,0 +1,32 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+PKG             := kcoreaddons
+$(PKG)_VERSION  := 5.49.0
+$(PKG)_CHECKSUM := 12afb12f79505614f6d5624d6c39b90b5fc39e4b1b5ddb2203622bbeb6144203
+$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.xz
+$(PKG)_HOME     := http://download.kde.org/stable/frameworks
+$(PKG)_URL      := $($(PKG)_HOME)/$(basename $($(PKG)_VERSION))/$($(PKG)_FILE)
+$(PKG)_DEPS     := qtbase extra-cmake-modules
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- http://download.kde.org/stable/frameworks/ | \
+    $(SED) -n 's,.*\([0-9]\+\.[0-9]\+\)/.*,\1.0,p' | \
+	tail -1
+endef
+
+define $(PKG)_BUILD
+	cd "$(1)/src/desktoptojson" && \
+		$(BUILD_CXX) -std=c++11 -fPIC \
+		$(shell pkg-config --cflags Qt5Core --libs Qt5Core) \
+		-DBUILDING_DESKTOPTOJSON_TOOL \
+		-o $(PREFIX)/bin/desktoptojson \
+		main.cpp desktoptojson.cpp ../lib/plugin/desktopfileparser.cpp
+
+    mkdir "$(1)/build"
+    cd "$(1)/build" && cmake .. \
+        -DCMAKE_TOOLCHAIN_FILE="$(CMAKE_TOOLCHAIN_FILE)" \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DKDE_INSTALL_USE_QT_SYS_PATHS=ON -DKDE_L10N_AUTO_TRANSLATIONS=ON \
+        -DBUILD_TESTING=OFF
+    $(MAKE) -C "$(1)/build" -j $(JOBS) install
+endef

--- a/plugins/kdeframeworks/kcrash.mk
+++ b/plugins/kdeframeworks/kcrash.mk
@@ -1,0 +1,25 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+PKG             := kcrash
+$(PKG)_VERSION  := 5.49.0
+$(PKG)_CHECKSUM  := 6315a1607aba1945d3d91092b9440f222f1bb25a8bf01cb0bd507540734eb976
+$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.xz
+$(PKG)_HOME     := http://download.kde.org/stable/frameworks
+$(PKG)_URL      := $($(PKG)_HOME)/$(basename $($(PKG)_VERSION))/$($(PKG)_FILE)
+$(PKG)_DEPS     := qtbase extra-cmake-modules kcoreaddons kwindowsystem
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- http://download.kde.org/stable/frameworks/ | \
+    $(SED) -n 's,.*\([0-9]\+\.[0-9]\+\)/.*,\1.0,p' | \
+	tail -1
+endef
+
+define $(PKG)_BUILD
+    mkdir "$(1)/build"
+    cd "$(1)/build" && cmake .. \
+        -DCMAKE_TOOLCHAIN_FILE="$(CMAKE_TOOLCHAIN_FILE)" \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DKDE_INSTALL_USE_QT_SYS_PATHS=ON -DKDE_L10N_AUTO_TRANSLATIONS=ON \
+        -DBUILD_TESTING=OFF
+    $(MAKE) -C "$(1)/build" -j $(JOBS) install
+endef

--- a/plugins/kdeframeworks/kdbusaddons.mk
+++ b/plugins/kdeframeworks/kdbusaddons.mk
@@ -1,0 +1,25 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+PKG             := kdbusaddons
+$(PKG)_VERSION  := 5.49.0
+$(PKG)_CHECKSUM := 70c5e439c2ecfa56ef0d65492ad77fd85fea7ea47fe2efa4e76e8eeb5cced5ba
+$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.xz
+$(PKG)_HOME     := http://download.kde.org/stable/frameworks
+$(PKG)_URL      := $($(PKG)_HOME)/$(basename $($(PKG)_VERSION))/$($(PKG)_FILE)
+$(PKG)_DEPS     := qtbase extra-cmake-modules
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- http://download.kde.org/stable/frameworks/ | \
+    $(SED) -n 's,.*\([0-9]\+\.[0-9]\+\)/.*,\1.0,p' | \
+	tail -1
+endef
+
+define $(PKG)_BUILD
+    mkdir "$(1)/build"
+    cd "$(1)/build" && cmake .. \
+        -DCMAKE_TOOLCHAIN_FILE="$(CMAKE_TOOLCHAIN_FILE)" \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DKDE_INSTALL_USE_QT_SYS_PATHS=ON -DKDE_L10N_AUTO_TRANSLATIONS=ON \
+        -DBUILD_TESTING=OFF
+    $(MAKE) -C "$(1)/build" -j $(JOBS) install
+endef

--- a/plugins/kdeframeworks/kdeclarative.mk
+++ b/plugins/kdeframeworks/kdeclarative.mk
@@ -1,0 +1,30 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+PKG             := kdeclarative
+$(PKG)_VERSION  := 5.49.0
+$(PKG)_CHECKSUM  := 49bbdf17f1ba3212b96ab8ebfbc31c78b3772b04b2f3c9c4b49a74c7d1e2ea4d
+$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.xz
+$(PKG)_HOME     := http://download.kde.org/stable/frameworks
+$(PKG)_URL      := $($(PKG)_HOME)/$(basename $($(PKG)_VERSION))/$($(PKG)_FILE)
+$(PKG)_DEPS     := qtbase extra-cmake-modules \
+	kconfig ki18n kiconthemes kio kwidgetsaddons \
+	kwindowsystem kglobalaccel kguiaddons kpackage
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- http://download.kde.org/stable/frameworks/ | \
+    $(SED) -n 's,.*\([0-9]\+\.[0-9]\+\)/.*,\1.0,p' | \
+	tail -1
+endef
+
+define $(PKG)_BUILD
+    mkdir "$(1)/build"
+    cd "$(1)/build" && cmake .. \
+        -DCMAKE_TOOLCHAIN_FILE="$(CMAKE_TOOLCHAIN_FILE)" \
+        -DCMAKE_CROSSCOMPILING=ON \
+        -DKF5_HOST_TOOLING=/usr/lib/x86_64-linux-gnu/cmake \
+        -DKCONFIGCOMPILER_PATH=/usr/lib/x86_64-linux-gnu/cmake/KF5Config/KF5ConfigCompilerTargets.cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DKDE_INSTALL_USE_QT_SYS_PATHS=ON -DKDE_L10N_AUTO_TRANSLATIONS=ON \
+        -DBUILD_TESTING=OFF
+    $(MAKE) -C "$(1)/build" -j $(JOBS) install
+endef

--- a/plugins/kdeframeworks/kdecoration.mk
+++ b/plugins/kdeframeworks/kdecoration.mk
@@ -1,0 +1,28 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+PKG             := kdecoration
+$(PKG)_VERSION  := 5.10.2
+$(PKG)_CHECKSUM  := 7ca62e41c76d1d3df31c83ea1ac49cf3746e64786679d4eb30dd79c59442af16
+$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.xz
+$(PKG)_HOME     := http://download.kde.org/stable/plasma
+$(PKG)_URL      := $($(PKG)_HOME)/$(basename $($(PKG)_VERSION))/$($(PKG)_FILE)
+$(PKG)_DEPS     := qtbase extra-cmake-modules
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- http://download.kde.org/stable/plasma/ | \
+    $(SED) -n 's,.*\([0-9]\+\.[0-9]\+\)/.*,\1.0,p' | \
+	tail -1
+endef
+
+define $(PKG)_BUILD
+    mkdir "$(1)/build"
+    cd "$(1)/build" && cmake .. \
+        -DCMAKE_TOOLCHAIN_FILE="$(CMAKE_TOOLCHAIN_FILE)" \
+        -DCMAKE_CROSSCOMPILING=ON \
+        -DKF5_HOST_TOOLING=/usr/lib/x86_64-linux-gnu/cmake \
+        -DKCONFIGCOMPILER_PATH=/usr/lib/x86_64-linux-gnu/cmake/KF5Config/KF5ConfigCompilerTargets.cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DKDE_INSTALL_USE_QT_SYS_PATHS=ON -DKDE_L10N_AUTO_TRANSLATIONS=ON \
+        -DBUILD_TESTING=OFF
+    $(MAKE) -C "$(1)/build" -j $(JOBS) install
+endef

--- a/plugins/kdeframeworks/kded.mk
+++ b/plugins/kdeframeworks/kded.mk
@@ -1,0 +1,26 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+PKG             := kded
+$(PKG)_VERSION  := 5.49.0
+$(PKG)_CHECKSUM  := cc7f716e2086f44410aa13b8415aad1dcf9ce1c8c78ec7250a66e875f5d0d0d0
+$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.xz
+$(PKG)_HOME     := http://download.kde.org/stable/frameworks
+$(PKG)_URL      := $($(PKG)_HOME)/$(basename $($(PKG)_VERSION))/$($(PKG)_FILE)
+$(PKG)_DEPS     := qtbase extra-cmake-modules kconfig kcoreaddons kcrash kdbusaddons kservice kinit
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- http://download.kde.org/stable/frameworks/ | \
+    $(SED) -n 's,.*\([0-9]\+\.[0-9]\+\)/.*,\1.0,p' | \
+	tail -1
+endef
+
+define $(PKG)_BUILD
+    mkdir "$(1)/build"
+    cd "$(1)/build" && cmake .. \
+        -DCMAKE_TOOLCHAIN_FILE="$(CMAKE_TOOLCHAIN_FILE)" \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DKDE_INSTALL_USE_QT_SYS_PATHS=ON -DKDE_L10N_AUTO_TRANSLATIONS=ON \
+        -DBUILD_TESTING=OFF
+    $(MAKE) -C "$(1)/build" -j $(JOBS)
+    $(MAKE) -C "$(1)/build" -j $(JOBS) install
+endef

--- a/plugins/kdeframeworks/kfilemetadata.mk
+++ b/plugins/kdeframeworks/kfilemetadata.mk
@@ -1,0 +1,26 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+PKG             := kfilemetadata
+$(PKG)_VERSION  := 5.49.0
+$(PKG)_CHECKSUM  := 00cd6d49c8046a83eb2d40309c375bf5c36f532281ea92b5c3e04d645f0db310
+$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.xz
+$(PKG)_HOME     := http://download.kde.org/stable/frameworks
+$(PKG)_URL      := $($(PKG)_HOME)/$(basename $($(PKG)_VERSION))/$($(PKG)_FILE)
+$(PKG)_DEPS     := qtbase extra-cmake-modules karchive ki18n
+# poppler
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- http://download.kde.org/stable/frameworks/ | \
+    $(SED) -n 's,.*\([0-9]\+\.[0-9]\+\)/.*,\1.0,p' | \
+	tail -1
+endef
+
+define $(PKG)_BUILD
+    mkdir "$(1)/build"
+    cd "$(1)/build" && cmake .. \
+        -DCMAKE_TOOLCHAIN_FILE="$(CMAKE_TOOLCHAIN_FILE)" \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DKDE_INSTALL_USE_QT_SYS_PATHS=ON -DKDE_L10N_AUTO_TRANSLATIONS=ON \
+        -DBUILD_TESTING=OFF
+    $(MAKE) -C "$(1)/build" -j $(JOBS) install
+endef

--- a/plugins/kdeframeworks/kglobalaccel.mk
+++ b/plugins/kdeframeworks/kglobalaccel.mk
@@ -1,0 +1,25 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+PKG             := kglobalaccel
+$(PKG)_VERSION  := 5.49.0
+$(PKG)_CHECKSUM  := 147ed37e1ceb39d4d40e5e94a73e8b9519be7da9f08eea23aefa64eebee267ba
+$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.xz
+$(PKG)_HOME     := http://download.kde.org/stable/frameworks
+$(PKG)_URL      := $($(PKG)_HOME)/$(basename $($(PKG)_VERSION))/$($(PKG)_FILE)
+$(PKG)_DEPS     := qtbase extra-cmake-modules kconfig kcoreaddons kcrash kdbusaddons ki18n kwindowsystem kservice
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- http://download.kde.org/stable/frameworks/ | \
+    $(SED) -n 's,.*\([0-9]\+\.[0-9]\+\)/.*,\1.0,p' | \
+	tail -1
+endef
+
+define $(PKG)_BUILD
+    mkdir "$(1)/build"
+    cd "$(1)/build" && cmake .. \
+        -DCMAKE_TOOLCHAIN_FILE="$(CMAKE_TOOLCHAIN_FILE)" \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DKDE_INSTALL_USE_QT_SYS_PATHS=ON -DKDE_L10N_AUTO_TRANSLATIONS=ON \
+        -DBUILD_TESTING=OFF
+    $(MAKE) -C "$(1)/build" -j $(JOBS) install
+endef

--- a/plugins/kdeframeworks/kguiaddons.mk
+++ b/plugins/kdeframeworks/kguiaddons.mk
@@ -1,0 +1,25 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+PKG             := kguiaddons
+$(PKG)_VERSION  := 5.49.0
+$(PKG)_CHECKSUM := b393163c4ca80f08126d9601e70d2a705fdb157e6dd1c4188d7bfb5be86872fe
+$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.xz
+$(PKG)_HOME     := http://download.kde.org/stable/frameworks
+$(PKG)_URL      := $($(PKG)_HOME)/$(basename $($(PKG)_VERSION))/$($(PKG)_FILE)
+$(PKG)_DEPS     := qtbase extra-cmake-modules
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- http://download.kde.org/stable/frameworks/ | \
+    $(SED) -n 's,.*\([0-9]\+\.[0-9]\+\)/.*,\1.0,p' | \
+	tail -1
+endef
+
+define $(PKG)_BUILD
+    mkdir "$(1)/build"
+    cd "$(1)/build" && cmake .. \
+        -DCMAKE_TOOLCHAIN_FILE="$(CMAKE_TOOLCHAIN_FILE)" \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DKDE_INSTALL_USE_QT_SYS_PATHS=ON -DKDE_L10N_AUTO_TRANSLATIONS=ON \
+        -DBUILD_TESTING=OFF
+    $(MAKE) -C "$(1)/build" -j $(JOBS) install
+endef

--- a/plugins/kdeframeworks/ki18n.mk
+++ b/plugins/kdeframeworks/ki18n.mk
@@ -1,0 +1,26 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+PKG             := ki18n
+$(PKG)_VERSION  := 5.49.0
+$(PKG)_CHECKSUM := 5f4a54e755990104537729f4c26e054f146cd20acdd5e90cfd8558ab7a6e99c4
+$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.xz
+$(PKG)_HOME     := http://download.kde.org/stable/frameworks
+$(PKG)_URL      := $($(PKG)_HOME)/$(basename $($(PKG)_VERSION))/$($(PKG)_FILE)
+$(PKG)_DEPS     := qtbase extra-cmake-modules qttools gettext \
+ qtscript 
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- http://download.kde.org/stable/frameworks/ | \
+    $(SED) -n 's,.*\([0-9]\+\.[0-9]\+\)/.*,\1.0,p' | \
+	tail -1
+endef
+
+define $(PKG)_BUILD
+    mkdir "$(1)/build"
+    cd "$(1)/build" && cmake .. \
+        -DCMAKE_TOOLCHAIN_FILE="$(CMAKE_TOOLCHAIN_FILE)" \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DKDE_INSTALL_USE_QT_SYS_PATHS=ON -DKDE_L10N_AUTO_TRANSLATIONS=ON \
+        -DBUILD_TESTING=OFF
+    $(MAKE) -C "$(1)/build" -j $(JOBS) install
+endef

--- a/plugins/kdeframeworks/kiconthemes.mk
+++ b/plugins/kdeframeworks/kiconthemes.mk
@@ -1,0 +1,25 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+PKG             := kiconthemes
+$(PKG)_VERSION  := 5.49.0
+$(PKG)_CHECKSUM  := 55b0708aaffb8e1d2e5dfede6a378a2f35386bf585e7294fadc08958b599f7b8
+$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.xz
+$(PKG)_HOME     := http://download.kde.org/stable/frameworks
+$(PKG)_URL      := $($(PKG)_HOME)/$(basename $($(PKG)_VERSION))/$($(PKG)_FILE)
+$(PKG)_DEPS     := qtbase extra-cmake-modules qtsvg karchive ki18n kconfigwidgets kwidgetsaddons kitemviews breeze-icons
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- http://download.kde.org/stable/frameworks/ | \
+    $(SED) -n 's,.*\([0-9]\+\.[0-9]\+\)/.*,\1.0,p' | \
+	tail -1
+endef
+
+define $(PKG)_BUILD
+    mkdir "$(1)/build"
+    cd "$(1)/build" && cmake .. \
+        -DCMAKE_TOOLCHAIN_FILE="$(CMAKE_TOOLCHAIN_FILE)" \
+        -DCMAKE_BUILD_TYPE=Debug \
+        -DKDE_INSTALL_USE_QT_SYS_PATHS=ON -DKDE_L10N_AUTO_TRANSLATIONS=ON \
+        -DBUILD_TESTING=OFF
+    $(MAKE) -C "$(1)/build" -j $(JOBS) install
+endef

--- a/plugins/kdeframeworks/kinit.mk
+++ b/plugins/kdeframeworks/kinit.mk
@@ -1,0 +1,26 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+PKG             := kinit
+$(PKG)_VERSION  := 5.49.0
+$(PKG)_CHECKSUM  := 25b5e07c2dd651a96f79ea58e0a76a172aac4b818892641adf97bdf6525909e7
+$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.xz
+$(PKG)_HOME     := http://download.kde.org/stable/frameworks
+$(PKG)_URL      := $($(PKG)_HOME)/$(basename $($(PKG)_VERSION))/$($(PKG)_FILE)
+$(PKG)_DEPS     := qtbase extra-cmake-modules kio kcrash kconfig ki18n kservice kwindowsystem
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- http://download.kde.org/stable/frameworks/ | \
+    $(SED) -n 's,.*\([0-9]\+\.[0-9]\+\)/.*,\1.0,p' | \
+	tail -1
+endef
+
+define $(PKG)_BUILD
+    mkdir "$(1)/build"
+    cd "$(1)/build" && cmake .. \
+        -DCMAKE_TOOLCHAIN_FILE="$(CMAKE_TOOLCHAIN_FILE)" \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DKDE_INSTALL_USE_QT_SYS_PATHS=ON -DKDE_L10N_AUTO_TRANSLATIONS=ON \
+        -DBUILD_TESTING=OFF
+    $(MAKE) -C "$(1)/build" -j $(JOBS)
+    $(MAKE) -C "$(1)/build" -j $(JOBS) install
+endef

--- a/plugins/kdeframeworks/kio.mk
+++ b/plugins/kdeframeworks/kio.mk
@@ -1,0 +1,29 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+PKG             := kio
+$(PKG)_VERSION  := 5.49.0
+$(PKG)_CHECKSUM  := f3089c1746dcd86d100b57a011e6f6fcbdf0622bad6f546e63048815de783a67
+$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.xz
+$(PKG)_HOME     := http://download.kde.org/stable/frameworks
+$(PKG)_URL      := $($(PKG)_HOME)/$(basename $($(PKG)_VERSION))/$($(PKG)_FILE)
+$(PKG)_DEPS     := qtbase extra-cmake-modules \
+	karchive kcodecs kconfig kcoreaddons kdbusaddons ki18n kitemviews solid kwidgetsaddons kwindowsystem \
+	kcompletion kjobwidgets \
+	kbookmarks kconfigwidgets kiconthemes knotifications kservice kxmlgui kwallet
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- http://download.kde.org/stable/frameworks/ | \
+    $(SED) -n 's,.*\([0-9]\+\.[0-9]\+\)/.*,\1.0,p' | \
+	tail -1
+endef
+
+define $(PKG)_BUILD
+    mkdir "$(1)/build"
+    cd "$(1)/build" && cmake .. \
+        -DCMAKE_TOOLCHAIN_FILE="$(CMAKE_TOOLCHAIN_FILE)" \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DKDE_INSTALL_USE_QT_SYS_PATHS=ON -DKDE_L10N_AUTO_TRANSLATIONS=ON \
+        -DDESKTOPTOJSON_EXECUTABLE=$(PREFIX)/bin/desktoptojson \
+        -DBUILD_TESTING=OFF
+    $(MAKE) -C "$(1)/build" -j $(JOBS) install
+endef

--- a/plugins/kdeframeworks/kitemviews.mk
+++ b/plugins/kdeframeworks/kitemviews.mk
@@ -1,0 +1,25 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+PKG             := kitemviews
+$(PKG)_VERSION  := 5.49.0
+$(PKG)_CHECKSUM  := b75d7cfcde8c3a9c0d24b1509db074bdd835d2eac2819856265c9c2b700146aa
+$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.xz
+$(PKG)_HOME     := http://download.kde.org/stable/frameworks
+$(PKG)_URL      := $($(PKG)_HOME)/$(basename $($(PKG)_VERSION))/$($(PKG)_FILE)
+$(PKG)_DEPS     := qtbase extra-cmake-modules qttools
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- http://download.kde.org/stable/frameworks/ | \
+    $(SED) -n 's,.*\([0-9]\+\.[0-9]\+\)/.*,\1.0,p' | \
+	tail -1
+endef
+
+define $(PKG)_BUILD
+    mkdir "$(1)/build"
+    cd "$(1)/build" && cmake .. \
+        -DCMAKE_TOOLCHAIN_FILE="$(CMAKE_TOOLCHAIN_FILE)" \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DKDE_INSTALL_USE_QT_SYS_PATHS=ON -DKDE_L10N_AUTO_TRANSLATIONS=ON \
+        -DBUILD_TESTING=OFF
+    $(MAKE) -C "$(1)/build" -j $(JOBS) install
+endef

--- a/plugins/kdeframeworks/kjobwidgets.mk
+++ b/plugins/kdeframeworks/kjobwidgets.mk
@@ -1,0 +1,25 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+PKG             := kjobwidgets
+$(PKG)_VERSION  := 5.49.0
+$(PKG)_CHECKSUM  := af0c5a67ed60cf8d8f46bc5865569f6de15809812d4435b204f6c4d8d7662512
+$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.xz
+$(PKG)_HOME     := http://download.kde.org/stable/frameworks
+$(PKG)_URL      := $($(PKG)_HOME)/$(basename $($(PKG)_VERSION))/$($(PKG)_FILE)
+$(PKG)_DEPS     := qtbase extra-cmake-modules kcoreaddons kwidgetsaddons
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- http://download.kde.org/stable/frameworks/ | \
+    $(SED) -n 's,.*\([0-9]\+\.[0-9]\+\)/.*,\1.0,p' | \
+	tail -1
+endef
+
+define $(PKG)_BUILD
+    mkdir "$(1)/build"
+    cd "$(1)/build" && cmake .. \
+        -DCMAKE_TOOLCHAIN_FILE="$(CMAKE_TOOLCHAIN_FILE)" \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DKDE_INSTALL_USE_QT_SYS_PATHS=ON -DKDE_L10N_AUTO_TRANSLATIONS=ON \
+        -DBUILD_TESTING=OFF
+    $(MAKE) -C "$(1)/build" -j $(JOBS) install
+endef

--- a/plugins/kdeframeworks/knewstuff.mk
+++ b/plugins/kdeframeworks/knewstuff.mk
@@ -1,0 +1,25 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+PKG             := knewstuff
+$(PKG)_VERSION  := 5.49.0
+$(PKG)_CHECKSUM  := b32eb46afc101771e9d50ed96aec3dc186e8fdb09c050ad2400fb39cbea00cee
+$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.xz
+$(PKG)_HOME     := http://download.kde.org/stable/frameworks
+$(PKG)_URL      := $($(PKG)_HOME)/$(basename $($(PKG)_VERSION))/$($(PKG)_FILE)
+$(PKG)_DEPS     := qtbase extra-cmake-modules karchive kcompletion kconfig kcoreaddons ki18n kiconthemes kio kitemviews ktextwidgets kwidgetsaddons kxmlgui
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- http://download.kde.org/stable/frameworks/ | \
+    $(SED) -n 's,.*\([0-9]\+\.[0-9]\+\)/.*,\1.0,p' | \
+	tail -1
+endef
+
+define $(PKG)_BUILD
+    mkdir "$(1)/build"
+    cd "$(1)/build" && cmake .. \
+        -DCMAKE_TOOLCHAIN_FILE="$(CMAKE_TOOLCHAIN_FILE)" \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DKDE_INSTALL_USE_QT_SYS_PATHS=ON -DKDE_L10N_AUTO_TRANSLATIONS=ON \
+        -DBUILD_TESTING=OFF
+    $(MAKE) -C "$(1)/build" -j $(JOBS) install
+endef

--- a/plugins/kdeframeworks/knotifications.mk
+++ b/plugins/kdeframeworks/knotifications.mk
@@ -1,0 +1,25 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+PKG             := knotifications
+$(PKG)_VERSION  := 5.49.0
+$(PKG)_CHECKSUM  := a9b55f92ceb1bbd1804e9b5ad52ca0d25bfa561781c46e42c310d31c850c8880
+$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.xz
+$(PKG)_HOME     := http://download.kde.org/stable/frameworks
+$(PKG)_URL      := $($(PKG)_HOME)/$(basename $($(PKG)_VERSION))/$($(PKG)_FILE)
+$(PKG)_DEPS     := qtbase extra-cmake-modules kwindowsystem kservice kconfig kiconthemes kcodecs kcoreaddons phonon
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- http://download.kde.org/stable/frameworks/ | \
+    $(SED) -n 's,.*\([0-9]\+\.[0-9]\+\)/.*,\1.0,p' | \
+	tail -1
+endef
+
+define $(PKG)_BUILD
+    mkdir "$(1)/build"
+    cd "$(1)/build" && cmake .. \
+        -DCMAKE_TOOLCHAIN_FILE="$(CMAKE_TOOLCHAIN_FILE)" \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DKDE_INSTALL_USE_QT_SYS_PATHS=ON -DKDE_L10N_AUTO_TRANSLATIONS=ON \
+        -DBUILD_TESTING=OFF
+    $(MAKE) -C "$(1)/build" -j $(JOBS) install
+endef

--- a/plugins/kdeframeworks/knotifyconfig.mk
+++ b/plugins/kdeframeworks/knotifyconfig.mk
@@ -1,0 +1,25 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+PKG             := knotifyconfig
+$(PKG)_VERSION  := 5.49.0
+$(PKG)_CHECKSUM  := cad17429256dfae8808c3d14b7e639794a9b81071670c8957858a3d40b566427
+$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.xz
+$(PKG)_HOME     := http://download.kde.org/stable/frameworks
+$(PKG)_URL      := $($(PKG)_HOME)/$(basename $($(PKG)_VERSION))/$($(PKG)_FILE)
+$(PKG)_DEPS     := qtbase extra-cmake-modules kcompletion kconfig ki18n kio kservice
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- http://download.kde.org/stable/frameworks/ | \
+    $(SED) -n 's,.*\([0-9]\+\.[0-9]\+\)/.*,\1.0,p' | \
+	tail -1
+endef
+
+define $(PKG)_BUILD
+    mkdir "$(1)/build"
+    cd "$(1)/build" && cmake .. \
+        -DCMAKE_TOOLCHAIN_FILE="$(CMAKE_TOOLCHAIN_FILE)" \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DKDE_INSTALL_USE_QT_SYS_PATHS=ON -DKDE_L10N_AUTO_TRANSLATIONS=ON \
+        -DBUILD_TESTING=OFF
+    $(MAKE) -C "$(1)/build" -j $(JOBS) install
+endef

--- a/plugins/kdeframeworks/kpackage.mk
+++ b/plugins/kdeframeworks/kpackage.mk
@@ -1,0 +1,30 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+PKG             := kpackage
+$(PKG)_VERSION  := 5.49.0
+$(PKG)_CHECKSUM  := 8d4dab6fd11b4e565e38590a9d8f98f85b26814eb56808de43ce3db23a976ef5
+$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.xz
+$(PKG)_HOME     := http://download.kde.org/stable/frameworks
+$(PKG)_URL      := $($(PKG)_HOME)/$(basename $($(PKG)_VERSION))/$($(PKG)_FILE)
+$(PKG)_DEPS     := qtbase extra-cmake-modules breeze-icons kdecoration
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- http://download.kde.org/stable/frameworks/ | \
+    $(SED) -n 's,.*\([0-9]\+\.[0-9]\+\)/.*,\1.0,p' | \
+	tail -1
+endef
+
+define $(PKG)_BUILD
+	# mkdir "$(1)/build-kpackagetool5"
+	# cd "$(1)/build-kpackagetool5" && cmake .. -DCMAKE_PREFIX_PATH=/usr/lib/x86_64-linux-gnu/cmake/
+	# $(MAKE) -C "$(1)/build-kpackagetool5" -j $(JOBS) kpackagetool5
+	# cp "$(1)/build-kpackagetool5/src/kpackagetool/kpackagetool5" $(PREFIX)/bin
+	# cp "$(1)/build-kpackagetool5/src/kpackage/libKF5Package.so*" $(PREFIX)/lib
+    mkdir "$(1)/build"
+    cd "$(1)/build" && cmake .. \
+        -DCMAKE_TOOLCHAIN_FILE="$(CMAKE_TOOLCHAIN_FILE)" \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DKDE_INSTALL_USE_QT_SYS_PATHS=ON -DKDE_L10N_AUTO_TRANSLATIONS=ON \
+        -DBUILD_TESTING=OFF
+    $(MAKE) -C "$(1)/build" -j $(JOBS) install
+endef

--- a/plugins/kdeframeworks/kplotting.mk
+++ b/plugins/kdeframeworks/kplotting.mk
@@ -1,0 +1,25 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+PKG             := kplotting
+$(PKG)_VERSION  := 5.49.0
+$(PKG)_CHECKSUM  := c0869429fc17d2215fe616c6a857aefa62d26561342d5fac5192e8ee27c6df8d
+$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.xz
+$(PKG)_HOME     := http://download.kde.org/stable/frameworks
+$(PKG)_URL      := $($(PKG)_HOME)/$(basename $($(PKG)_VERSION))/$($(PKG)_FILE)
+$(PKG)_DEPS     := qtbase extra-cmake-modules
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- http://download.kde.org/stable/frameworks/ | \
+    $(SED) -n 's,.*\([0-9]\+\.[0-9]\+\)/.*,\1.0,p' | \
+	tail -1
+endef
+
+define $(PKG)_BUILD
+    mkdir "$(1)/build"
+    cd "$(1)/build" && cmake .. \
+        -DCMAKE_TOOLCHAIN_FILE="$(CMAKE_TOOLCHAIN_FILE)" \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DKDE_INSTALL_USE_QT_SYS_PATHS=ON -DKDE_L10N_AUTO_TRANSLATIONS=ON \
+        -DBUILD_TESTING=OFF
+    $(MAKE) -C "$(1)/build" -j $(JOBS) install
+endef

--- a/plugins/kdeframeworks/kservice.mk
+++ b/plugins/kdeframeworks/kservice.mk
@@ -1,0 +1,25 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+PKG             := kservice
+$(PKG)_VERSION  := 5.49.0
+$(PKG)_CHECKSUM  := 1fd516e6454523707bd173b253fdde5fd39c0b60b3a943ae096b38540d338bf3
+$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.xz
+$(PKG)_HOME     := http://download.kde.org/stable/frameworks
+$(PKG)_URL      := $($(PKG)_HOME)/$(basename $($(PKG)_VERSION))/$($(PKG)_FILE)
+$(PKG)_DEPS     := qtbase extra-cmake-modules kconfig kcoreaddons kcrash kdbusaddons ki18n
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- http://download.kde.org/stable/frameworks/ | \
+    $(SED) -n 's,.*\([0-9]\+\.[0-9]\+\)/.*,\1.0,p' | \
+	tail -1
+endef
+
+define $(PKG)_BUILD
+    mkdir "$(1)/build"
+    cd "$(1)/build" && cmake .. \
+        -DCMAKE_TOOLCHAIN_FILE="$(CMAKE_TOOLCHAIN_FILE)" \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DKDE_INSTALL_USE_QT_SYS_PATHS=ON -DKDE_L10N_AUTO_TRANSLATIONS=ON \
+        -DBUILD_TESTING=OFF
+    $(MAKE) -C "$(1)/build" -j $(JOBS) install
+endef

--- a/plugins/kdeframeworks/ktextwidgets.mk
+++ b/plugins/kdeframeworks/ktextwidgets.mk
@@ -1,0 +1,25 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+PKG             := ktextwidgets
+$(PKG)_VERSION  := 5.49.0
+$(PKG)_CHECKSUM  := 81eb2c1832c2fb013565ed019c9a9d55ca3b0472967e28eee4aef25ba1a6ec91
+$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.xz
+$(PKG)_HOME     := http://download.kde.org/stable/frameworks
+$(PKG)_URL      := $($(PKG)_HOME)/$(basename $($(PKG)_VERSION))/$($(PKG)_FILE)
+$(PKG)_DEPS     := qtbase extra-cmake-modules kcompletion kconfig kconfigwidgets ki18n kiconthemes kservice kwidgetsaddons kwindowsystem sonnet kconfigwidgets
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- http://download.kde.org/stable/frameworks/ | \
+    $(SED) -n 's,.*\([0-9]\+\.[0-9]\+\)/.*,\1.0,p' | \
+	tail -1
+endef
+
+define $(PKG)_BUILD
+    mkdir "$(1)/build"
+    cd "$(1)/build" && cmake .. \
+        -DCMAKE_TOOLCHAIN_FILE="$(CMAKE_TOOLCHAIN_FILE)" \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DKDE_INSTALL_USE_QT_SYS_PATHS=ON -DKDE_L10N_AUTO_TRANSLATIONS=ON \
+        -DBUILD_TESTING=OFF
+    $(MAKE) -C "$(1)/build" -j $(JOBS) install
+endef

--- a/plugins/kdeframeworks/kwallet.mk
+++ b/plugins/kdeframeworks/kwallet.mk
@@ -1,0 +1,26 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+PKG             := kwallet
+$(PKG)_VERSION  := 5.49.0
+$(PKG)_CHECKSUM  := 3fd8d7a940adc974b6ee8a9af0d3f40eae9d279eb8884d99b9d08f25939e758d
+$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.xz
+$(PKG)_HOME     := http://download.kde.org/stable/frameworks
+$(PKG)_URL      := $($(PKG)_HOME)/$(basename $($(PKG)_VERSION))/$($(PKG)_FILE)
+$(PKG)_DEPS     := qtbase extra-cmake-modules kconfig kcoreaddons kdbusaddons ki18n kiconthemes knotifications kwindowsystem libgcrypt
+                   # gpgme
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- http://download.kde.org/stable/frameworks/ | \
+    $(SED) -n 's,.*\([0-9]\+\.[0-9]\+\)/.*,\1.0,p' | \
+	tail -1
+endef
+
+define $(PKG)_BUILD
+    mkdir "$(1)/build"
+    cd "$(1)/build" && cmake .. \
+        -DCMAKE_TOOLCHAIN_FILE="$(CMAKE_TOOLCHAIN_FILE)" \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DKDE_INSTALL_USE_QT_SYS_PATHS=ON -DKDE_L10N_AUTO_TRANSLATIONS=ON \
+        -DBUILD_TESTING=OFF
+    $(MAKE) -C "$(1)/build" -j $(JOBS) install
+endef

--- a/plugins/kdeframeworks/kwidgetsaddons.mk
+++ b/plugins/kdeframeworks/kwidgetsaddons.mk
@@ -1,0 +1,25 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+PKG             := kwidgetsaddons
+$(PKG)_VERSION  := 5.49.0
+$(PKG)_CHECKSUM  := 2251de1577e7d1e379e9d9fa301e3d2705e821b8863ee3dd0d882d69d3c72fbb
+$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.xz
+$(PKG)_HOME     := http://download.kde.org/stable/frameworks
+$(PKG)_URL      := $($(PKG)_HOME)/$(basename $($(PKG)_VERSION))/$($(PKG)_FILE)
+$(PKG)_DEPS     := qtbase extra-cmake-modules
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- http://download.kde.org/stable/frameworks/ | \
+    $(SED) -n 's,.*\([0-9]\+\.[0-9]\+\)/.*,\1.0,p' | \
+	tail -1
+endef
+
+define $(PKG)_BUILD
+    mkdir "$(1)/build"
+    cd "$(1)/build" && cmake .. \
+        -DCMAKE_TOOLCHAIN_FILE="$(CMAKE_TOOLCHAIN_FILE)" \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DKDE_INSTALL_USE_QT_SYS_PATHS=ON -DKDE_L10N_AUTO_TRANSLATIONS=ON \
+        -DBUILD_TESTING=OFF
+    $(MAKE) -C "$(1)/build" -j $(JOBS) install
+endef

--- a/plugins/kdeframeworks/kwindowsystem.mk
+++ b/plugins/kdeframeworks/kwindowsystem.mk
@@ -1,0 +1,25 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+PKG             := kwindowsystem
+$(PKG)_VERSION  := 5.49.0
+$(PKG)_CHECKSUM  := d7390eca239f42033af9ebca5e3b7f2987dc605c34844ebce70a362b33ffb99c
+$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.xz
+$(PKG)_HOME     := http://download.kde.org/stable/frameworks
+$(PKG)_URL      := $($(PKG)_HOME)/$(basename $($(PKG)_VERSION))/$($(PKG)_FILE)
+$(PKG)_DEPS     := qtbase extra-cmake-modules qtwinextras
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- http://download.kde.org/stable/frameworks/ | \
+    $(SED) -n 's,.*\([0-9]\+\.[0-9]\+\)/.*,\1.0,p' | \
+	tail -1
+endef
+
+define $(PKG)_BUILD
+    mkdir "$(1)/build"
+    cd "$(1)/build" && cmake .. \
+        -DCMAKE_TOOLCHAIN_FILE="$(CMAKE_TOOLCHAIN_FILE)" \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DKDE_INSTALL_USE_QT_SYS_PATHS=ON -DKDE_L10N_AUTO_TRANSLATIONS=ON \
+        -DBUILD_TESTING=OFF
+    $(MAKE) -C "$(1)/build" -j $(JOBS) install
+endef

--- a/plugins/kdeframeworks/kxmlgui.mk
+++ b/plugins/kdeframeworks/kxmlgui.mk
@@ -1,0 +1,25 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+PKG             := kxmlgui
+$(PKG)_VERSION  := 5.49.0
+$(PKG)_CHECKSUM  := cad50edb7692432adbd402dc1220b4b621acc1882987e8332bccf2a17cd14f73
+$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.xz
+$(PKG)_HOME     := http://download.kde.org/stable/frameworks
+$(PKG)_URL      := $($(PKG)_HOME)/$(basename $($(PKG)_VERSION))/$($(PKG)_FILE)
+$(PKG)_DEPS     := qtbase extra-cmake-modules kitemviews kconfig kglobalaccel kconfigwidgets ki18n kiconthemes ktextwidgets kwidgetsaddons attica
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- http://download.kde.org/stable/frameworks/ | \
+    $(SED) -n 's,.*\([0-9]\+\.[0-9]\+\)/.*,\1.0,p' | \
+	tail -1
+endef
+
+define $(PKG)_BUILD
+    mkdir "$(1)/build"
+    cd "$(1)/build" && cmake .. \
+        -DCMAKE_TOOLCHAIN_FILE="$(CMAKE_TOOLCHAIN_FILE)" \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DKDE_INSTALL_USE_QT_SYS_PATHS=ON -DKDE_L10N_AUTO_TRANSLATIONS=ON \
+        -DBUILD_TESTING=OFF
+    $(MAKE) -C "$(1)/build" -j $(JOBS) install
+endef

--- a/plugins/kdeframeworks/overrides.mk
+++ b/plugins/kdeframeworks/overrides.mk
@@ -1,0 +1,10 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+$(info == Custom Qt overrides: $(lastword $(MAKEFILE_LIST)))
+
+# reduced qt5
+qtbase_DEPS := $(filter-out libmysqlclient postgresql freetds,$(qtbase_DEPS))
+qtbase_BUILD_SHARED = $(subst -plugin-sql-mysql, -no-sql-mysql, \
+					  $(subst -plugin-sql-psql, -no-sql-psql, \
+					  $(subst -plugin-sql-tds, -no-sql-tds, \
+					  $(subst -static, -shared, $(qtbase_BUILD)) )))

--- a/plugins/kdeframeworks/phonon.mk
+++ b/plugins/kdeframeworks/phonon.mk
@@ -1,0 +1,27 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+PKG             := phonon
+$(PKG)_VERSION  := 4.10.1
+$(PKG)_CHECKSUM  := e5a98df31aeffc22493afc8d6adbca5d6f0c27cc2eed73b3be05195321e08db7
+$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.xz
+$(PKG)_HOME     := http://download.kde.org/stable/phonon
+$(PKG)_URL      := $($(PKG)_HOME)/$($(PKG)_VERSION)/$($(PKG)_FILE)
+$(PKG)_DEPS     := qtbase extra-cmake-modules
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- http://download.kde.org/stable/phonon/ | \
+    $(SED) -n 's,.*\([0-9]\+\.[0-9]\+.[0-9]\+\)/.*,\1,p' | \
+	tail -1
+endef
+
+define $(PKG)_BUILD
+    mkdir "$(1)/build"
+    cd "$(1)/build" && cmake .. \
+        -DCMAKE_TOOLCHAIN_FILE="$(CMAKE_TOOLCHAIN_FILE)" \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DPHONON_BUILD_EXAMPLES=OFF \
+        -DPHONON_BUILD_TESTS=OFF \
+        -DPHONON_INSTALL_QT_EXTENSIONS_INTO_SYSTEM_QT=ON \
+        -DPHONON_BUILD_PHONON4QT5=ON
+    $(MAKE) -C "$(1)/build" -j $(JOBS) install
+endef

--- a/plugins/kdeframeworks/solid.mk
+++ b/plugins/kdeframeworks/solid.mk
@@ -1,0 +1,25 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+PKG             := solid
+$(PKG)_VERSION  := 5.49.0
+$(PKG)_CHECKSUM  := f70dc2006d84f1eb342ec9d5827977d2fb1f19edfcdc7f5807a220275c6df9dc
+$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.xz
+$(PKG)_HOME     := http://download.kde.org/stable/frameworks
+$(PKG)_URL      := $($(PKG)_HOME)/$(basename $($(PKG)_VERSION))/$($(PKG)_FILE)
+$(PKG)_DEPS     := qtbase extra-cmake-modules
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- http://download.kde.org/stable/frameworks/ | \
+    $(SED) -n 's,.*\([0-9]\+\.[0-9]\+\)/.*,\1.0,p' | \
+	tail -1
+endef
+
+define $(PKG)_BUILD
+    mkdir "$(1)/build"
+    cd "$(1)/build" && cmake .. \
+        -DCMAKE_TOOLCHAIN_FILE="$(CMAKE_TOOLCHAIN_FILE)" \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DKDE_INSTALL_USE_QT_SYS_PATHS=ON -DKDE_L10N_AUTO_TRANSLATIONS=ON \
+        -DBUILD_TESTING=OFF
+    $(MAKE) -C "$(1)/build" -j $(JOBS) install
+endef

--- a/plugins/kdeframeworks/sonnet.mk
+++ b/plugins/kdeframeworks/sonnet.mk
@@ -1,0 +1,30 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+# need to symlink host "parsetrigrams" to $(PREFIX)/bin !!!
+
+PKG             := sonnet
+$(PKG)_VERSION  := 5.49.0
+$(PKG)_CHECKSUM  := 63053a671a8dc7a2a97cd49fe915e02e4b37fe41a06f3cd8785a7218d4acb754
+$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.xz
+$(PKG)_HOME     := http://download.kde.org/stable/frameworks
+$(PKG)_URL      := $($(PKG)_HOME)/$(basename $($(PKG)_VERSION))/$($(PKG)_FILE)
+$(PKG)_DEPS     := qtbase extra-cmake-modules
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- http://download.kde.org/stable/frameworks/ | \
+    $(SED) -n 's,.*\([0-9]\+\.[0-9]\+\)/.*,\1.0,p' | \
+	tail -1
+endef
+
+define $(PKG)_BUILD
+	cd "$(1)/data" && $(BUILD_CXX) -std=c++11 parsetrigrams.cpp -o $(PREFIX)/bin/parsetrigrams -fPIC $(shell pkg-config --cflags Qt5Core --libs Qt5Core)
+    mkdir "$(1)/build"
+    cd "$(1)/build" && cmake .. \
+        -DCMAKE_TOOLCHAIN_FILE="$(CMAKE_TOOLCHAIN_FILE)" \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DKDE_INSTALL_USE_QT_SYS_PATHS=ON -DKDE_L10N_AUTO_TRANSLATIONS=ON \
+        -DBUILD_TESTING=OFF \
+        -DPARSETRIGRAMS_EXECUTABLE=$(PREFIX)/bin/parsetrigrams
+    $(MAKE) -C "$(1)/build" -j $(JOBS) install
+endef

--- a/plugins/multimedia/ffmpeg-overlay.mk
+++ b/plugins/multimedia/ffmpeg-overlay.mk
@@ -1,0 +1,32 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+$(info == Custom FFmpeg overrides: $(lastword $(MAKEFILE_LIST)))
+
+gtk2_BUILD_SHARED = $(gtk2_BUILD)
+
+ffmpeg_DEPS := sdl2 x265 $(filter-out sdl \
+	gnutls \
+	libass \
+	libbluray \
+	libbs2b \
+	libcaca \
+	speex \
+	opencore-amr \
+	vo-amrwbenc \
+	xvidcore \
+	, $(ffmpeg_DEPS))
+
+ffmpeg_BUILD_SHARED = $(subst --enable-libx264, --enable-libx264 --enable-libx265, \
+	$(filter-out \
+	--enable-gnutls \
+	--enable-libass \
+	--enable-libbluray \
+	--enable-libbs2b \
+	--enable-libcaca \
+	--enable-libspeex \
+	--enable-libopencore-amrnb \
+	--enable-libopencore-amrwb \
+	--enable-libvo-amrwbenc \
+	--enable-libxvid \
+	, $(ffmpeg_BUILD)))
+

--- a/plugins/multimedia/frei0r-plugins.mk
+++ b/plugins/multimedia/frei0r-plugins.mk
@@ -1,0 +1,24 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+PKG             := frei0r-plugins
+$(PKG)_VERSION  := 1.6.1
+$(PKG)_CHECKSUM := e0c24630961195d9bd65aa8d43732469e8248e8918faa942cfb881769d11515e
+$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.gz
+$(PKG)_HOME     := https://files.dyne.org/frei0r/releases/
+$(PKG)_URL      := $($(PKG)_HOME)/$($(PKG)_FILE)
+$(PKG)_DEPS     := cairo
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O-  https://files.dyne.org/frei0r/releases | \
+    $(SED) -n 's,.*frei0r-plugins_\([0-9][^>]*\)\.tar.gz,\1,p' | \
+    head -1
+endef
+
+define $(PKG)_BUILD
+    mkdir -p '$(1)/build-mxe'
+    cd '$(1)/build-mxe' && cmake .. \
+        -DCMAKE_TOOLCHAIN_FILE='$(CMAKE_TOOLCHAIN_FILE)' \
+        -DWITHOUT_GAVL=1 -DWITHOUT_OPENCV=1
+    $(MAKE) -C '$(1)/build-mxe' -j '$(JOBS)' install
+endef

--- a/plugins/multimedia/mlt-1-fix-pkg-config-detection.patch
+++ b/plugins/multimedia/mlt-1-fix-pkg-config-detection.patch
@@ -1,0 +1,12 @@
+diff -Naur mlt-6.4.1/src/melt/Makefile mlt-6.4.1-patch/src/melt/Makefile
+--- mlt-6.4.1/src/melt/Makefile	2016-11-16 07:53:11.000000000 +0100
++++ mlt-6.4.1-patch/src/melt/Makefile	2016-11-19 09:22:19.618700486 +0100
+@@ -11,7 +11,7 @@
+ 
+ ifeq ($(targetos), MinGW)
+ ifeq (, $(findstring MELT_NOSDL, $(CFLAGS)))
+-ifeq (, $(shell pkg-config --exists sdl))
++ifeq (, $(shell pkg-config --exists sdl && echo yes))
+ CFLAGS += $(shell  sdl-config --cflags)
+ LDFLAGS += $(shell sdl-config --libs)
+ else

--- a/plugins/multimedia/mlt.mk
+++ b/plugins/multimedia/mlt.mk
@@ -1,0 +1,47 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+PKG             := mlt
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 6.10.0
+$(PKG)_CHECKSUM := 10642a80f81e12c6cc5405e60ced640b3dd325c793fe73207ae07de321ad6810
+$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.gz
+$(PKG)_URL      := http://$(SOURCEFORGE_MIRROR)/project/$(PKG)/$(PKG)/$($(PKG)_FILE)
+$(PKG)_DEPS     := gcc libxml2 ffmpeg qtbase qtsvg dlfcn-win32 \
+	frei0r-plugins ladspa-sdk fftw libsamplerate vorbis \
+	sdl2 gtk2
+	#sox movit exif
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- 'https://github.com/mltframework/mlt/tags' | \
+    grep '<a href="/mltframework/mlt/archive/' | \
+    $(SED) -n 's,.*href="/mltframework/mlt/archive/v\([0-9][^"]*\)\.tar.*,\1,p' | \
+    head -1
+endef
+
+define $(PKG)_BUILD
+	$(MAKE) -C '$(1)' distclean
+    cd '$(1)' && \
+	CFLAGS="-I$(PREFIX)/$(TARGET)/include" \
+	PKG_CONFIG_LIBDIR=$(PREFIX)/$(TARGET)/lib/pkgconfig \
+	CC=$(TARGET)-gcc \
+	./configure $(MXE_CONFIGURE_OPTS) \
+		--target-os=MinGW --rename-melt=melt.exe \
+		--qt-includedir=$(PREFIX)/$(TARGET)/qt5/include \
+		--qt-libdir=$(PREFIX)/$(TARGET)/qt5/lib \
+		--enable-gpl --enable-gpl3 --disable-rtaudio --disable-sox --disable-sdl --enable-sdl2
+	$(MAKE) -C '$(1)' uninstall
+	$(MAKE) -C '$(1)/src/modules/lumas' CC=$(BUILD_CC) luma
+	CXXFLAGS=-std=c++11 \
+	CFLAGS="-I$(PREFIX)/$(TARGET)/include" \
+	LDFLAGS="-L$(PREFIX)/$(TARGET)/lib" \
+	PKG_CONFIG_LIBDIR=$(PREFIX)/$(TARGET)/lib/pkgconfig \
+	$(MAKE) -C '$(1)' \
+		CC=$(TARGET)-gcc \
+		CXX=$(TARGET)-g++ \
+		LD=$(TARGET)-ld \
+		-j '$(JOBS)' all
+    $(MAKE) -C '$(1)' -j 1 install
+	$(SED) -i 's/swresample,//' $(PREFIX)/$(TARGET)/share/mlt/core/loader.ini
+endef
+

--- a/src/drmingw.mk
+++ b/src/drmingw.mk
@@ -1,0 +1,15 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+PKG             := drmingw
+$(PKG)_WEBSITE  := https://github.com/jrfonseca/drmingw
+$(PKG)_DESCR    := Postmortem debugging tools for MinGW
+$(PKG)_VERSION  := 0.8.2
+$(PKG)_CHECKSUM := cbb26e513a8faf0393d2d60319da944ef963e592919c4f92990c5e2752fa9d26
+$(PKG)_GH_CONF  := jrfonseca/drmingw/releases/latest
+$(PKG)_DEPS     := cc
+
+define $(PKG)_BUILD
+    cd '$(BUILD_DIR)' && $(TARGET)-cmake '$(SOURCE_DIR)'
+    $(MAKE) -C '$(BUILD_DIR)' -j $(JOBS)
+    $(MAKE) -C '$(BUILD_DIR)' -j 1 install
+endef

--- a/src/x264.mk
+++ b/src/x264.mk
@@ -18,7 +18,7 @@ define $(PKG)_UPDATE
 endef
 
 define $(PKG)_BUILD
-    cd '$(BUILD_DIR)' && AS='$(PREFIX)/$(BUILD)/bin/nasm' '$(SOURCE_DIR)/configure'\
+    cd '$(BUILD_DIR)' && '$(SOURCE_DIR)/configure'\
         $(MXE_CONFIGURE_OPTS) \
         --cross-prefix='$(TARGET)'- \
         --enable-win32thread \

--- a/src/x265.mk
+++ b/src/x265.mk
@@ -3,17 +3,17 @@
 PKG             := x265
 $(PKG)_WEBSITE  := http://x265.org
 $(PKG)_IGNORE   :=
-$(PKG)_VERSION  := 2.4
-$(PKG)_CHECKSUM := 9c2aa718d78f6fecdd783f08ab83b98d3169e5f670404da4c16439306907d729
-$(PKG)_SUBDIR   := x265_$($(PKG)_VERSION)
+$(PKG)_VERSION  := 2.6
+$(PKG)_CHECKSUM := 1bf0036415996af841884802161065b9e6be74f5f6808ac04831363e2549cdbf
+$(PKG)_SUBDIR   := x265_v$($(PKG)_VERSION)
 $(PKG)_FILE     := x265_$($(PKG)_VERSION).tar.gz
 $(PKG)_URL      := https://bitbucket.org/multicoreware/x265/downloads/$($(PKG)_FILE)
-$(PKG)_DEPS     := cc yasm
+$(PKG)_DEPS     := cc $(BUILD)~nasm
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- https://ftp.videolan.org/pub/videolan/x265/ | \
+    $(WGET) -q -O- https://bitbucket.org/multicoreware/x265/downloads/ | \
     $(SED) -n 's,.*">x265_\([0-9][^<]*\)\.t.*,\1,p' | \
-    tail -1
+    head -1
 endef
 
 # note: assembly for i686 targets is not officially supported


### PR DESCRIPTION
Hello,

I'm generating Kdenlive (KDE video editor) windows binaries for almost 2 years with MXE.
I have been waiting for long to share my work with you, mainly because I wanted to clean & upstream most of the patches.
Anyway here is the set I have been using again today... open to your wise comments :)

One thing that still bothers me is that some KDE frameworks generate binaries that are then called later in the process, the simplest solution I have found was to call my system installed ones :( 

And again, many many thanks for developing MXE, which is really a fantastic build/packaging system!

Vincent