### PR TITLE
New package: fluidsynth

### DIFF
--- a/src/fluidsynth-test.c
+++ b/src/fluidsynth-test.c
@@ -4,17 +4,18 @@
 
 #include <fluidsynth.h>
 
-int main(int argc, char** argv) 
+int main(int argc, char *argv[])
 {
     fluid_settings_t* settings;
     fluid_synth_t* synth;
+    (void)argc;
+    (void)argv;
+    /* Set up the synthesizer */
     settings = new_fluid_settings();
     synth = new_fluid_synth(settings);
 
-	/* Do useful things here */
-
+    /* ...and delete it again*/
     delete_fluid_synth(synth);
     delete_fluid_settings(settings);
-
     return 0;
 }

--- a/src/fluidsynth-test.c
+++ b/src/fluidsynth-test.c
@@ -1,0 +1,20 @@
+/*
+ This file is part of MXE. See LICENSE.md for licensing information.
+ */
+
+#include <fluidsynth.h>
+
+int main(int argc, char** argv) 
+{
+    fluid_settings_t* settings;
+    fluid_synth_t* synth;
+    settings = new_fluid_settings();
+    synth = new_fluid_synth(settings);
+
+	/* Do useful things here */
+
+    delete_fluid_synth(synth);
+    delete_fluid_settings(settings);
+
+    return 0;
+}

--- a/src/fluidsynth.mk
+++ b/src/fluidsynth.mk
@@ -10,16 +10,22 @@ $(PKG)_GH_CONF  := FluidSynth/fluidsynth/tags,v
 $(PKG)_DEPS     := cc glib
 
 define $(PKG)_BUILD
-    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' '$(SOURCE_DIR)' \
-        -DBUILD_SHARED_LIBS=$(CMAKE_SHARED_BOOL) \
-	-DCMAKE_BUILD_TYPE=Release
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' '$(SOURCE_DIR)'
     $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)' VERBOSE=1
-    $(MAKE) -C '$(BUILD_DIR)' -j 1 install VERBOSE=1
+
+    $(INSTALL) -d '$(PREFIX)/$(TARGET)/include/fluidsynth'
+    $(INSTALL) -v '$(BUILD_DIR)/include/fluidsynth.h'    '$(PREFIX)/$(TARGET)/include/'
+    $(INSTALL) -v '$(BUILD_DIR)/include/fluidsynth/'*.h  '$(PREFIX)/$(TARGET)/include/fluidsynth/'
+    $(INSTALL) -v '$(SOURCE_DIR)/include/fluidsynth/'*.h '$(PREFIX)/$(TARGET)/include/fluidsynth/'
+    $(INSTALL) -v '$(BUILD_DIR)/fluidsynth.pc'           '$(PREFIX)/$(TARGET)/lib/pkgconfig/' 
+    $(INSTALL) -v '$(BUILD_DIR)/src/libfluidsynth.a' '$(PREFIX)/$(TARGET)/lib/'
+    $(if $(BUILD_SHARED),\
+    $(INSTALL) -m755 -v '$(BUILD_DIR)/src/libfluidsynth.dll.a' '$(PREFIX)/$(TARGET)/bin/')
 
     # compile test
     '$(TARGET)-gcc' \
         -W -Wall -ansi -pedantic \
         '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-fluidsynth.exe' \
         `'$(TARGET)-pkg-config' --cflags --libs fluidsynth` \
-	`'$(TARGET)-pkg-config' --cflags --libs glib-2.0`
+        `'$(TARGET)-pkg-config' --cflags --libs glib-2.0`
 endef

--- a/src/fluidsynth.mk
+++ b/src/fluidsynth.mk
@@ -1,0 +1,18 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+PKG             := fluidsynth
+$(PKG)_WEBSITE  := http://fluidsynth.org/
+$(PKG)_DESCR    := FluidSynth - a free software synthesizer based on the SoundFont 2 specifications
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 2.0.5
+$(PKG)_CHECKSUM := 69b244512883491e7e66b4d0151c61a0d6d867d4d2828c732563be0f78abcc51
+$(PKG)_GH_CONF  := FluidSynth/fluidsynth/tags,v
+$(PKG)_DEPS     := cc glib
+
+define $(PKG)_BUILD
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' '$(SOURCE_DIR)' \
+        -DBUILD_SHARED_LIBS=$(CMAKE_SHARED_BOOL) \
+	-DCMAKE_BUILD_TYPE=Release
+    $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)' VERBOSE=1
+    $(MAKE) -C '$(BUILD_DIR)' -j 1 install VERBOSE=1
+endef

--- a/src/fluidsynth.mk
+++ b/src/fluidsynth.mk
@@ -13,8 +13,8 @@ define $(PKG)_BUILD
     cd '$(BUILD_DIR)' && '$(TARGET)-cmake' '$(SOURCE_DIR)'
     $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)' VERBOSE=1
 
