### PR TITLE
Avoid unnecessary implied native builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -681,7 +681,10 @@ download-$(3)~$(1): download-only-$(1) \
                     $(addprefix download-,$(PKG_ALL_DEPS))
 
 .PHONY: $(1) $(1)~$(3)
-$(1) $(1)~$(3): $(PREFIX)/$(3)/installed/$(1)
+# requested pkgs should not build their native version unless
+# explicitly set in DEPS or they only have a single target
+$(if $(filter-out $(BUILD),$(3))$(call not,$(word 2,$($(1)_TARGETS))),$(1)) \
+    $(1)~$(3): $(PREFIX)/$(3)/installed/$(1)
 $(PREFIX)/$(3)/installed/$(1): $(PKG_MAKEFILES) \
                           $($(PKG)_PATCHES) \
                           $(PKG_TESTFILES) \

--- a/src/qtifw.mk
+++ b/src/qtifw.mk
@@ -9,9 +9,10 @@ $(PKG)_CHECKSUM := a4ecafc37086f96a833463214f873caac977199e64f0b1453aa49bdd6f24f
 $(PKG)_SUBDIR    = qt-installer-framework-opensource-src-$($(PKG)_VERSION)
 $(PKG)_FILE     := $($(PKG)_SUBDIR).zip
 $(PKG)_URL      := https://download.qt.io/official_releases/qt-installer-framework/$($(PKG)_VERSION)/$($(PKG)_FILE)
-$(PKG)_DEPS     := cc qtbase qttools qtwinextras
-$(PKG)_DEPS_$(BUILD) := qtbase qttools
 $(PKG)_TARGETS  := $(BUILD) $(MXE_TARGETS)
+
+$(PKG)_DEPS_$(BUILD) := cc qtbase qttools
+$(PKG)_DEPS_STATIC   := $($(PKG)_DEPS_$(BUILD)) qtwinextras $(BUILD)~$(PKG)
 
 define $(PKG)_BUILD_$(BUILD)
     cd '$(1)' && $(TARGET)-qmake-qt5


### PR DESCRIPTION
From #2285

Build only `gcc` with required native libs:
```
$ make MXE_BUILD_DRY_RUN=1 gcc
== gcc is now a dependency of virtual toolchain package cc
      - cc will build gcc, pkgconf, and other core toolchain packages
      - please update scripts accordingly (ignore if you are building gcc alone)

[check reqs]
[nonet lib]   /Users/tonyt/dev/mxe/usr/x86_64-apple-darwin18.2.0/lib/nonetwork.dylib
[git-log]   7ce446c6 Update packages.json & build-matrix.html
[dry-run]     mxe-conf               i686-w64-mingw32.static
[dry-run]     binutils               i686-w64-mingw32.static
[dry-run]     mingw-w64              i686-w64-mingw32.static
[dry-run]     mxe-conf               x86_64-apple-darwin18.2.0
[dry-run]     gmp                    x86_64-apple-darwin18.2.0
[dry-run]     isl                    x86_64-apple-darwin18.2.0
[dry-run]     mpfr                   x86_64-apple-darwin18.2.0
[dry-run]     mpc                    x86_64-apple-darwin18.2.0
[dry-run]     gcc                    i686-w64-mingw32.static
```

Build virtual `cc` package to complete core toolchain with custom `pkgconf` and platform specific native tools from https://github.com/mxe/mxe/tree/master/plugins/native
```
$ make MXE_BUILD_DRY_RUN=1 cc
[dry-run]     pkgconf                x86_64-apple-darwin18.2.0
[dry-run]     pkgconf                i686-w64-mingw32.static
[dry-run]     flex                   x86_64-apple-darwin18.2.0
[dry-run]     bison                  x86_64-apple-darwin18.2.0
[dry-run]     patch                  x86_64-apple-darwin18.2.0
[meta]        cc                     i686-w64-mingw32.static
```

Build `boost` and implied `cmake`
```
$ make MXE_BUILD_DRY_RUN=1 boost
[dry-run]     bzip2                  i686-w64-mingw32.static
[dry-run]     expat                  i686-w64-mingw32.static
[dry-run]     zlib                   i686-w64-mingw32.static
[dry-run]     cmake                  x86_64-apple-darwin18.2.0
[dry-run]     cmake-conf             x86_64-apple-darwin18.2.0
[dry-run]     cmake-conf             i686-w64-mingw32.static
[dry-run]     boost                  i686-w64-mingw32.static
```

