### PR TITLE
ghostscript 9.26

### DIFF
--- a/src/ghostscript-1-fixes.patch
+++ b/src/ghostscript-1-fixes.patch
@@ -4,8 +4,8 @@ Contains ad hoc patches for cross building.
 
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: darealshinji <djcj@gmx.de>
-Date: Fri, 25 May 2018 00:43:55 +0200
-Subject: [PATCH 1/1] cross-build fixes, symbol visibility option
+Date: Mon, 3 Dec 2018 21:05:41 +0100
+Subject: [PATCH 1/1] cross-build fixes, hide libgs symbols
 
 
 diff --git a/Makefile.in b/Makefile.in
@@ -104,7 +104,7 @@ diff --git a/base/unix-aux.mak b/base/unix-aux.mak
 index 1111111..2222222 100644
 --- a/base/unix-aux.mak
 +++ b/base/unix-aux.mak
-@@ -67,23 +67,29 @@ $(GLOBJ)gp_sysv.$(OBJ): $(GLSRC)gp_sysv.c $(stdio__h) $(time__h) $(AK)\
+@@ -57,23 +57,29 @@ $(AUX)gp_stdia.$(OBJ): $(GLSRC)gp_stdia.c $(AK)\
  # -------------------------- Auxiliary programs --------------------------- #
  
  $(ECHOGS_XE): $(GLSRC)echogs.c $(AK) $(stdpre_h) $(UNIX_AUX_MAK) $(MAKEDIRS)
@@ -134,7 +134,7 @@ index 1111111..2222222 100644
  	$(CCAUX_) $(GENHT_CFLAGS) $(O_)$(GENHT_XE) $(GLSRC)genht.c $(AUXEXTRALIBS)
  
  # To get GS to use the system zlib, you remove/hide the gs/zlib directory
-@@ -94,6 +100,7 @@ MKROMFS_OBJS_0=$(MKROMFS_ZLIB_OBJS) $(AUX)gpmisc.$(OBJ) $(AUX)gp_getnv.$(OBJ) \
+@@ -84,6 +90,7 @@ MKROMFS_OBJS_0=$(MKROMFS_ZLIB_OBJS) $(AUX)gpmisc.$(OBJ) $(AUX)gp_getnv.$(OBJ) \
   $(AUX)gp_stdia.$(OBJ) $(AUX)gsutil.$(OBJ) $(AUX)memento.$(OBJ)
  
  $(MKROMFS_XE)_0: $(GLSRC)mkromfs.c $(MKROMFS_COMMON_DEPS) $(MKROMFS_OBJS_0) $(UNIX_AUX_MAK) $(MAKEDIRS)
@@ -142,7 +142,7 @@ index 1111111..2222222 100644
  	$(CCAUX_) $(GENOPTAUX) $(I_)$(GLSRCDIR)$(_I) $(I_)$(GLOBJ)$(_I) $(I_)$(ZSRCDIR)$(_I) $(GLSRC)mkromfs.c $(O_)$(MKROMFS_XE)_0 $(MKROMFS_OBJS_0) $(AUXEXTRALIBS)
  
  # .... and one using the zlib library linked via the command line
-@@ -103,9 +110,11 @@ MKROMFS_OBJS_1=$(AUX)gscdefs.$(OBJ) \
+@@ -93,9 +100,11 @@ MKROMFS_OBJS_1=$(AUX)gscdefs.$(OBJ) \
   $(AUX)gp_stdia.$(OBJ) $(AUX)gsutil.$(OBJ)
  
  $(MKROMFS_XE)_1: $(GLSRC)mkromfs.c $(MKROMFS_COMMON_DEPS) $(MKROMFS_OBJS_1) $(UNIX_AUX_MAK) $(MAKEDIRS)
@@ -158,17 +158,16 @@ diff --git a/base/unix-dll.mak b/base/unix-dll.mak
 index 1111111..2222222 100644
 --- a/base/unix-dll.mak
 +++ b/base/unix-dll.mak
