### PR TITLE
Grantlee

### DIFF
--- a/src/grantlee-1-fixes.patch
+++ b/src/grantlee-1-fixes.patch
@@ -1,0 +1,31 @@
+This file is part of MXE. See LICENSE.md for licensing information.
+
+Contains a fix for building on QT 5.13.
+
+From 1b4f22431ae35dfd11f07a5ae88a1b4db3de2a85 Mon Sep 17 00:00:00 2001
+From: Michael Pyne <mpyne@kde.org>
+Date: Tue, 18 Dec 2018 17:47:21 -0500
+Subject: [PATCH] Fix build with Qt 5.13 / GCC 8.2.
+
+At this point Grantlee doesn't build for me because QList is an
+incomplete type. I think the compiler is right to complain, so I fix by
+including the appropriate header.
+
+Fixes issue #47.
+---
+ templates/lib/lexer_p.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/templates/lib/lexer_p.h b/templates/lib/lexer_p.h
+index 275aeea..1ae451a 100644
+--- a/templates/lib/lexer_p.h
++++ b/templates/lib/lexer_p.h
+@@ -24,7 +24,7 @@
+ #include "textprocessingmachine_p.h"
+ #include "token.h"
+ 
+-template <typename T> class QList;
++#include <QList>
+ 
+ namespace Grantlee
+ {

--- a/src/grantlee.mk
+++ b/src/grantlee.mk
@@ -1,8 +1,8 @@
 # This file is part of MXE. See LICENSE.md for licensing information.
 
 PKG             := grantlee
-$(PKG)_WEBSITE  := 
-$(PKG)_DESCR    := 
+$(PKG)_WEBSITE  := https://github.com/steveire/grantlee
+$(PKG)_DESCR    := Grantlee is a set of Free Software libraries written using the Qt framework
 $(PKG)_IGNORE   :=
 $(PKG)_VERSION  := 5.1.0
 $(PKG)_CHECKSUM := 3836572fe5e49d28a1d99186c6d96f88ff839644b4bc77b73b6d8208f6ccc9d1
@@ -14,5 +14,4 @@ define $(PKG)_BUILD
          $($(PKG)_CONFIGURE_OPTS)
     $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)' VERBOSE=1
     $(MAKE) -C '$(BUILD_DIR)' -j 1 install VERBOSE=1
-
  endef

--- a/src/grantlee.mk
+++ b/src/grantlee.mk
@@ -1,0 +1,18 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+PKG             := grantlee
+$(PKG)_WEBSITE  := 
+$(PKG)_DESCR    := 
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 5.1.0
+$(PKG)_CHECKSUM := 3836572fe5e49d28a1d99186c6d96f88ff839644b4bc77b73b6d8208f6ccc9d1
+$(PKG)_GH_CONF  := steveire/grantlee/tags,v
+$(PKG)_DEPS     := cc qtbase
+
+define $(PKG)_BUILD
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' '$(SOURCE_DIR)' \
+         $($(PKG)_CONFIGURE_OPTS)
+    $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)' VERBOSE=1
+    $(MAKE) -C '$(BUILD_DIR)' -j 1 install VERBOSE=1
+
+ endef


### PR DESCRIPTION
Adds grantlee texttemplating Qt package.
Builds the 5.1 version with a patch to build on Qt 5.13
I am not associated with this package, the project I am contributing to (subsurface-divelog) uses it as well as MXE. 