Build `pe-util` and required native `boost`
```
$ make MXE_BUILD_DRY_RUN=1 pe-util
[dry-run]     pe-parse               i686-w64-mingw32.static
[dry-run]     zlib                   x86_64-apple-darwin18.2.0
[dry-run]     boost                  x86_64-apple-darwin18.2.0
[dry-run]     pe-util                x86_64-apple-darwin18.2.0
[dry-run]     pe-util                i686-w64-mingw32.static
```

Build some Qt components with implied `autotools` (script to test basic `autoconf`) and required native `glib` tools  
```
$ make MXE_BUILD_DRY_RUN=1 qtbase qttools qtwinextras
[check reqs]
[git-log]   2ba6ce78 qtifw: set only static deps
[dry-run]     dbus                   i686-w64-mingw32.static
[dry-run]     libpng                 i686-w64-mingw32.static
[dry-run]     freetype-bootstrap     i686-w64-mingw32.static
[dry-run]     libiconv               i686-w64-mingw32.static
[dry-run]     libiconv               x86_64-apple-darwin18.2.0
[dry-run]     gettext                x86_64-apple-darwin18.2.0
[dry-run]     gettext                i686-w64-mingw32.static
[dry-run]     autotools              x86_64-apple-darwin18.2.0
[dry-run]     fontconfig             i686-w64-mingw32.static
[dry-run]     openssl                i686-w64-mingw32.static
[dry-run]     freetds                i686-w64-mingw32.static
[dry-run]     libffi                 i686-w64-mingw32.static
[dry-run]     pcre                   i686-w64-mingw32.static
[dry-run]     libffi                 x86_64-apple-darwin18.2.0
[dry-run]     glib                   x86_64-apple-darwin18.2.0
[dry-run]     glib                   i686-w64-mingw32.static
[dry-run]     lzo                    i686-w64-mingw32.static
[dry-run]     pixman                 i686-w64-mingw32.static
[dry-run]     cairo                  i686-w64-mingw32.static
[dry-run]     icu4c                  i686-w64-mingw32.static
[dry-run]     harfbuzz               i686-w64-mingw32.static
[dry-run]     freetype               i686-w64-mingw32.static
[dry-run]     jpeg                   i686-w64-mingw32.static
[dry-run]     libmysqlclient         i686-w64-mingw32.static
[dry-run]     pcre2                  i686-w64-mingw32.static
[dry-run]     pthreads               i686-w64-mingw32.static
[dry-run]     postgresql             i686-w64-mingw32.static
[dry-run]     sqlite                 i686-w64-mingw32.static
[dry-run]     qtbase                 i686-w64-mingw32.static
[dry-run]     qtactiveqt             i686-w64-mingw32.static
[dry-run]     qtsvg                  i686-w64-mingw32.static
[dry-run]     qtxmlpatterns          i686-w64-mingw32.static
[dry-run]     qtdeclarative          i686-w64-mingw32.static
[dry-run]     qttools                i686-w64-mingw32.static
[dry-run]     qtmultimedia           i686-w64-mingw32.static
[dry-run]     qtwinextras            i686-w64-mingw32.static
```

Build `qtifw` with required native Qt components
```
$ make MXE_BUILD_DRY_RUN=1 qtifw
[meta]        cc                     x86_64-apple-darwin18.2.0
[dry-run]     qtbase                 x86_64-apple-darwin18.2.0
[dry-run]     qtactiveqt             x86_64-apple-darwin18.2.0
[dry-run]     qtsvg                  x86_64-apple-darwin18.2.0
[dry-run]     qtxmlpatterns          x86_64-apple-darwin18.2.0
[dry-run]     qtdeclarative          x86_64-apple-darwin18.2.0
[dry-run]     qttools                x86_64-apple-darwin18.2.0
[dry-run]     qtifw                  x86_64-apple-darwin18.2.0
[dry-run]     qtifw                  i686-w64-mingw32.static
```

Build shared `qtifw` with no reqs for disabled build, `mxe-conf` is implied for all packages
```
$ make MXE_BUILD_DRY_RUN=1 MXE_TARGETS=i686-w64-mingw32.shared qtifw
[dry-run]     mxe-conf               i686-w64-mingw32.shared
[disabled]    qtifw                  i686-w64-mingw32.shared
```