-@@ -66,10 +66,6 @@ GPDL_SONAME_BASE=lib$(GPDL_SO_BASE)
+@@ -66,9 +66,6 @@ GPDL_SONAME_BASE=lib$(GPDL_SO_BASE)
  GS_SOEXT=$(SO_LIB_EXT)
  GS_DLLEXT=$(DLL_EXT)
  
 -GS_SONAME=$(GS_SONAME_BASE)$(GS_SOEXT)$(GS_DLLEXT)
 -GS_SONAME_MAJOR=$(GS_SONAME_BASE)$(GS_SOEXT)$(SO_LIB_VERSION_SEPARATOR)$(GS_VERSION_MAJOR)$(GS_DLLEXT)
 -GS_SONAME_MAJOR_MINOR=$(GS_SONAME_BASE)$(GS_SOEXT)$(SO_LIB_VERSION_SEPARATOR)$(GS_VERSION_MAJOR)$(SO_LIB_VERSION_SEPARATOR)$(GS_VERSION_MINOR)$(GS_DLLEXT)
--
+ 
  PCL_SONAME=$(PCL_SONAME_BASE)$(GS_SOEXT)$(GS_DLLEXT)
  PCL_SONAME_MAJOR=$(PCL_SONAME_BASE)$(GS_SOEXT)$(SO_LIB_VERSION_SEPARATOR)$(GS_VERSION_MAJOR)$(GS_DLLEXT)
- PCL_SONAME_MAJOR_MINOR=$(PCL_SONAME_BASE)$(GS_SOEXT)$(SO_LIB_VERSION_SEPARATOR)$(GS_VERSION_MAJOR)$(SO_LIB_VERSION_SEPARATOR)$(GS_VERSION_MINOR)$(GS_DLLEXT)
 diff --git a/configure.ac b/configure.ac
 index 1111111..2222222 100644
 --- a/configure.ac
@@ -199,25 +198,15 @@ index 1111111..2222222 100644
    echo $AUXFLAGS_MAK_LINE07 >> $AUXFLAGS_MAK.in
  
 -  ../$0 CC="$CCAUX" CFLAGS="$CFLAGSAUX" LDFLAGS="$LDFLAGSAUX" CCAUX= CFLAGSAUX= CFLAGSAUX= MAKEFILE=$AUXFLAGS_MAK --host= --build= --without-libtiff --disable-contrib --disable-fontconfig --disable-dbus --disable-freetype --disable-fapi --disable-cups --disable-openjpeg --disable-gtk --with-libiconv=no --without-libidn --without-libpaper --without-pdftoraster --without-ijs --without-luratech --without-jbig2dec --without-x --with-drivers=""
--  status=$?
--  cp config.log ../configaux.log
 +  AC_MSG_NOTICE([Begin recursive call to configure script (for auxiliary tools)])
-+  "$absolute_source_path/configure" CC="$CCAUX" CFLAGS="$CFLAGSAUX" LDFLAGS="$LDFLAGSAUX" CCAUX= CFLAGSAUX= CFLAGSAUX= MAKEFILE=$AUXFLAGS_MAK --host=$build --build=$build --enable-auxtools_only --disable-hidden-visibility --with-local-zlib --without-libtiff --disable-contrib --disable-fontconfig --disable-dbus --disable-freetype --disable-fapi --disable-cups --disable-openjpeg --disable-gtk --with-libiconv=no --without-libidn --without-libpaper --without-pdftoraster --without-ijs --without-luratech --without-jbig2dec --without-x --with-drivers=""
-+   status=$?
++  "$absolute_source_path/configure" CC="$CCAUX" CFLAGS="$CFLAGSAUX" LDFLAGS="$LDFLAGSAUX" CCAUX= CFLAGSAUX= CFLAGSAUX= MAKEFILE=$AUXFLAGS_MAK --host=$build --build=$build --enable-auxtools_only --with-local-zlib --without-libtiff --disable-contrib --disable-fontconfig --disable-dbus --disable-freetype --disable-fapi --disable-cups --disable-openjpeg --disable-gtk --with-libiconv=no --without-libidn --without-libpaper --without-pdftoraster --without-ijs --without-luratech --without-jbig2dec --without-x --with-drivers=""
+   status=$?
+-  cp config.log ../configaux.log
 +  cp config.log $olddir/configaux.log
    if test $status -eq 0 ; then
      CCAUX=$(grep CCAUX $AUXFLAGS_MAK | sed "s/CCAUX=//g")
      GCFLAGSAUXTMP=$(grep GCFLAGSAUX $AUXFLAGS_MAK | sed "s/GCFLAGSAUX=//g")
