### PR TITLE
Add glib-networking package

### DIFF
--- a/src/glib-networking.mk
+++ b/src/glib-networking.mk
@@ -1,0 +1,24 @@
+PKG             := glib-networking
+$(PKG)_WEBSITE  := https://www.gnome.org
+$(PKG)_DESCR    := Network-related GIO modules for glib
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 2.54.1
+$(PKG)_CHECKSUM := eaa787b653015a0de31c928e9a17eb57b4ce23c8cf6f277afaec0d685335012f
+$(PKG)_SUBDIR   := glib-networking-$($(PKG)_VERSION)
+$(PKG)_FILE     := glib-networking-$($(PKG)_VERSION).tar.xz
+$(PKG)_URL      := https://download.gnome.org/sources/$(PKG)/$(call SHORT_PKG_VERSION,$(PKG))/$($(PKG)_FILE)
+$(PKG)_DEPS     := cc gnutls glib
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- 'https://gitlab.gnome.org/GNOME/glib-networking/-/tags' | \
+    $(SED) -n "s,.*glib-networking-\([0-9]\+\.[0-9]*[0-9]*\.[^']*\)\.tar.*,\1,p" | \
+    $(SORT) -Vr | \
+    head -1
+endef
+
+define $(PKG)_BUILD
+    cd '$(BUILD_DIR)' && '$(SOURCE_DIR)/configure' \
+         $(MXE_CONFIGURE_OPTS)
+    $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)'
+    $(MAKE) -C '$(BUILD_DIR)' install
+endef


### PR DESCRIPTION
Newer versions of glib-networking would require complete meson build system support as autotools has been dropped.