### PR TITLE
WIP: Add boost 1.66 as plugin

### DIFF
--- a/plugins/boost_1_66_0/boost-overlay.mk
+++ b/plugins/boost_1_66_0/boost-overlay.mk
@@ -1,0 +1,126 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+PKG             := boost
+$(PKG)_WEBSITE  := https://www.boost.org/
+$(PKG)_DESCR    := Boost C++ Library
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 1.66.0
+$(PKG)_CHECKSUM := 5721818253e6a0989583192f96782c4a98eb6204965316df9f5ad75819225ca9
+$(PKG)_SUBDIR   := $(PKG)_$(subst .,_,$($(PKG)_VERSION))
+$(PKG)_FILE     := $(PKG)_$(subst .,_,$($(PKG)_VERSION)).tar.bz2
+$(PKG)_URL      := https://$(SOURCEFORGE_MIRROR)/project/boost/boost/$($(PKG)_VERSION)/$($(PKG)_FILE)
+$(PKG)_TARGETS  := $(BUILD) $(MXE_TARGETS)
+$(PKG)_DEPS     := cc bzip2 expat zlib
+$(PKG)_PATCHES  := $(dir $(lastword $(MAKEFILE_LIST)))/boost.patch
+
+$(PKG)_DEPS_$(BUILD) := zlib
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- 'https://www.boost.org/users/download/' | \
+    $(SED) -n 's,.*/boost/\([0-9][^"/]*\)/".*,\1,p' | \
+    grep -v beta | \
+    head -1
+endef
+
+define $(PKG)_BUILD
+    # old version appears to interfere
+    rm -rf '$(PREFIX)/$(TARGET)/include/boost/'
+    rm -f "$(PREFIX)/$(TARGET)/lib/libboost"*
+
+    # create user-config
+    echo 'using gcc : mxe : $(TARGET)-g++ : <rc>$(TARGET)-windres <archiver>$(TARGET)-ar <ranlib>$(TARGET)-ranlib ;' > '$(1)/user-config.jam'
+
+    # compile boost build (b2)
+    cd '$(1)/tools/build/' && ./bootstrap.sh
+
+    # cross-build, see b2 options at:
+    # https://www.boost.org/build/doc/html/bbv2/overview/invocation.html
+    cd '$(1)' && ./tools/build/b2 \
+        -a \
+        -q \
+        -j '$(JOBS)' \
+        --ignore-site-config \
+        --user-config=user-config.jam \
+        abi=ms \
+        address-model=$(BITS) \
+        architecture=x86 \
+        binary-format=pe \
+        link=$(if $(BUILD_STATIC),static,shared) \
+        target-os=windows \
+        threadapi=win32 \
+        threading=multi \
+        variant=release \
+        toolset=gcc-mxe \
+        cxxflags=$(if $(findstring posix,$(MXE_GCC_THREADS)),-std=gnu++11,-std=gnu++98) \
+        --layout=tagged \
+        --disable-icu \
+        --without-mpi \
+        --without-python \
+        --prefix='$(PREFIX)/$(TARGET)' \
+        --exec-prefix='$(PREFIX)/$(TARGET)/bin' \
+        --libdir='$(PREFIX)/$(TARGET)/lib' \
+        --includedir='$(PREFIX)/$(TARGET)/include' \
+        -sEXPAT_INCLUDE='$(PREFIX)/$(TARGET)/include' \
+        -sEXPAT_LIBPATH='$(PREFIX)/$(TARGET)/lib' \
+        install
+
+    $(if $(BUILD_SHARED), \
+        mv -fv '$(PREFIX)/$(TARGET)/lib/'libboost_*.dll '$(PREFIX)/$(TARGET)/bin/')
+
+    # setup cmake toolchain
+    echo 'set(Boost_THREADAPI "win32")' > '$(CMAKE_TOOLCHAIN_DIR)/$(PKG).cmake'
+
+    '$(TARGET)-g++' \
+        -W -Wall -Werror -ansi -std=c++11 -U__STRICT_ANSI__ -pedantic \
+	'$(PWD)/plugins/$($(PKG)_SUBDIR)/$(PKG)-test.cpp' -o '$(PREFIX)/$(TARGET)/bin/test-boost.exe' \
+        -DBOOST_THREAD_USE_LIB \
+        -lboost_serialization-mt \
+	-lboost_thread-mt \
+        -lboost_system-mt \
+        -lboost_chrono-mt \
+        -lboost_context-mt
+
+    # test cmake
+    #mkdir '$(1)-test-cmake'
+    #cd '$(1)-test-cmake' && '$(TARGET)-cmake' \
+        -DPKG=$(PKG) \
+        -DPKG_VERSION=$($(PKG)_VERSION) \
+        '$(PWD)/src/cmake/test'
+    #$(MAKE) -C '$(1)-test-cmake' -j 1 install
+endef
+
+define $(PKG)_BUILD_$(BUILD)
+    # old version appears to interfere
+    rm -rf '$(PREFIX)/$(TARGET)/include/boost/'
+    rm -f "$(PREFIX)/$(TARGET)/lib/libboost"*
+
+    # compile boost build (b2)
+    cd '$(SOURCE_DIR)/tools/build/' && ./bootstrap.sh
+
+    # minimal native build - for more features, replace:
+    # --with-system \
+    # --with-filesystem \
+    #
+    # with:
+    # --without-mpi \
+    # --without-python \
+
+    cd '$(SOURCE_DIR)' && ./tools/build/b2 \
+        -a \
+        -q \
+        -j '$(JOBS)' \
+        --ignore-site-config \
+        variant=release \
+        link=static \
+        threading=multi \
+        runtime-link=static \
+        --disable-icu \
+        --with-system \
+        --with-filesystem \
+        --build-dir='$(BUILD_DIR)' \
+        --prefix='$(PREFIX)/$(TARGET)' \
+        --exec-prefix='$(PREFIX)/$(TARGET)/bin' \
+        --libdir='$(PREFIX)/$(TARGET)/lib' \
+        --includedir='$(PREFIX)/$(TARGET)/include' \
+        install
+endef

