### PR TITLE
add package libfcgi

### DIFF
--- a/src/libfcgi-1-fixes.patch
+++ b/src/libfcgi-1-fixes.patch
@@ -1,0 +1,121 @@
+This file is part of MXE. See LICENSE.md for licensing information.
+
+Contains ad hoc patches for cross building.
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Boris Pek <tehnick-8@yandex.ru>
+Date: Wed, 9 Jan 2019 15:57:45 +0300
+Subject: [PATCH 1/1] Fix build as static library for MS Windows using MinGW.
+
++ Delete extra definitions.
+
+diff --git a/include/fcgi_stdio.h b/include/fcgi_stdio.h
+index 1111111..2222222 100644
+--- a/include/fcgi_stdio.h
++++ b/include/fcgi_stdio.h
+@@ -24,7 +24,7 @@ extern "C" {
+ #endif
+ 
+ #ifndef DLLAPI
+-#ifdef _WIN32
++#if defined (_WIN32) && defined (_MSC_VER)
+ #define DLLAPI __declspec(dllimport)
+ #else
+ #define DLLAPI
+diff --git a/include/fcgiapp.h b/include/fcgiapp.h
+index 1111111..2222222 100644
+--- a/include/fcgiapp.h
++++ b/include/fcgiapp.h
+@@ -23,7 +23,7 @@
+ #endif
+ 
+ #ifndef DLLAPI
+-#ifdef _WIN32
++#if defined (_WIN32) && defined (_MSC_VER)
+ #define DLLAPI __declspec(dllimport)
+ #else
+ #define DLLAPI
+diff --git a/include/fcgio.h b/include/fcgio.h
+index 1111111..2222222 100644
+--- a/include/fcgio.h
++++ b/include/fcgio.h
+@@ -35,7 +35,7 @@
+ #include "fcgiapp.h"
+ 
+ #ifndef DLLAPI
+-#ifdef _WIN32
++#if defined (_WIN32) && defined (_MSC_VER)
+ #define DLLAPI __declspec(dllimport)
+ #else
+ #define DLLAPI
+diff --git a/include/fcgios.h b/include/fcgios.h
+index 1111111..2222222 100755
+--- a/include/fcgios.h
++++ b/include/fcgios.h
+@@ -50,7 +50,7 @@ extern "C" {
+ #endif /* !_WIN32 */
+ 
+ #ifndef DLLAPI
+-#ifdef _WIN32
++#if defined (_WIN32) && defined (_MSC_VER)
+ #define DLLAPI __declspec(dllimport)
+ #else
+ #define DLLAPI
+diff --git a/libfcgi/fcgi_stdio.c b/libfcgi/fcgi_stdio.c
+index 1111111..2222222 100644
+--- a/libfcgi/fcgi_stdio.c
++++ b/libfcgi/fcgi_stdio.c
+@@ -22,10 +22,6 @@
+ #include <unistd.h>
+ #endif
+ 
+-#ifdef _WIN32
+-#define DLLAPI  __declspec(dllexport)
+-#endif
+-
+ #include "fcgiapp.h"
+ #include "fcgios.h"
+ #include "fcgimisc.h"
+diff --git a/libfcgi/fcgiapp.c b/libfcgi/fcgiapp.c
+index 1111111..2222222 100644
+--- a/libfcgi/fcgiapp.c
++++ b/libfcgi/fcgiapp.c
+@@ -40,10 +40,6 @@
+ #include <limits.h>
+ #endif
+ 
+-#ifdef _WIN32
+-#define DLLAPI  __declspec(dllexport)
+-#endif
+-
+ #include "fcgimisc.h"
+ #include "fastcgi.h"
+ #include "fcgios.h"
+diff --git a/libfcgi/fcgio.cpp b/libfcgi/fcgio.cpp
+index 1111111..2222222 100644
+--- a/libfcgi/fcgio.cpp
++++ b/libfcgi/fcgio.cpp
+@@ -18,10 +18,6 @@
+ // implied; without even the implied warranty of MERCHANTABILITY or
+ // FITNESS FOR A PARTICULAR PURPOSE.
+ 
+-#ifdef _WIN32
+-#define DLLAPI  __declspec(dllexport)
+-#endif
+-
+ #include <stdio.h>
+ #include <limits.h>
+ #include "fcgio.h"
+diff --git a/libfcgi/os_win32.c b/libfcgi/os_win32.c
+index 1111111..2222222 100755
+--- a/libfcgi/os_win32.c
++++ b/libfcgi/os_win32.c
+@@ -27,8 +27,6 @@
+ #include <process.h>
+ #include <signal.h>
+ 
+-#define DLLAPI  __declspec(dllexport)
+-
+ #include "fcgimisc.h"
+ #include "fcgios.h"
+ 

--- a/src/libfcgi-test.cpp
+++ b/src/libfcgi-test.cpp
@@ -1,0 +1,62 @@
+/*
+ * This file is part of MXE. See LICENSE.md for licensing information.
+ */
+
+#include <sstream>
+
+#include <fcgi_stdio.h>
+
+using std::string;
+using std::stringstream;
+
+void show_html(const string &);
+bool ends_with(const string &, const string &);
+string get_env_var(const string &);
+
+int main(void)
+{
+    unsigned long counter = 0;
+    while (FCGI_Accept() >= 0) {
+        ++counter;
+
+        const string full_path = get_env_var("SCRIPT_NAME");
+        if (ends_with(full_path, "") || ends_with(full_path, "/")) {
+            show_html("<b>Hello, stranger!</b></br>\n"
+                      "</br>\n"
+                      "What are you looking for?</br>\n"
+                      "</br>\n"
+                      "Counter of visits may be found <a href='/counter'>here</a></br>\n");
+        }
+        else if (ends_with(full_path, "/counter") || ends_with(full_path, "/counter/")) {
+            stringstream counter_str;
+            counter_str << counter;
+            show_html("Counter: " + counter_str.str());
+        }
+        else {
+            show_html("<center><h2>This is not the page you are looking for!</h2></center>\n");
+        }
+    }
+
+    return 0;
+}
+
+void show_html(const string &str)
+{
+    printf("Content-type: text/html\n\n");
+    printf("%s", str.c_str());
+}
+
+bool ends_with(const string &str, const string &sfx)
+{
+    if (sfx.size() > str.size())
+        return false;
+
+    return equal(str.begin() + str.size() - sfx.size(), str.end(), sfx.begin());
+}
+
+string get_env_var(const string &var)
+{
+    const char *ptr = getenv(var.c_str());
+    return (ptr ? string(ptr) : "");
+}
+

--- a/src/libfcgi.mk
+++ b/src/libfcgi.mk
@@ -1,0 +1,26 @@
+# This file is part of MXE.
+# See index.html for further information.
+
+PKG             := libfcgi
+$(PKG)_WEBSITE  := https://github.com/FastCGI-Archives
+$(PKG)_DESCR    := FastCGI
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := a6ad89b
+$(PKG)_CHECKSUM := c6ced2e940f662adc337a5e5dd74e3a13d7e14687d9cb71fe9c4185f36d2e57f
+$(PKG)_GH_CONF  := FastCGI-Archives/fcgi2/branches/master
+$(PKG)_DEPS     := cc
+
+define $(PKG)_BUILD
+    cd '$(SOURCE_DIR)' && autoreconf -fi
+    cd '$(BUILD_DIR)' && '$(SOURCE_DIR)/configure' \
+        $(MXE_CONFIGURE_OPTS)
+
+    $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)' $(MXE_DISABLE_CRUFT)
+    $(MAKE) -C '$(BUILD_DIR)' -j 1 install $(MXE_DISABLE_CRUFT)
+
+    # Test
+    '$(TARGET)-g++' \
+        -W -Wall -Werror -std=c++0x -pedantic \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-$(PKG).exe' \
+        `'$(TARGET)-pkg-config' fcgi --cflags --libs` -lws2_32
+endef


### PR DESCRIPTION
* For *.shared targets all is built fine.
* For *.static targets library is built fine, but there is a problem of linking of test program:
```
# Test
'i686-w64-mingw32.static-g++' -W -Wall -Werror -std=c++0x -pedantic '/opt/mxe-master/src/libfcgi-test.cpp' -o '/opt/mxe-master/usr/i686-w64-mingw32.static/bin/test-libfcgi.exe' `'i686-w64-mingw32.static-pkg-config' fcgi --cflags --libs`
/tmp/ccwzI8FC.o:libfcgi-test.cpp:(.text+0x5c): undefined reference to `_imp__FCGI_Accept'
/tmp/ccwzI8FC.o:libfcgi-test.cpp:(.text+0x7f2): undefined reference to `_imp__FCGI_printf'
/tmp/ccwzI8FC.o:libfcgi-test.cpp:(.text+0x80c): undefined reference to `_imp__FCGI_printf'
collect2: error: ld returned 1 exit status
```
And I am failing to understand that is wrong here...
Any help is welcome!