-@@ -167,6 +172,8 @@ if test x"$CCAUX" != x"" ; then
- 
-   if test $status -ne 0 ; then
-     AC_MSG_ERROR([Recursive call to configure (for auxiliary tools) script failed], $status)
-+  else
-+    AC_MSG_NOTICE([Recursive call to configure script succeeded])
-   fi
- fi
- 
-@@ -204,7 +211,7 @@ AC_PATH_TOOL(PKGCONFIG, pkg-config)
+@@ -204,7 +209,7 @@ AC_PATH_TOOL(PKGCONFIG, pkg-config)
  # but if we are cross compiling, and there isn't a matching
  # pkconfig for the --host setting, then don't use the 'local'
  # pkconfig at all
@@ -226,7 +215,7 @@ index 1111111..2222222 100644
    AC_PATH_PROG(BUILD_PKGCONFIG, pkg-config)
    if test x"$BUILD_PKGCONFIG" = x"$PKGCONFIG" ; then
      PKGCONFIG=
-@@ -217,7 +224,7 @@ AC_PATH_TOOL(STRIP_XE, strip)
+@@ -217,7 +222,7 @@ AC_PATH_TOOL(STRIP_XE, strip)
  # but if we are cross compiling, and there isn't a matching
  # pkconfig for the --host setting, then don't use the 'local'
  # pkconfig at all
@@ -235,7 +224,7 @@ index 1111111..2222222 100644
    AC_PATH_PROG(BUILD_STRIP_XE, strip)
    if test x"$BUILD_STRIP_XE" = x"$STRIP_XE" ; then
      STRIP_XE=
-@@ -234,18 +241,14 @@ CONTRIBINCLUDE="include $srcdir/contrib/contrib.mak"
+@@ -234,18 +239,14 @@ CONTRIBINCLUDE="include $srcdir/contrib/contrib.mak"
  INSTALL_CONTRIB="install-contrib-extras"
  
  if test x"$enable_contrib" = x; then
@@ -256,7 +245,7 @@ index 1111111..2222222 100644
  fi
  
  if test x"$enable_contrib" != x"no"; then
-@@ -274,33 +277,34 @@ dnl --------------------------------------------------
+@@ -274,26 +275,27 @@ dnl --------------------------------------------------
  CC_OPT_FLAGS_TO_TRY="-O"
  SET_DT_SONAME="-soname="
  
@@ -268,14 +257,21 @@ index 1111111..2222222 100644
 -else
 -  case `uname` in
 -        Linux*|GNU*)
-+case $host in
-+        *-linux*|*-gnu)
++  case $host in
++        *-mingw*|*-msys*|*-cygwin*)
          if test $ac_cv_prog_gcc = yes; then
              CC_OPT_FLAGS_TO_TRY="-O2"
              CC_DBG_FLAGS_TO_TRY="-gdwarf-2 -g3 -O0"
          fi
++        SET_DT_SONAME=""
          ;;
 -        *BSD)
++        *-linux*|*-gnu)
++        if test $ac_cv_prog_gcc = yes; then
++            CC_OPT_FLAGS_TO_TRY="-O2"
++            CC_DBG_FLAGS_TO_TRY="-gdwarf-2 -g3 -O0"
++        fi
++        ;;
 +        *bsd*)
          if test $ac_cv_prog_gcc = yes; then
              CC_OPT_FLAGS_TO_TRY="-O2"
@@ -283,44 +279,19 @@ index 1111111..2222222 100644
          fi
          ;;
 -        Darwin*)
-+        *-arwin*)
++        *-darwin*)
          if test $ac_cv_prog_gcc = yes; then
              CC_OPT_FLAGS_TO_TRY="-O2"
              CC_DBG_FLAGS_TO_TRY="-gdwarf-2 -g3 -O0"
-         fi
-         SET_DT_SONAME=""
-         ;;
--        SunOS)
-+        *-mingw*|*-msys*|*-cygwin*)
-+        if test $ac_cv_prog_gcc = yes; then
-+            CC_OPT_FLAGS_TO_TRY="-O2"
-+            CC_DBG_FLAGS_TO_TRY="-gdwarf-2 -g3 -O0"
-+        fi
-+        SET_DT_SONAME=""
-+        ;;
-+        *-sun*)
-         CC_OPT_FLAGS_TO_TRY="-O2"
-         # the trailing space is required!
-         if test $ac_cv_prog_gcc = no; then
-@@ -313,15 +317,14 @@ else
-             CC_DBG_FLAGS_TO_TRY="-g -O0"
+@@ -321,7 +323,6 @@ else
          fi
          ;;
