### PR TITLE
add support for lzip archives

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ WGET        = $(WGET_TOOL) --user-agent='$(or $($(1)_UA),$(DEFAULT_UA))'
 
 REQUIREMENTS := autoconf automake autopoint bash bison bzip2 flex \
                 $(BUILD_CC) $(BUILD_CXX) gperf intltoolize $(LIBTOOL) \
-                $(LIBTOOLIZE) $(MAKE) $(OPENSSL) $(PATCH) $(PERL) python \
+                $(LIBTOOLIZE) lzip $(MAKE) $(OPENSSL) $(PATCH) $(PERL) python \
                 ruby $(SED) $(SORT) unzip wget xz 7za gdk-pixbuf-csource
 
 PREFIX     := $(PWD)/usr
@@ -231,13 +231,14 @@ UNPACK_ARCHIVE = \
     $(if $(filter %.tar.Z,   $(1)),tar xzf '$(1)', \
     $(if $(filter %.tbz2,    $(1)),tar xjf '$(1)', \
     $(if $(filter %.tar.bz2, $(1)),tar xjf '$(1)', \
+    $(if $(filter %.tar.lz,  $(1)),lzip -dc '$(1)'| tar xf -, \
     $(if $(filter %.tar.lzma,$(1)),xz -dc -F lzma '$(1)' | tar xf -, \
     $(if $(filter %.txz,     $(1)),xz -dc '$(1)' | tar xf -, \
     $(if $(filter %.tar.xz,  $(1)),xz -dc '$(1)' | tar xf -, \
     $(if $(filter %.7z,      $(1)),7za x '$(1)', \
     $(if $(filter %.zip,     $(1)),unzip -q '$(1)', \
     $(if $(filter %.deb,     $(1)),ar x '$(1)' && tar xf data.tar*, \
-    $(error Unknown archive format: $(1)))))))))))))
+    $(error Unknown archive format: $(1))))))))))))))
 
 UNPACK_PKG_ARCHIVE = \
     $(call UNPACK_ARCHIVE,$(PKG_DIR)/$($(1)_FILE))

--- a/docs/index.html
+++ b/docs/index.html
@@ -622,6 +622,10 @@ USE_OSGPLUGIN(&lt;plugin2&gt;)
         <td>≥ 2.2</td>
     </tr>
     <tr>
+        <td><a href="http://lzip.nongnu.org/">Lzip</a></td>
+        <td></td>
+    </tr>
+    <tr>
         <td><a href="https://www.openssl.org/">OpenSSL</a>-dev</td>
         <td>≥ 1.01</td>
     </tr>
@@ -694,6 +698,7 @@ USE_OSGPLUGIN(&lt;plugin2&gt;)
     libssl-dev \
     libtool-bin \
     libxml-parser-perl \
+    lzip \
     make \
     openssl \
     p7zip-full \
@@ -751,6 +756,7 @@ USE_OSGPLUGIN(&lt;plugin2&gt;)
     gperf \
     intltool \
     libtool \
+    lzip \
     make \
     openssl-devel \
     p7zip \
@@ -858,6 +864,7 @@ USE_OSGPLUGIN(&lt;plugin2&gt;)
     gperf \
     intltool \
     libtool \
+    lzip \
     make \
     openssl \
     patch \
@@ -882,6 +889,7 @@ USE_OSGPLUGIN(&lt;plugin2&gt;)
     <!-- https://packages.gentoo.org/ -->
     <pre>emerge \
     app-arch/bzip2 \
+    app-arch/lzip \
     app-arch/p7zip \
     app-arch/unzip \
     app-arch/xz-utils \
@@ -929,6 +937,7 @@ USE_OSGPLUGIN(&lt;plugin2&gt;)
     gsed \
     intltool \
     libtool \
+    lzip \
     p7zip \
     pkgconfig \
     wget \
@@ -947,6 +956,7 @@ USE_OSGPLUGIN(&lt;plugin2&gt;)
     glib \
     intltool \
     libtool \
+    lzip \
     p7zip \
     sed \
     tar \
@@ -973,6 +983,7 @@ USE_OSGPLUGIN(&lt;plugin2&gt;)
     gnu-tar \
     intltool \
     libtool \
+    lzip \
     p7zip \
     pkg-config \
     wget \
@@ -1021,6 +1032,7 @@ USE_OSGPLUGIN(&lt;plugin2&gt;)
     libopenssl-devel \
     libstdc++46-devel-32bit \
     libtool \
+    lzip \
     make \
     openssl \
     p7zip \
@@ -1064,6 +1076,7 @@ USE_OSGPLUGIN(&lt;plugin2&gt;)
     intltool \
     libcurl-devel \
     libtool \
+    lzip \
     make \
     p7zip \
     patch \

--- a/src/wget.mk
+++ b/src/wget.mk
@@ -3,9 +3,9 @@
 PKG             := wget
 $(PKG)_WEBSITE  := https://www.gnu.org/software/wget/
 $(PKG)_VERSION  := 1.20.1
-$(PKG)_CHECKSUM := b783b390cb571c837b392857945f5a1f00ec6b043177cc42abb8ee1b542ee1b3
+$(PKG)_CHECKSUM := 0f63e84dd23dc53ab3ab6f483c3afff8301e54c165783f772101cdd9b1c64928
 $(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
-$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.gz
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.lz
 $(PKG)_URL      := https://ftp.gnu.org/gnu/$(PKG)/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc gnutls libidn2 libntlm pcre2 pthreads
 


### PR DESCRIPTION
.tar.lz (lzip) archives seem to be increasing in popularity. As far as I can tell, the lzma, xz, and 7z utilities do not support this format, so lzip is required to decompress them.

Could the knowledgeable ones please check the distro-specific package names in this commit?

In the Makefile macro UNPACK_ARCHIVE, plain "tar xf" could be used more generally, since modern tar understands many compressed formats, including lzip. I imagine the support in tar also depends on lzip being installed. Are there still good reasons for explicitly invoking specific decompression tools based on file extension?