### PR TITLE
qtifw: update and build test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -230,6 +230,7 @@ SHORT_PKG_VERSION = \
     $(word 1,$(subst ., ,$($(1)_VERSION))).$(word 2,$(subst ., ,$($(1)_VERSION)))
 
 UNPACK_ARCHIVE = \
+    $(if $(filter %.tar,     $(1)),tar xf  '$(1)', \
     $(if $(filter %.tgz,     $(1)),tar xzf '$(1)', \
     $(if $(filter %.tar.gz,  $(1)),tar xzf '$(1)', \
     $(if $(filter %.tar.Z,   $(1)),tar xzf '$(1)', \
@@ -242,7 +243,7 @@ UNPACK_ARCHIVE = \
     $(if $(filter %.7z,      $(1)),7za x '$(1)', \
     $(if $(filter %.zip,     $(1)),unzip -q '$(1)', \
     $(if $(filter %.deb,     $(1)),ar x '$(1)' && tar xf data.tar*, \
-    $(error Unknown archive format: $(1))))))))))))))
+    $(error Unknown archive format: $(1)))))))))))))))
 
 UNPACK_PKG_ARCHIVE = \
     $(call UNPACK_ARCHIVE,$(PKG_DIR)/$($(1)_FILE))

--- a/src/qtifw-1-fixes.patch
+++ b/src/qtifw-1-fixes.patch
@@ -17,7 +17,7 @@ diff --git a/src/libs/7zip/win/CPP/Windows/SecurityUtils.h b/src/libs/7zip/win/C
 index 715de250..bfb65a34 100644
 --- a/src/libs/7zip/win/CPP/Windows/SecurityUtils.h
 +++ b/src/libs/7zip/win/CPP/Windows/SecurityUtils.h
-@@ -3,7 +3,7 @@
+@@ -2,7 +2,7 @@
  #ifndef __WINDOWS_SECURITY_UTILS_H
  #define __WINDOWS_SECURITY_UTILS_H
  

--- a/src/qtifw.mk
+++ b/src/qtifw.mk
@@ -4,11 +4,11 @@ PKG             := qtifw
 $(PKG)_WEBSITE  := https://doc.qt.io/qtinstallerframework/index.html
 $(PKG)_DESCR    := Qt Installer Framework
 $(PKG)_IGNORE   :=
-$(PKG)_VERSION  := 3.0.4
-$(PKG)_CHECKSUM := a4ecafc37086f96a833463214f873caac977199e64f0b1453aa49bdd6f24f32e
-$(PKG)_SUBDIR    = qt-installer-framework-opensource-src-$($(PKG)_VERSION)
-$(PKG)_FILE     := $($(PKG)_SUBDIR).zip
-$(PKG)_URL      := https://download.qt.io/official_releases/qt-installer-framework/$($(PKG)_VERSION)/$($(PKG)_FILE)
+$(PKG)_VERSION  := 3.1.1
+$(PKG)_CHECKSUM := 59b5370aaf521bb1a34a025ac451bb3bbbfa519ee271156aba9d42ee1132d1b1
+# the archive is in fact only a tar file, not a tar.gz
+$(PKG)_FILE     := qtifw-$($(PKG)_VERSION).tar
+$(PKG)_URL      := https://download.qt.io/official_releases/qt-installer-framework/$($(PKG)_VERSION)/qt-installer-framework-opensource-src-$($(PKG)_VERSION).tar.gz
 $(PKG)_TARGETS  := $(BUILD) $(MXE_TARGETS)
 
 $(PKG)_DEPS_$(BUILD) := cc qtbase qttools
@@ -28,4 +28,7 @@ define $(PKG)_BUILD_STATIC
     cd '$(1)' && '$(PREFIX)/$(TARGET)/qt5/bin/qmake'
     $(MAKE) -C '$(1)' -j '$(JOBS)' || $(MAKE) -C '$(1)' -j  1
     $(MAKE) -C '$(1)' -j 1 install
+
+    # build the tutorial installer in /tmp, because the binarycreator internal rename will fail if /tmp is not in the same filesystem as mxe
+    cd '$(1)examples/tutorial' && '$(PREFIX)/bin/$(BUILD)-binarycreator' -c config/config.xml -p packages -t $(PREFIX)/$(TARGET)/qt5/bin/installerbase.exe /tmp/test-$(PKG)-tutorialinstaller.exe && mv /tmp/test-$(PKG)-tutorialinstaller.exe $(PREFIX)/$(TARGET)/bin/test-$(PKG)-tutorialinstaller.exe
 endef


### PR DESCRIPTION
I switched to the unix-download, hence the changed lineendings in the patch.
The unix-download is a tar archive with a false tar.gz file suffix, so I had to change the filename and enable tar archives in mxe.

This package will now create an example installer as test executable.