--        AIX)
-+        *-aix*)
-         if test $ac_cv_prog_gcc = yes; then
-             CC_OPT_FLAGS_TO_TRY="-O2"
-             CC_DBG_FLAGS_TO_TRY="-gdwarf-2 -g3 -O0"
-             SET_DT_SONAME="so"
-         fi
-         ;;
--  esac
+   esac
 -fi
-+esac
  
  AC_SUBST(SET_DT_SONAME)
  
-@@ -346,18 +349,20 @@ AC_ARG_WITH([arch_h], AC_HELP_STRING([--with-arch_h=<arch.h to use>],
+@@ -368,18 +369,20 @@ AC_ARG_WITH([arch_h], AC_HELP_STRING([--with-arch_h=<arch.h to use>],
  ARCH_CONF_HEADER=
  
  if test x"$with_arch_h" = x""; then
@@ -329,7 +300,7 @@ index 1111111..2222222 100644
 -  else
 -    case `uname` in
 -          Darwin*)
-+    case $host in
++  case $host in
 +          x86_64*-mingw*|x86_64*-msys*|x86_64*-cygwin*)
 +            ARCH_CONF_HEADER="\$(GLSRCDIR)/../arch/windows-x64-msvc.h"
 +          ;;
@@ -347,36 +318,7 @@ index 1111111..2222222 100644
  else
    ARCH_CONF_HEADER=$with_arch_h
  fi
-@@ -489,13 +494,23 @@ dnl - BSD Make treats obj special and cd into it first.
- dnl --------------------------------------------------
- 
- OBJDIR_BSDMAKE_WORKAROUND=obj
-+SUB_MAKE_OPTION=
-+ORDER_ONLY=""
- 
--case `uname` in
--        *BSD)
--        OBJDIR_BSDMAKEWORKAOROUND="notobj"
--        ;;
--esac
-+AC_MSG_CHECKING(if make is GNU make)
-+if make --version 2> /dev/null | grep GNU 2>&1 > /dev/null ; then
-+  AC_MSG_RESULT(yes)
-+  SUB_MAKE_OPTION="-f \$(MAKEFILE)"
-+  ORDER_ONLY="|"
-+else
-+  AC_MSG_RESULT(no)
-+  # BSD Make treats obj special and cd into it first
-+  OBJDIR_BSDMAKEWORKAOROUND="notobj"
-+fi
-+ 
- AC_SUBST(OBJDIR_BSDMAKE_WORKAROUND)
-+AC_SUBST(ORDER_ONLY)
-+AC_SUBST(SUB_MAKE_OPTION)
- AC_CHECK_HEADER([sys/window.h])
- 
- dnl --------------------------------------------------
-@@ -636,15 +651,7 @@ dnl Set options that we want to pass into all other
+@@ -658,15 +661,7 @@ dnl Set options that we want to pass into all other
  dnl configure scripts we might call
  dnl --------------------------------------------------
  
@@ -393,7 +335,7 @@ index 1111111..2222222 100644
  
  dnl --------------------------------------------------
  dnl Check for libraries
-@@ -974,7 +981,7 @@ if test x"$enable_fapi" != xno; then
+@@ -996,7 +991,7 @@ if test x"$enable_fapi" != xno; then
              if $PKGCONFIG --atleast-version=12.0.6 freetype2; then
                  AC_MSG_RESULT(yes)
                  FT_CFLAGS="$CFLAGS `$PKGCONFIG --cflags freetype2`"
@@ -402,7 +344,7 @@ index 1111111..2222222 100644
                  FT_BRIDGE=1
                  SHARE_FT=1
              else
-@@ -1025,6 +1032,14 @@ AC_SUBST(FTSRCDIR)
+@@ -1047,6 +1042,14 @@ AC_SUBST(FTSRCDIR)
  AC_SUBST(FT_CFLAGS)
  AC_SUBST(FT_LIBS)
  
@@ -417,7 +359,7 @@ index 1111111..2222222 100644
  AC_MSG_CHECKING([for local jpeg library source])
  dnl At present, we give the local source priority over the shared
  dnl build, so that the D_MAX_BLOCKS_IN_MCU patch will be applied.
-@@ -1066,6 +1081,13 @@ else
+@@ -1088,6 +1091,13 @@ else
      [define if the libjpeg memory system prototypes aren't available])
  fi
  
@@ -431,7 +373,7 @@ index 1111111..2222222 100644
  AC_MSG_CHECKING([for local zlib source])
  dnl zlib is needed for language level 3, and libpng
  # we must define ZLIBDIR regardless because png.mak does a -I$(ZLIBDIR)
-@@ -1074,6 +1096,13 @@ ZLIBDIR=src
+@@ -1096,6 +1106,13 @@ ZLIBDIR=src
  AUX_SHARED_ZLIB=
  ZLIBCFLAGS=""
  
@@ -445,15 +387,17 @@ index 1111111..2222222 100644
  if test -d $srcdir/zlib; then
          AC_MSG_RESULT([yes])
          SHARE_ZLIB=0
-@@ -1088,6 +1117,7 @@ else
+@@ -1110,6 +1127,9 @@ else
            AC_CHECK_HEADERS(zlib.h, [SHARE_ZLIB=1; AUX_SHARED_ZLIB="-l\$(ZLIB_NAME)"])
          ])
  fi