--- a/plugins/boost_1_66_0/boost-test.cmake
+++ b/plugins/boost_1_66_0/boost-test.cmake
@@ -1,0 +1,13 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+# partial module - included by src/cmake/CMakeLists.txt
+
+set(TGT test-${PKG}-cmake)
+
+enable_language(CXX)
+add_executable(${TGT} ${CMAKE_CURRENT_LIST_DIR}/${PKG}-test.cpp)
+
+find_package(Boost ${PKG_VERSION} EXACT COMPONENTS chrono context serialization system thread REQUIRED)
+target_link_libraries(${TGT} ${Boost_LIBRARIES})
+
+install(TARGETS ${TGT} DESTINATION bin)

--- a/plugins/boost_1_66_0/boost-test.cpp
+++ b/plugins/boost_1_66_0/boost-test.cpp
@@ -1,0 +1,65 @@
+/*
+ * This file is part of MXE. See LICENSE.md for licensing information.
+ */
+
+#include <iostream>
+#include <tuple>
+
+#include <boost/archive/xml_oarchive.hpp>
+#include <boost/thread/thread.hpp>
+#include <boost/thread/tss.hpp>
+
+boost::thread_specific_ptr<int> ptr;
+
+// https://www.boost.org/doc/libs/1_60_0/libs/context/doc/html/context/context.html
+#include <boost/context/all.hpp>
+
+void test_thread()
+{
+	if (ptr.get() == 0) {
+		ptr.reset(new int(0));
+	}
+	std::cout << "Hello, World! from thread" << std::endl;
+}
+
+int main(int, char * [])
+{
+	{
+		boost::archive::xml_oarchive oa(std::cout);
+		std::string s = "\n\n    Hello, World!\n\n";
+		oa << BOOST_SERIALIZATION_NVP(s);
+	}
+
+	{
+		boost::thread thrd(test_thread);
+		thrd.join();
+	}
+
+	{
+		namespace ctx = boost::context;
+		int data = 0;
+		ctx::continuation c = ctx::callcc([&data](ctx::continuation && c) {
+			std::cout << "f1: entered first time: " << data << std::endl;
+			data += 1;
+			c = c.resume();
+			std::cout << "f1: entered second time: " << data << std::endl;
+			data += 1;
+			c = c.resume();
+			std::cout << "f1: entered third time: " << data << std::endl;
+			return std::move(c);
+		});
+		std::cout << "f1: returned first time: " << data << std::endl;
+		data += 1;
+		c = c.resume();
+		std::cout << "f1: returned second time: " << data << std::endl;
+		data += 1;
+		c = c.resume_with([&data](ctx::continuation && c) {
+			std::cout << "f2: entered: " << data << std::endl;
+			data = -1;
+			return std::move(c);
+		});
+		std::cout << "f1: returned third time" << std::endl;
+	}
+
+	return 0;
+}

