### PR TITLE
curl: switch to winssl/schannel

### DIFF
--- a/src/curl.mk
+++ b/src/curl.mk
@@ -9,7 +9,7 @@ $(PKG)_CHECKSUM := f2d98854813948d157f6a91236ae34ca4a1b4cb302617cebad263d79b0235
 $(PKG)_SUBDIR   := curl-$($(PKG)_VERSION)
 $(PKG)_FILE     := curl-$($(PKG)_VERSION).tar.xz
 $(PKG)_URL      := https://curl.haxx.se/download/$($(PKG)_FILE)
-$(PKG)_DEPS     := cc gnutls libidn2 libssh2 pthreads
+$(PKG)_DEPS     := cc libidn2 libssh2 pthreads
 
 define $(PKG)_UPDATE
     $(WGET) -q -O- 'https://curl.haxx.se/download/?C=M;O=D' | \
@@ -20,7 +20,7 @@ endef
 define $(PKG)_BUILD
     cd '$(1)' && ./configure \
         $(MXE_CONFIGURE_OPTS) \
-        --with-gnutls \
+	--with-winssl \
         --without-ssl \
         --with-libidn2 \
         --enable-sspi \


### PR DESCRIPTION
Currently, libcurl is not able to use the SSL certificates from the certificate store in Windows due to the dependency on gnutls. This patch fixes this by switching to Schannel/WinSSL, Windows' native SSL library which has access to the certificate store of the OS.

I originally stumbled across this issue in https://github.com/mxe/mxe/issues/2380.

If you don't want any changes in the current curl.mk package, I'll happily split this into a seperate curl-winssl.mk file.