++
 +fi # $with_local_zlib
++
  if test -z "$SHARE_ZLIB"; then
    AC_MSG_ERROR([I did not find a copy of zlib on your system.
    Please either install it, or unpack a copy of the source in a
-@@ -1114,6 +1144,11 @@ AC_SUBST(ZLIBDIR)
+@@ -1136,6 +1156,11 @@ AC_SUBST(ZLIBDIR)
  AC_SUBST(FT_SYS_ZLIB)
  
  dnl png for the png output device; it also requires zlib
@@ -465,11 +409,13 @@ index 1111111..2222222 100644
  LIBPNGDIR=src
  PNGDEVS=''
  PNGDEVS_ALL='png48 png16m pnggray pngmono pngmonod png256 png16 pngalpha'
-@@ -1135,12 +1170,19 @@ fi
+@@ -1157,12 +1182,21 @@ fi
  if test -z "$PNGDEVS"; then
    AC_MSG_NOTICE([disabling png output devices])
  fi
++
 +fi # $enable_auxtools_only
++
  AC_SUBST(SHARE_LIBPNG)
  AC_SUBST(LIBPNGDIR)
  #AC_SUBST(PNGDEVS)
@@ -482,18 +428,19 @@ index 1111111..2222222 100644
 +  LCMS2MTDIR=
 +else
 +
- AC_MSG_CHECKING([for local lcms2 library source])
+ AC_MSG_CHECKING([for local lcms2mt library source])
  LCMS2DIR=src
- LCMS2ARTDIR=src
-@@ -1172,6 +1214,7 @@ else
-       fi
+ LCMS2MTDIR=src
+@@ -1197,6 +1231,8 @@ else
     fi
  fi
-+fi # $enable_auxtools_only
  
++fi # $enable_auxtools_only
++
  AC_SUBST(SHARELCMS)
  AC_SUBST(WHICHLCMS)
-@@ -1314,7 +1357,7 @@ EXPATDIR=src
+ AC_SUBST(LCMS2DIR)
+@@ -1349,7 +1385,7 @@ EXPATDIR=src
  EXPAT_CFLAGS=
  EXPAT_LIBS=
  
@@ -502,27 +449,26 @@ index 1111111..2222222 100644
    if test -f $srcdir/xps/xps.mak; then
      AC_MSG_CHECKING([for local expat library source])
      if test -f $srcdir/expat/lib/expat.h ; then
-@@ -1493,16 +1536,14 @@ dnl look for IJS implementation
+@@ -1528,16 +1564,14 @@ dnl look for IJS implementation
  AC_ARG_WITH([ijs], AC_HELP_STRING([--without-ijs],
      [disable IJS driver support]))
  
 -if test x"$cross_compiling" != x"yes"; then
 -  case `uname` in
 -    MINGW*|MSYS*)
-+case $host in
++  case $host in
 +    *-mingw*|*-msys*|*-cygwin*)
        AC_MSG_WARN([disabling the ijs device])
        with_ijs=no
      ;;
      *)
      ;;
--  esac
+   esac
 -fi
-+esac
  
  dnl set safe defaults
      IJSDIR=src
-@@ -1554,18 +1595,11 @@ if test x$with_luratech != xno; then
+@@ -1589,15 +1623,8 @@ if test x$with_luratech != xno; then
      SHARE_JBIG2=0
      JBIG2DIR=$srcdir/luratech/ldf_jb2
  
