### PR TITLE
New package: libmpeg2

### DIFF
--- a/src/libmpeg2-1.patch
+++ b/src/libmpeg2-1.patch
@@ -1,0 +1,24 @@
+This file is part of MXE. See LICENSE.md for licensing information.
+
+The patch was taken from the scummvm.org documentation, it is
+required on 64 bit systems due to the very old codebase.
+
+--- a/libvo/video_out_dx.c.orig   2014-02-17 16:38:24.000000000 +0100
++++ b/libvo/video_out_dx.c        2014-02-17 16:39:34.000000000 +0100
+@@ -92,7 +92,7 @@
+     switch (message) {
+ 
+     case WM_WINDOWPOSCHANGED:
+-	instance = (dx_instance_t *) GetWindowLong (hwnd, GWL_USERDATA);
++	instance = (dx_instance_t *) GetWindowLongPtr (hwnd, GWLP_USERDATA);
+ 
+        /* update the window position and size */
+        point_window.x = 0;
+@@ -173,7 +173,7 @@
+     /* store a directx_instance pointer into the window local storage
+      * (for later use in event_handler).
+      * We need to use SetWindowLongPtr when it is available in mingw */
+-    SetWindowLong (instance->window, GWL_USERDATA, (LONG) instance);
++    SetWindowLongPtr (instance->window, GWLP_USERDATA, (LONG_PTR) instance);
+ 
+     ShowWindow (instance->window, SW_SHOW);

--- a/src/libmpeg2.mk
+++ b/src/libmpeg2.mk
@@ -1,0 +1,34 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+PKG             := libmpeg2
+$(PKG)_WEBSITE  := https://plib.sourceforge.io/
+$(PKG)_DESCR    := libmpeg2 - a free MPEG-2 video stream decoder
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 0.5.1
+$(PKG)_CHECKSUM := dee22e893cb5fc2b2b6ebd60b88478ab8556cb3b93f9a0d7ce8f3b61851871d4
+$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.gz
+$(PKG)_URL      := http://libmpeg2.sourceforge.net/files/$($(PKG)_FILE)
+$(PKG)_DEPS     := cc
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- 'http://libmpeg2.sourceforge.net/downloads.html' | \
+    $(SED) -n 's,.*files/libmpeg2-\([0-9][^"]*\)\.tar.*,\1,p' | \
+    head -1
+endef
+
+define $(PKG)_BUILD
+    cd '$(BUILD_DIR)' && '$(SOURCE_DIR)/configure' 'CFLAGS=-std=gnu89' \
+        $(MXE_CONFIGURE_OPTS) \
+        --disable-sdl
+        PKG_CONFIG='$(TARGET)-pkg-config'
+
+    $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)'
+    $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)' install $(MXE_DISABLE_PRGRAMS)
+
+    # compile test (sample1.c included with libmpeg2)
+    '$(TARGET)-gcc' \
+	    -W -Wall -ansi -pedantic \
+	    '$(SOURCE_DIR)/doc/sample1.c' -o '$(PREFIX)/$(TARGET)/bin/test-libmpeg2.exe' \
+	    `'$(TARGET)-pkg-config' --cflags --libs libmpeg2`
+endef


### PR DESCRIPTION
This commit adds a package for libmpeg2, a free MPEG-2 decoding library used by various projects. The codebase is quite ancient (last version from 2008), so building with x86_64 needs a patch. The patch was taken from https://wiki.scummvm.org/index.php/Compiling_ScummVM/MinGW#libmpeg2.