-    echo "Requires: glib-2.0" >> '$(BUILD_DIR)/fluidsynth.pc'
-
+    echo 'Requires: glib-2.0' >> '$(BUILD_DIR)'/fluidsynth.pc
+    $(SED) -i -e 's/Libs: -L$${libdir} -lfluidsynth/Libs: -L$${libdir} -lfluidsynth -ldsound/g' '$(BUILD_DIR)/fluidsynth.pc'
     $(INSTALL) -d '$(PREFIX)/$(TARGET)/include/fluidsynth'
     $(INSTALL) -v '$(BUILD_DIR)/include/fluidsynth.h'    '$(PREFIX)/$(TARGET)/include/'
     $(INSTALL) -v '$(BUILD_DIR)/include/fluidsynth/'*.h  '$(PREFIX)/$(TARGET)/include/fluidsynth/'

--- a/src/fluidsynth.mk
+++ b/src/fluidsynth.mk
@@ -15,4 +15,11 @@ define $(PKG)_BUILD
 	-DCMAKE_BUILD_TYPE=Release
     $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)' VERBOSE=1
     $(MAKE) -C '$(BUILD_DIR)' -j 1 install VERBOSE=1
+
+    # compile test
+    '$(TARGET)-gcc' \
+        -W -Wall -ansi -pedantic \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-fluidsynth.exe' \
+        `'$(TARGET)-pkg-config' --cflags --libs fluidsynth` \
+	`'$(TARGET)-pkg-config' --cflags --libs glib-2.0`
 endef

--- a/src/fluidsynth.mk
+++ b/src/fluidsynth.mk
@@ -26,7 +26,7 @@ define $(PKG)_BUILD
 
     # compile test
     '$(TARGET)-gcc' \
-        -W -Wall -ansi -pedantic \
+        -W -Wall -Werror -ansi -pedantic \
         '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-fluidsynth.exe' \
         `'$(TARGET)-pkg-config' --cflags --libs fluidsynth`
 endef

--- a/src/fluidsynth.mk
+++ b/src/fluidsynth.mk
@@ -13,6 +13,8 @@ define $(PKG)_BUILD
     cd '$(BUILD_DIR)' && '$(TARGET)-cmake' '$(SOURCE_DIR)'
     $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)' VERBOSE=1
 
+    echo "Requires: glib-2.0" >> '$(BUILD_DIR)/fluidsynth.pc'
+
     $(INSTALL) -d '$(PREFIX)/$(TARGET)/include/fluidsynth'
     $(INSTALL) -v '$(BUILD_DIR)/include/fluidsynth.h'    '$(PREFIX)/$(TARGET)/include/'
     $(INSTALL) -v '$(BUILD_DIR)/include/fluidsynth/'*.h  '$(PREFIX)/$(TARGET)/include/fluidsynth/'
@@ -26,6 +28,5 @@ define $(PKG)_BUILD
     '$(TARGET)-gcc' \
         -W -Wall -ansi -pedantic \
         '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-fluidsynth.exe' \
-        `'$(TARGET)-pkg-config' --cflags --libs fluidsynth` \
-        `'$(TARGET)-pkg-config' --cflags --libs glib-2.0`
+        `'$(TARGET)-pkg-config' --cflags --libs fluidsynth`
 endef

--- a/src/fluidsynth.mk
+++ b/src/fluidsynth.mk
@@ -18,7 +18,7 @@ define $(PKG)_BUILD
     $(INSTALL) -v '$(BUILD_DIR)/include/fluidsynth/'*.h  '$(PREFIX)/$(TARGET)/include/fluidsynth/'
     $(INSTALL) -v '$(SOURCE_DIR)/include/fluidsynth/'*.h '$(PREFIX)/$(TARGET)/include/fluidsynth/'
     $(INSTALL) -v '$(BUILD_DIR)/fluidsynth.pc'           '$(PREFIX)/$(TARGET)/lib/pkgconfig/' 
-    $(INSTALL) -v '$(BUILD_DIR)/src/libfluidsynth.a' '$(PREFIX)/$(TARGET)/lib/'
+    $(INSTALL) -v '$(BUILD_DIR)/src/libfluidsynth.a'     '$(PREFIX)/$(TARGET)/lib/'
     $(if $(BUILD_SHARED),\
     $(INSTALL) -m755 -v '$(BUILD_DIR)/src/libfluidsynth.dll.a' '$(PREFIX)/$(TARGET)/bin/')
 


### PR DESCRIPTION
This adds a package for the FluidSynth library, a free Soundfont compatible MIDI synthesizer. This library is for example used by VLC and is supported by ScummVM.