@@ -539,12 +485,8 @@ index 1111111..2222222 100644
 +        *-darwin*)
            JBIG2_AUTOCONF_CFLAGS="-DUSE_LDF_JB2 -DMAC -DMAC_OS_X_BUILD -fsigned-char"
          ;;
--        AIX)
-+        *-aix*)
-           if test $ac_cv_prog_gcc = yes; then
-             JBIG2_AUTOCONF_CFLAGS="-DUSE_LDF_JB2 -fsigned-char -DLINUX=1 -DFORTE"
-           else
-@@ -1576,7 +1610,6 @@ if test x$with_luratech != xno; then
+         AIX)
+@@ -1611,7 +1638,6 @@ if test x$with_luratech != xno; then
            JBIG2_AUTOCONF_CFLAGS="-DUSE_LDF_JB2 -fsigned-char -DLINUX=1 -DFORTE"
          ;;
        esac
@@ -552,7 +494,7 @@ index 1111111..2222222 100644
  
      JBIG2FILEDEVS='$(DD)gdevjbig2.dev'
      JBIG2DEVS='$(PSD)jbig2.dev'
-@@ -1683,18 +1716,11 @@ if test x$with_luratech != xno; then
+@@ -1718,15 +1744,8 @@ if test x$with_luratech != xno; then
      SHARE_JPX=0
      JPXDIR=$srcdir/luratech/lwf_jp2
  
@@ -569,12 +511,8 @@ index 1111111..2222222 100644
 +        *-darwin*)
            JPX_AUTOCONF_CFLAGS="-DUSE_LWF_JP2 -DMAC -DMAC_OS_X_BUILD"
          ;;
--        AIX)
-+        *-aix*)
-           if test $ac_cv_prog_gcc = yes; then
-             JPX_AUTOCONF_CFLAGS="-DUSE_LWF_JP2 -fsigned-char -DLINUX=1 -DFORTE"
-           else
-@@ -1705,7 +1731,6 @@ if test x$with_luratech != xno; then
+         AIX)
+@@ -1740,7 +1759,6 @@ if test x$with_luratech != xno; then
            JPX_AUTOCONF_CFLAGS="-DUSE_LWF_JP2 -DLINUX=1 -DFORTE"
          ;;
        esac
@@ -582,7 +520,7 @@ index 1111111..2222222 100644
      JPXDEVS='$(PSD)jpx.dev'
    else
      AC_MSG_RESULT([no])
-@@ -2318,21 +2343,30 @@ SO_LIB_EXT=".so"
+@@ -2357,22 +2375,15 @@ SO_LIB_EXT=".so"
  DLL_EXT=""
  SO_LIB_VERSION_SEPARATOR="."
  
@@ -591,6 +529,7 @@ index 1111111..2222222 100644
 -  GS_DYNAMIC_LDFLAGS="-shared -Wl,\$(LD_SET_DT_SONAME)\$(LDFLAGS_SO_PREFIX)\$(GS_SONAME_MAJOR)"
 -  PCL_DYNAMIC_LDFLAGS="-shared -Wl,\$(LD_SET_DT_SONAME)\$(LDFLAGS_SO_PREFIX)\$(PCL_SONAME_MAJOR)"
 -  XPS_DYNAMIC_LDFLAGS="-shared -Wl,\$(LD_SET_DT_SONAME)\$(LDFLAGS_SO_PREFIX)\$(XPS_SONAME_MAJOR)"
+-  PDL_DYNAMIC_LDFLAGS="-shared -Wl,\$(LD_SET_DT_SONAME)\$(LDFLAGS_SO_PREFIX)\$(GPDL_SONAME_MAJOR)"
 -  if test $ac_cv_prog_gcc = yes; then
 -    # GCC high level flag
 -    DYNAMIC_LIBS="-rdynamic"
@@ -608,27 +547,12 @@ index 1111111..2222222 100644
 +GS_SONAME_MAJOR="lib\$(GS${libname2}"
 +GS_SONAME_MAJOR_MINOR="lib\$(GS${libname3}"
 +
