### PR TITLE
fix boost build under gentoo host

### DIFF
--- a/src/boost.mk
+++ b/src/boost.mk
@@ -108,6 +108,7 @@ define $(PKG)_BUILD_$(BUILD)
         -a \
         -q \
         -j '$(JOBS)' \
+        --ignore-site-config \
         variant=release \
         link=static \
         threading=multi \


### PR DESCRIPTION
063cd91e1 made some bigger changes to `boost.mk`.  While the first call to `b2` has `--ignore-site-config`, the second one missed it, breaking compilation under gentoo hosts. 