### PR TITLE
Bump taglib

### DIFF
--- a/src/taglib.mk
+++ b/src/taglib.mk
@@ -4,8 +4,8 @@ PKG             := taglib
 $(PKG)_WEBSITE  := https://taglib.org/
 $(PKG)_DESCR    := TagLib
 $(PKG)_IGNORE   :=
-$(PKG)_VERSION  := d8d56d3
-$(PKG)_CHECKSUM := eef49c9c2273f1b00299ef4fdcde2f1095cfa8ee4699365c6a6499b13cc3a072
+$(PKG)_VERSION  := 5cb589a
+$(PKG)_CHECKSUM := faae533f6139e6d6d9642d3b5afa1b9b5706c0800a1d8baa3c6f051edc75b34b
 $(PKG)_GH_CONF  := taglib/taglib/branches/master
 $(PKG)_DEPS     := cc zlib
 


### PR DESCRIPTION
This will most likely be the next taglib release, I will switch back from git to normal versioning when it is released. See https://github.com/taglib/taglib/issues/837