-+hide_symbols=no
-+attr_default=
-+attr_hidden=
-+_ldflags=
-+
-+AC_ARG_ENABLE([hidden-visibility],
-+    AC_HELP_STRING([--enable-hidden-visibility],
-+        [hide all shared library symbols which are not part of its public API]),
-+    [hide_symbols=yes])
-+
-+if test x$hide_symbols = xyes -a $ac_cv_prog_gcc = yes; then
-+    attr_default="__attribute__((visibility(\\\"default\\\")))"
-+    attr_hidden="__attribute__((visibility(\\\"hidden\\\")))"
-+fi
-+
 +case $host in
 +    *-linux*|*-gnu)
        DYNAMIC_CFLAGS="-fPIC"
        GS_DYNAMIC_LDFLAGS="-shared -Wl,\$(LD_SET_DT_SONAME)\$(LDFLAGS_SO_PREFIX)\$(GS_SONAME_MAJOR)"
        PCL_DYNAMIC_LDFLAGS="-shared -Wl,\$(LD_SET_DT_SONAME)\$(LDFLAGS_SO_PREFIX)\$(PCL_SONAME_MAJOR)"
-@@ -2345,16 +2379,25 @@ else
+@@ -2386,17 +2397,21 @@ else
        fi
        SO_LIB_EXT=".so"
      ;;
@@ -636,15 +560,11 @@ index 1111111..2222222 100644
 -      DYNAMIC_CFLAGS=""
 -      GS_DYNAMIC_LDFLAGS="-shared  -Wl,--out-implib=\$(BINDIR)/lib\$(GS_SO_BASE).dll.a -Wl,--export-all-symbols -Wl,--enable-auto-import"
 +    *-mingw*|*-msys*|*-cygwin*)
-+      if test x$hide_symbols = xyes; then
-+        DYNAMIC_CFLAGS="-fvisibility=hidden -DGSDLLEXPORT=\"__declspec(dllexport)\""
-+      else
-+        _ldflags="-Wl,--export-all-symbols"
-+      fi
-+      _ldflags="$_ldflags -Wl,--enable-auto-import"
-+      GS_DYNAMIC_LDFLAGS="-shared -Wl,--out-implib=\$(BINDIR)/lib\$(GS_SO_BASE).dll.a $_ldflags"
++      DYNAMIC_CFLAGS="-fvisibility=hidden -DGSDLLEXPORT=\"__declspec(dllexport)\""
++      GS_DYNAMIC_LDFLAGS="-shared -Wl,--out-implib=\$(BINDIR)/lib\$(GS_SO_BASE).dll.a -Wl,--enable-auto-import"
        PCL_DYNAMIC_LDFLAGS="-shared  -Wl,--out-implib=\$(BINDIR)/lib\$(PCL_SO_BASE).dll.a -Wl,--export-all-symbols -Wl,--enable-auto-import"
        XPS_DYNAMIC_LDFLAGS="-shared  -Wl,--out-implib=\$(BINDIR)/lib\$(XPS_SO_BASE).dll.a -Wl,--export-all-symbols -Wl,--enable-auto-import"
+       PDL_DYNAMIC_LDFLAGS="-shared  -Wl,--out-implib=\$(BINDIR)/lib\$(PDL_SO_BASE).dll.a -Wl,--export-all-symbols -Wl,--enable-auto-import"
        SO_LIB_EXT=""
        DLL_EXT=".dll"
        SO_LIB_VERSION_SEPARATOR="-"
@@ -658,7 +578,7 @@ index 1111111..2222222 100644
        DYNAMIC_CFLAGS="-fPIC"
        GS_DYNAMIC_LDFLAGS="-shared -Wl,\$(LD_SET_DT_SONAME)\$(LDFLAGS_SO_PREFIX)\$(GS_SONAME_MAJOR)"
        PCL_DYNAMIC_LDFLAGS="-shared -Wl,\$(LD_SET_DT_SONAME)\$(LDFLAGS_SO_PREFIX)\$(PCL_SONAME_MAJOR)"
-@@ -2362,14 +2405,14 @@ else
+@@ -2404,7 +2419,7 @@ else
        DYNAMIC_LIBS=""
        SO_LIB_EXT=".so"
      ;;
@@ -667,25 +587,8 @@ index 1111111..2222222 100644
        GS_DYNAMIC_LDFLAGS="-dynamiclib -install_name \$(GS_SONAME_MAJOR_MINOR)"
        PCL_DYNAMIC_LDFLAGS="-dynamiclib -install_name \$(PCL_SONAME_MAJOR_MINOR)"
        XPS_DYNAMIC_LDFLAGS="-dynamiclib -install_name \$(XPS_SONAME_MAJOR_MINOR)"