--- a/plugins/boost_1_66_0/boost.patch
+++ b/plugins/boost_1_66_0/boost.patch
@@ -1,0 +1,38 @@
+diff -ur a/boost/thread/win32/basic_timed_mutex.hpp b/boost/thread/win32/basic_timed_mutex.hpp
+--- a/boost/thread/win32/basic_timed_mutex.hpp	2017-12-14 00:56:49.000000000 +0100
++++ b/boost/thread/win32/basic_timed_mutex.hpp	2018-01-29 18:43:25.615734914 +0100
+@@ -23,6 +23,7 @@
+ #include <boost/chrono/ceil.hpp>
+ #endif
+ #include <boost/config/abi_prefix.hpp>
++#include <boost/winapi/wait.hpp>
+ 
+ namespace boost
+ {
+@@ -81,7 +82,7 @@
+ 
+                     do
+                     {
+-                        unsigned const retval(winapi::WaitForSingleObjectEx(sem, ::boost::detail::win32::infinite,0));
++                        unsigned const retval(::boost::winapi::WaitForSingleObjectEx(sem, ::boost::detail::win32::infinite,0));
+                         BOOST_VERIFY(0 == retval || ::boost::detail::win32::wait_abandoned == retval);
+ //                        BOOST_VERIFY(winapi::WaitForSingleObject(
+ //                                         sem,::boost::detail::win32::infinite)==0);
+@@ -142,7 +143,7 @@
+ 
+                     do
+                     {
+-                        if(winapi::WaitForSingleObjectEx(sem,::boost::detail::get_milliseconds_until(wait_until),0)!=0)
++                        if(::boost::winapi::WaitForSingleObjectEx(sem,::boost::detail::get_milliseconds_until(wait_until),0)!=0)
+                         {
+                             BOOST_INTERLOCKED_DECREMENT(&active_count);
+                             return false;
+@@ -210,7 +211,7 @@
+                       }
+                       chrono::milliseconds rel_time= chrono::ceil<chrono::milliseconds>(tp-now);
+ 
+-                      if(winapi::WaitForSingleObjectEx(sem,static_cast<unsigned long>(rel_time.count()),0)!=0)
++                      if(::boost::winapi::WaitForSingleObjectEx(sem,static_cast<unsigned long>(rel_time.count()),0)!=0)
+                       {
+                           BOOST_INTERLOCKED_DECREMENT(&active_count);
+                           return false;


### PR DESCRIPTION
In reference to https://github.com/mxe/mxe/pull/2043, here's an attempt at making boost 1.66 available as a plugin.  (Boost 1.69, the most current version, would require a newer CMake version.)

There are two isses yet to be resolved:
* The tests are commented in `boost-overlay.mk` because I couldn't figure out how to make it *not* build the test in `src` but the one in `plugins/boost_1_66_0`.
* Only building the two static targets worked for me.  For shared targets, I got an internal compiler error.  This seems like a separate gcc8 bug, and I don't know how it would affect the state of this plugin.

Happy for feedback!
