### PR TITLE
libgpg_error: fix build for non-default targets

### DIFF
--- a/src/libgpg_error.mk
+++ b/src/libgpg_error.mk
@@ -19,8 +19,7 @@ define $(PKG)_UPDATE
 endef
 
 define $(PKG)_BUILD
-    cd '$(1)/src/syscfg' && ln -s lock-obj-pub.mingw32.h lock-obj-pub.mingw32.static.h
-    cd '$(1)/src/syscfg' && ln -s lock-obj-pub.mingw32.h lock-obj-pub.mingw32.shared.h
+    cd '$(1)/src/syscfg' && ln -s lock-obj-pub.mingw32.h lock-obj-pub.mingw32.$(call merge,.,$(call rest,$(call split,.,$(TARGET)))).h
     cd '$(1)' && ./configure \
         $(MXE_CONFIGURE_OPTS) \
         --disable-nls \


### PR DESCRIPTION
Tested for many targets. See #2259.