-       DYNAMIC_LIBS=""
-       SO_LIB_EXT=".dylib"
-     ;;
--    SunOS)
-+    *-sun*)
-       if test $ac_cv_prog_gcc = yes; then
-         DYNAMIC_CFLAGS="-fPIC"
-       else
-@@ -2381,7 +2424,7 @@ else
-       DYNAMIC_LIBS=""
-       SO_LIB_EXT=".so"
-       ;;
--    AIX)
-+    *-aix*)
-       DYNAMIC_CFLAGS="-fPIC"
-       GCFLAGS="-Wl,-brtl -D_LARGE_FILES $GCFLAGS"
-       GS_DYNAMIC_LDFLAGS="-shared -Wl,-brtl,-G -fPIC"
-@@ -2389,15 +2432,18 @@ else
-       XPS_DYNAMIC_LDFLAGS="-shared -Wl,-brtl,-G -fPIC"
+@@ -2442,15 +2457,18 @@ else
+       fi
        SO_LIB_EXT=".so"
        ;;
 -  esac
@@ -707,7 +610,7 @@ index 1111111..2222222 100644
        INSTALL_SHARED="install-shared"
        if test "x$X_DEVS" != x; then
                DYNAMIC_DEVS="\$(GLOBJDIR)/X11.so"
-@@ -2409,21 +2455,21 @@ AC_ARG_ENABLE([dynamic], AC_HELP_STRING([--enable-dynamic],
+@@ -2462,14 +2480,14 @@ AC_ARG_ENABLE([dynamic], AC_HELP_STRING([--enable-dynamic],
        OPT_CFLAGS="$DYNAMIC_CFLAGS $OPT_CFLAGS"
        DBG_CFLAGS="$DYNAMIC_CFLAGS $DBG_CFLAGS"
        ;;
@@ -724,24 +627,7 @@ index 1111111..2222222 100644
        INSTALL_SHARED="install-shared"
        DYNAMIC_FLAGS="-DGS_DEVS_SHARED -DGS_DEVS_SHARED_DIR=\\\"\$(gssharedir)\\\""
        X11_DEVS=""
-       OPT_CFLAGS="$DYNAMIC_CFLAGS $OPT_CFLAGS"
-       DBG_CFLAGS="$DYNAMIC_CFLAGS $DBG_CFLAGS"
-       ;;
--      SunOS)
-+      *-sun*)
-       DYNAMIC_DEVS="\$(GLOBJDIR)/X11.so"
-       DYNAMIC_FLAGS="-DGS_DEVS_SHARED -DGS_DEVS_SHARED_DIR=\\\"\$(gssharedir)\\\""
-       OPT_CFLAGS="$DYNAMIC_CFLAGS $OPT_CFLAGS"
-@@ -2529,7 +2575,7 @@ dnl --------------------------------------------------
- dnl disable the memory header ID code on SPARC
- dnl --------------------------------------------------
- 
--case `uname -a` in
-+case $host in
-         *sparc*)
- 	  GCFLAGS="$GCFLAGS -DGS_USE_MEMORY_HEADER_ID=0"
-         ;;
-@@ -2757,23 +2803,31 @@ AC_SUBST(AUXDIRPOSTFIX)
+@@ -2814,23 +2832,31 @@ AC_SUBST(AUXDIRPOSTFIX)
  # usually empty on Unix-like systems
  # --------------------------------------------------
  EXEEXT=""
@@ -785,7 +671,7 @@ index 1111111..2222222 100644
  
  # --------------------------------------------------
  # Check for disabling of versioned path option.
-@@ -2828,7 +2882,7 @@ fi
+@@ -2885,7 +2911,7 @@ fi
  
  AC_SUBST(CLUSTER_CFLAGS)
  
@@ -794,7 +680,7 @@ index 1111111..2222222 100644
  
    ilog2()
    {
-@@ -2968,7 +3022,7 @@ AC_SUBST(AUXEXTRALIBS)
+@@ -3025,7 +3051,7 @@ AC_SUBST(AUXEXTRALIBS)
  
  CONFIG_FILES_LIST="$CONFIG_FILES_LIST $THEMAKEFILE"
  


### PR DESCRIPTION
Update Ghostscript to version 9.26, always hide libgs symbols, use local lcms fork (lcms2mt).
