### PR TITLE
Set tries and timeout for wget in update rules

### DIFF
--- a/src/a52dec.mk
+++ b/src/a52dec.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://liba52.sourceforge.io/files/$(PKG)-$($(PKG)_VERSION).
 $(PKG)_DEPS     := cc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://liba52.sourceforge.io/downloads.html' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://liba52.sourceforge.io/downloads.html' | \
     $(SED) -n 's,.*files/a52dec-\([0-9][^"]*\)\.tar.*,\1,p' | \
     head -1
 endef

--- a/src/agg.mk
+++ b/src/agg.mk
@@ -13,7 +13,7 @@ $(PKG)_URL_2    := https://web.archive.org/web/20170111090029/www.antigrain.com/
 $(PKG)_DEPS     := cc freetype sdl
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://antigrain.com/download/index.html' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://antigrain.com/download/index.html' | \
     $(SED) -n 's,.*<A href="https://antigrain.com/agg-\([0-9.]*\).tar.gz".*,\1,p' | \
     head -1
 endef

--- a/src/alure.mk
+++ b/src/alure.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://kcat.strangesoft.net/alure-releases/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc flac libsndfile mpg123 ogg openal vorbis
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- https://repo.or.cz/alure.git/tags | \
+    $(WGET) -q -O- -t 2 --timeout=6 https://repo.or.cz/alure.git/tags | \
     grep alure- | \
     $(SED) -n 's,.*alure-\([0-9\.]*\)<.*,\1,p' | \
     head -1

--- a/src/apr-util.mk
+++ b/src/apr-util.mk
@@ -13,7 +13,7 @@ $(PKG)_URL_2    := https://www.apache.org/dist/apr/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc apr expat libiconv
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://apr.apache.org/download.cgi' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://apr.apache.org/download.cgi' | \
     grep 'aprutil1.*best' |
     $(SED) -n 's,.*APR-util \([0-9.]*\).*,\1,p'
 endef

--- a/src/apr.mk
+++ b/src/apr.mk
@@ -13,7 +13,7 @@ $(PKG)_URL_2    := https://www.apache.org/dist/apr/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://apr.apache.org/download.cgi' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://apr.apache.org/download.cgi' | \
     grep 'apr1.*best' |
     $(SED) -n 's,.*APR \([0-9.]*\).*,\1,p'
 endef

--- a/src/armadillo.mk
+++ b/src/armadillo.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://$(SOURCEFORGE_MIRROR)/project/arma/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc hdf5 openblas
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://sourceforge.net/projects/arma/files/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://sourceforge.net/projects/arma/files/' | \
     $(SED) -n 's,.*/armadillo-\([0-9.]*\)[.]tar.*".*,\1,p' | \
     head -1
 endef

--- a/src/aspell.mk
+++ b/src/aspell.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://ftp.gnu.org/gnu/$(PKG)/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc gettext
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://ftp.gnu.org/gnu/aspell/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://ftp.gnu.org/gnu/aspell/' | \
     $(SED) -n 's,.*/\([0-9][^"]*\)/".*,\1,p' | \
     head -1
 endef

--- a/src/atk.mk
+++ b/src/atk.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://download.gnome.org/sources/atk/$(call SHORT_PKG_VERSI
 $(PKG)_DEPS     := cc gettext glib
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://gitlab.gnome.org/GNOME/atk/tags' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://gitlab.gnome.org/GNOME/atk/tags' | \
     $(SED) -n "s,.*<a [^>]\+>ATK_\([0-9]\+_[0-9_]\+\)<.*,\1,p" | \
     $(SED) "s,_,.,g;" | \
     head -1

--- a/src/atkmm.mk
+++ b/src/atkmm.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://download.gnome.org/sources/atkmm/$(call SHORT_PKG_VER
 $(PKG)_DEPS     := cc atk glibmm
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://gitlab.gnome.org/GNOME/atkmm/tags' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://gitlab.gnome.org/GNOME/atkmm/tags' | \
     $(SED) -n "s,.*<a [^>]\+>v\?\([0-9]\+\.[0-9.]\+\)<.*,\1,p" | \
     head -1
 endef

--- a/src/aubio.mk
+++ b/src/aubio.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://www.aubio.org/pub/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc ffmpeg fftw jack libsamplerate libsndfile $(BUILD)~waf
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://www.aubio.org/download' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://www.aubio.org/download' | \
     $(SED) -n 's,.*aubio-\([0-9][^>]*\)\.tar.*,\1,p' | \
     head -1
 endef

--- a/src/binutils.mk
+++ b/src/binutils.mk
@@ -12,7 +12,7 @@ $(PKG)_URL_2    := https://ftpmirror.gnu.org/binutils/$($(PKG)_FILE)
 $(PKG)_DEPS     :=
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://ftp.gnu.org/gnu/binutils/?C=M;O=D' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://ftp.gnu.org/gnu/binutils/?C=M;O=D' | \
     $(SED) -n 's,.*<a href="binutils-\([0-9][^"]*\)\.tar.*,\1,p' | \
     $(SORT) -V | \
     tail -1

--- a/src/boost.mk
+++ b/src/boost.mk
@@ -15,7 +15,7 @@ $(PKG)_DEPS     := cc bzip2 expat zlib
 $(PKG)_DEPS_$(BUILD) := zlib
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://www.boost.org/users/download/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://www.boost.org/users/download/' | \
     $(SED) -n 's,.*/release/\([0-9][^"/]*\)/.*,\1,p' | \
     grep -v beta | \
     head -1

--- a/src/bullet.mk
+++ b/src/bullet.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://storage.googleapis.com/google-code-archive-downloads/
 $(PKG)_DEPS     := cc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://code.google.com/p/bullet/downloads/list?sort=-uploaded' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://code.google.com/p/bullet/downloads/list?sort=-uploaded' | \
     $(SED) -n 's,.*bullet-\([0-9][^<]*\)\.tgz.*,\1,p' | \
     head -1
 endef

--- a/src/bzip2.mk
+++ b/src/bzip2.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://ftp.osuosl.org/pub/clfs/conglomeration/bzip2/$($(PKG)
 $(PKG)_DEPS     := cc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://ftp.osuosl.org/pub/clfs/conglomeration/bzip2/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://ftp.osuosl.org/pub/clfs/conglomeration/bzip2/' | \
     grep 'bzip2-' | \
     $(SED) -n 's,.*bzip2-\([0-9][^>]*\)\.tar.*,\1,p' | \
     sort -V | \

--- a/src/cairo.mk
+++ b/src/cairo.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://cairographics.org/releases/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc fontconfig freetype-bootstrap glib libpng lzo pixman zlib
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://cairographics.org/releases/?C=M;O=D' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://cairographics.org/releases/?C=M;O=D' | \
     $(SED) -n 's,.*"cairo-\([0-9]\.[0-9][^"]*\)\.tar.*,\1,p' | \
     head -1
 endef

--- a/src/cairomm.mk
+++ b/src/cairomm.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://cairographics.org/releases/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc cairo libsigc++
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://cairographics.org/releases/?C=M;O=D' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://cairographics.org/releases/?C=M;O=D' | \
     $(SED) -n 's,.*"cairomm-\([0-9][^"]*\)\.tar.*,\1,p' | \
     $(SORT) -V | \
     tail -1

--- a/src/ccfits.mk
+++ b/src/ccfits.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://heasarc.gsfc.nasa.gov/fitsio/CCfits/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc cfitsio
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- "https://heasarc.gsfc.nasa.gov/docs/software/fitsio/ccfits/" | \
+    $(WGET) -q -O- -t 2 --timeout=6 "https://heasarc.gsfc.nasa.gov/docs/software/fitsio/ccfits/" | \
     grep -i '<a href="CCfits.*tar' | \
     $(SED) -n 's,.*CCfits-\([0-9][^>]*\)\.tar.*,\1,p' | \
     head -1

--- a/src/cegui.mk
+++ b/src/cegui.mk
@@ -13,7 +13,7 @@ $(PKG)_DEPS     := cc expat freeglut freeimage freetype fribidi glew \
                    glfw3 glm libxml2 minizip pcre xerces
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://bitbucket.org/cegui/cegui/downloads' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://bitbucket.org/cegui/cegui/downloads' | \
     $(SED) -n 's,.*href=.*get/v\([0-9]*-[0-9]*-[0-9]*\)\.tar.*,\1,p' | \
     $(SED) 's,-,.,g' | \
     $(SORT) -V | \
@@ -22,7 +22,7 @@ endef
 
 # track dev branch v0-8 until next release
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://bitbucket.org/cegui/cegui/commits/branch/v0-8' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://bitbucket.org/cegui/cegui/commits/branch/v0-8' | \
     $(SED) -n 's,.*cegui/cegui/commits/\([^?]\{12\}\).*at=.*,\1,p' | \
     head -1
 endef

--- a/src/cfitsio.mk
+++ b/src/cfitsio.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://heasarc.gsfc.nasa.gov/FTP/software/fitsio/c/$($(PKG)_
 $(PKG)_DEPS     := cc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- "https://heasarc.gsfc.nasa.gov/FTP/software/fitsio/c/?C=M;O=D" | \
+    $(WGET) -q -O- -t 2 --timeout=6 "https://heasarc.gsfc.nasa.gov/FTP/software/fitsio/c/?C=M;O=D" | \
     grep -i '<a href="cfitsio.*tar' | \
     $(SED) -n 's,.*cfitsio\([0-9][^>]*\)\.tar.*,\1,p' | \
     head -1

--- a/src/check.mk
+++ b/src/check.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://$(SOURCEFORGE_MIRROR)/project/$(PKG)/$(PKG)/$($(PKG)_
 $(PKG)_DEPS     := cc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://sourceforge.net/projects/check/files/check/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://sourceforge.net/projects/check/files/check/' | \
     $(SED) -n 's,.*/projects/.*/\([0-9][^"]*\)/".*,\1,p' | \
     head -1
 endef

--- a/src/cimg.mk
+++ b/src/cimg.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := http://cimg.eu/files/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'http://cimg.eu/files/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'http://cimg.eu/files/' | \
     $(SED) -n 's,.*CImg_\([0-9][^"]*\)\.zip.*,\1,p' | \
     $(SORT) -Vr | \
     head -1

--- a/src/cloog.mk
+++ b/src/cloog.mk
@@ -13,7 +13,7 @@ $(PKG)_URL_2    := https://gcc.gnu.org/pub/gcc/infrastructure/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc gmp isl
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://www.bastoul.net/cloog/download.php' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://www.bastoul.net/cloog/download.php' | \
     $(SED) -n 's,.*cloog-\([0-9][^>]*\)\.tar.*,\1,p' | \
     $(SORT) -V |
     tail -1

--- a/src/cmake.mk
+++ b/src/cmake.mk
@@ -15,7 +15,7 @@ define $(PKG)_UPDATE
     echo 'NOTE: Please ensure all cmake packages build after updating with:' >&2;
     echo '    make `make show-downstream-deps-cmake` MXE_TARGETS="$(MXE_TARGET_LIST)"' >&2;
     echo '' >&2;
-    $(WGET) -q -O- 'https://www.cmake.org/cmake/resources/software.html' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://www.cmake.org/cmake/resources/software.html' | \
     $(SED) -n 's,.*cmake-\([0-9.]*\)\.tar.*,\1,p' | \
     $(SORT) -V | \
     tail -1

--- a/src/cminpack.mk
+++ b/src/cminpack.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := http://devernay.free.fr/hacks/cminpack/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'http://devernay.free.fr/hacks/cminpack/index.html' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'http://devernay.free.fr/hacks/cminpack/index.html' | \
     $(SED) -n 's,.*cminpack-\([0-9.]*\)\.tar.*,\1,p' | \
     head -1
 endef

--- a/src/coin.mk
+++ b/src/coin.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://bitbucket.org/Coin3D/coin/downloads/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc dlfcn-win32
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://bitbucket.org/Coin3D/coin/downloads' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://bitbucket.org/Coin3D/coin/downloads' | \
     $(SED) -n 's,.*Coin-\([0-9.]*\).tar.gz.*,\1,p' | \
     $(SORT) -V | \
     tail -1

--- a/src/cppunit.mk
+++ b/src/cppunit.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://dev-www.libreoffice.org/src/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://dev-www.libreoffice.org/src/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://dev-www.libreoffice.org/src/' | \
     $(SED) -n 's,.*href="cppunit-\([0-9][^"]*\)\.tar.*,\1,p' | \
     $(SORT) -Vr | \
     head -1

--- a/src/cryptopp.mk
+++ b/src/cryptopp.mk
@@ -14,7 +14,7 @@ $(PKG)_URL_2    := https://www.cryptopp.com/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://www.cryptopp.com/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://www.cryptopp.com/' | \
     $(SED) -n 's,<TITLE>Crypto++ Library \([0-9]\.[0-9]\.[0-9]\).*,\1,p'
 endef
 

--- a/src/cunit.mk
+++ b/src/cunit.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://$(SOURCEFORGE_MIRROR)/project/cunit/CUnit/$($(PKG)_VE
 $(PKG)_DEPS     := cc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://sourceforge.net/projects/cunit/files/CUnit/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://sourceforge.net/projects/cunit/files/CUnit/' | \
     $(SED) -n 's,.*/projects/.*/\([0-9][^"]*\)/".*,\1,p' | \
     head -1
 endef

--- a/src/curl.mk
+++ b/src/curl.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://curl.haxx.se/download/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc libidn2 libssh2 pthreads
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://curl.haxx.se/download/?C=M;O=D' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://curl.haxx.se/download/?C=M;O=D' | \
     $(SED) -n 's,.*curl-\([0-9][^"]*\)\.tar.*,\1,p' | \
     head -1
 endef

--- a/src/db.mk
+++ b/src/db.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://download.oracle.com/berkeley-db/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://www.oracle.com/technetwork/database/database-technologies/berkeleydb/downloads/index.html' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://www.oracle.com/technetwork/database/database-technologies/berkeleydb/downloads/index.html' | \
     $(SED) -n 's,.*/db-\([0-9\.]\+\)\.tar.gz.*,\1,p' | \
     head -1
 endef

--- a/src/dbus.mk
+++ b/src/dbus.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://$(PKG).freedesktop.org/releases/$(PKG)/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc expat
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://cgit.freedesktop.org/dbus/dbus/refs/tags' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://cgit.freedesktop.org/dbus/dbus/refs/tags' | \
     $(SED) -n "s,.*<a href='[^']*/tag/?h=dbus-\\([0-9][^']*\\)'.*,\\1,p" | \
     $(SORT) -V | \
     tail -1

--- a/src/dcmtk.mk
+++ b/src/dcmtk.mk
@@ -13,7 +13,7 @@ $(PKG)_URL_2    := https://mirrorservice.org/sites/ftp.debian.org/debian/pool/ma
 $(PKG)_DEPS     := cc libpng libxml2 openssl tiff zlib
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://dicom.offis.de/dcmtk.php.en' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://dicom.offis.de/dcmtk.php.en' | \
     $(SED) -n 's,.*/dcmtk-\([0-9][^"]*\)\.tar.*,\1,p' | \
     head -1
 endef

--- a/src/djvulibre.mk
+++ b/src/djvulibre.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://$(SOURCEFORGE_MIRROR)/project/djvu/DjVuLibre/$($(PKG)
 $(PKG)_DEPS     := cc jpeg tiff zlib
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://sourceforge.net/projects/djvu/files/DjVuLibre/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://sourceforge.net/projects/djvu/files/DjVuLibre/' | \
     $(SED) -n 's,.*/\([0-9][^A-Za-z"]*\)/".*,\1,p' | \
     head -1
 endef

--- a/src/eigen.mk
+++ b/src/eigen.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://bitbucket.org/$(PKG)/$(PKG)/get/$($(PKG)_VERSION).tar
 $(PKG)_DEPS     := cc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://eigen.tuxfamily.org/index.php?title=Main_Page#Download' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://eigen.tuxfamily.org/index.php?title=Main_Page#Download' | \
     grep 'eigen/get/' | \
     $(SED) -n 's,.*eigen/get/\(3[^>]*\)\.tar.*,\1,p' | \
     head -1

--- a/src/exiv2.mk
+++ b/src/exiv2.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://www.exiv2.org/releases/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc expat gettext mman-win32 zlib
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://www.exiv2.org/download.html' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://www.exiv2.org/download.html' | \
     grep 'href="exiv2-' | \
     $(SED) -n 's,.*exiv2-\([0-9][^>]*\)\.tar.*,\1,p' | \
     head -1

--- a/src/expat.mk
+++ b/src/expat.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://$(SOURCEFORGE_MIRROR)/project/expat/expat/$($(PKG)_VE
 $(PKG)_DEPS     := cc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://sourceforge.net/projects/expat/files/expat/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://sourceforge.net/projects/expat/files/expat/' | \
     $(SED) -n 's,.*/projects/.*/\([0-9][^"]*\)/".*,\1,p' | \
     head -1
 endef

--- a/src/faad2.mk
+++ b/src/faad2.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://$(SOURCEFORGE_MIRROR)/project/faac/$(PKG)-src/$(PKG)-
 $(PKG)_DEPS     := cc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://sourceforge.net/projects/faac/files/faad2-src/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://sourceforge.net/projects/faac/files/faad2-src/' | \
     $(SED) -n 's,.*faad2-\([0-9][^"]*\)/".*,\1,p' | \
     head -1
 endef

--- a/src/fdk-aac.mk
+++ b/src/fdk-aac.mk
@@ -15,7 +15,7 @@ $(PKG)_URL      := https://$(SOURCEFORGE_MIRROR)/project/opencore-amr/$(PKG)/$($
 $(PKG)_DEPS     := cc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://sourceforge.net/projects/opencore-amr/files/fdk-aac/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://sourceforge.net/projects/opencore-amr/files/fdk-aac/' | \
     $(SED) -n 's,.*fdk-aac-\([0-9.]*\)\.tar.*,\1,p' | \
     $(SORT) -V | \
     tail -1

--- a/src/ffmpeg.mk
+++ b/src/ffmpeg.mk
@@ -18,7 +18,7 @@ $(PKG)_DEPS     := cc bzip2 gnutls lame libass libbluray libbs2b libcaca \
 # See docs/index.html#potential-legal-issues
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://ffmpeg.org/releases/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://ffmpeg.org/releases/' | \
     $(SED) -n 's,.*ffmpeg-\([0-9][^>]*\)\.tar.*,\1,p' | \
     grep -v 'alpha\|beta\|rc\|git' | \
     $(SORT) -Vr | \

--- a/src/fftw.mk
+++ b/src/fftw.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := http://www.fftw.org/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'http://www.fftw.org/download.html' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'http://www.fftw.org/download.html' | \
     $(SED) -n 's,.*fftw-\([0-9][^>]*\)\.tar.*,\1,p' | \
     grep -v alpha | \
     grep -v beta | \

--- a/src/file.mk
+++ b/src/file.mk
@@ -13,7 +13,7 @@ $(PKG)_URL      := https://distfiles.macports.org/file/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc libgnurx
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://distfiles.macports.org/file/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://distfiles.macports.org/file/' | \
     grep 'file-' | \
     $(SED) -n 's,.*file-\([0-9][^>]*\)\.tar.*,\1,p' | \
     tail -1

--- a/src/flac.mk
+++ b/src/flac.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://downloads.xiph.org/releases/flac/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc ogg $(BUILD)~nasm
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://downloads.xiph.org/releases/flac/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://downloads.xiph.org/releases/flac/' | \
     $(SED) -n 's,.*<a href="flac-\([0-9][0-9.]*\)\.tar\.[gx]z">.*,\1,p' | \
     $(SORT) -V | \
     tail -1

--- a/src/flann.mk
+++ b/src/flann.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://www.cs.ubc.ca/research/flann/uploads/FLANN/$($(PKG)_F
 $(PKG)_DEPS     := cc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://www.cs.ubc.ca/research/flann/index.php/FLANN/Changelog' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://www.cs.ubc.ca/research/flann/index.php/FLANN/Changelog' | \
     grep 'Version' | \
     $(SED) -n 's,.*Version.\([0-9.]*\).*,\1,p' | \
     head -1

--- a/src/fltk.mk
+++ b/src/fltk.mk
@@ -13,7 +13,7 @@ $(PKG)_URL      := https://fltk.org/pub/fltk/$($(PKG)_MAJOR)/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc jpeg libpng pthreads zlib
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://www.fltk.org/software.php' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://www.fltk.org/software.php' | \
     $(SED) -n 's,.*>fltk-\([0-9]\+\([\.\-][0-9]\+\)\+\)-source\.tar\.gz<.*,\1,p' | \
     grep -v '^1\.1\.' | \
     head -1

--- a/src/fontconfig.mk
+++ b/src/fontconfig.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://fontconfig.org/release/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc expat freetype-bootstrap gettext
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://fontconfig.org/release/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://fontconfig.org/release/' | \
     $(SED) -n 's,.*fontconfig-\([0-9][^>]*\)\.tar.*,\1,p' | \
     grep -v '\([0-9]\+\.\)\{2\}9[0-9]' | \
     tail -1

--- a/src/freeglut.mk
+++ b/src/freeglut.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://$(SOURCEFORGE_MIRROR)/project/freeglut/freeglut/$($(P
 $(PKG)_DEPS     := cc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://sourceforge.net/projects/freeglut/files/freeglut/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://sourceforge.net/projects/freeglut/files/freeglut/' | \
     $(SED) -n 's,.*freeglut-\([0-9][^>]*\)\.tar.*,\1,p' | \
     head -1
 endef

--- a/src/freeimage.mk
+++ b/src/freeimage.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://$(SOURCEFORGE_MIRROR)/project/freeimage/Source Distri
 $(PKG)_DEPS     := cc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://sourceforge.net/projects/freeimage/files/Source Distribution/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://sourceforge.net/projects/freeimage/files/Source Distribution/' | \
     $(SED) -n 's,.*Distribution/\([0-9][^"]*\)/".*,\1,p' | \
     head -1
 endef

--- a/src/freetds.mk
+++ b/src/freetds.mk
@@ -13,7 +13,7 @@ $(PKG)_URL_2    := https://fossies.org/linux/privat/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc openssl libiconv
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://www.freetds.org/files/stable/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://www.freetds.org/files/stable/' | \
     $(SED) -n 's,.*freetds-\([0-9.]*\)\.tar.*,\1,p' | \
     $(SORT) -V | \
     tail -1

--- a/src/freetype.mk
+++ b/src/freetype.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://$(SOURCEFORGE_MIRROR)/project/freetype/freetype2/$(sh
 $(PKG)_DEPS     := cc bzip2 harfbuzz libpng zlib
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://sourceforge.net/projects/freetype/files/freetype2/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://sourceforge.net/projects/freetype/files/freetype2/' | \
     $(SED) -n 's,.*/projects/.*/\([0-9][^"]*\)/".*,\1,p' | \
     $(SORT) -V | \
     tail -1

--- a/src/freexl.mk
+++ b/src/freexl.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://www.gaia-gis.it/gaia-sins/freexl-sources/$($(PKG)_FIL
 $(PKG)_DEPS     := cc libiconv
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://www.gaia-gis.it/gaia-sins/freexl-sources/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://www.gaia-gis.it/gaia-sins/freexl-sources/' | \
     $(SED) -n 's,.*freexl-\([0-9][^>]*\)\.tar.*,\1,p' | \
     tail -1
 endef

--- a/src/ftgl.mk
+++ b/src/ftgl.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://$(SOURCEFORGE_MIRROR)/project/$(PKG)/FTGL Source/$($(
 $(PKG)_DEPS     := cc freeglut freetype
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://sourceforge.net/projects/ftgl/files/FTGL Source/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://sourceforge.net/projects/ftgl/files/FTGL Source/' | \
     $(SED) -n 's,.*<tr title="\([0-9][^"]*\)".*,\1,p' | \
     head -1
 endef

--- a/src/gcc.mk
+++ b/src/gcc.mk
@@ -13,7 +13,7 @@ $(PKG)_URL_2    := https://www.mirrorservice.org/sites/sourceware.org/pub/gcc/re
 $(PKG)_DEPS     := binutils mingw-w64 $(addprefix $(BUILD)~,gmp isl mpc mpfr)
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://ftp.gnu.org/gnu/gcc/?C=M;O=D' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://ftp.gnu.org/gnu/gcc/?C=M;O=D' | \
     grep -v 'gcc-6\|gcc-7' | \
     $(SED) -n 's,.*<a href="gcc-\([0-9][^"]*\)/".*,\1,p' | \
     $(SORT) -V | \

--- a/src/gd.mk
+++ b/src/gd.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://bitbucket.org/libgd/gd-libgd/downloads/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc fontconfig freetype jpeg libpng libvpx pthreads tiff
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://bitbucket.org/libgd/gd-libgd/downloads/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://bitbucket.org/libgd/gd-libgd/downloads/' | \
     $(SED) -n 's,.*libgd-\([0-9.]*\)\.tar.*,\1,p' | \
     head -1
 endef

--- a/src/gdal.mk
+++ b/src/gdal.mk
@@ -14,7 +14,7 @@ $(PKG)_DEPS     := cc armadillo curl expat geos giflib gta hdf4 hdf5 \
                    netcdf openjpeg postgresql proj spatialite sqlite tiff zlib
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://trac.osgeo.org/gdal/wiki/DownloadSource' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://trac.osgeo.org/gdal/wiki/DownloadSource' | \
     $(SED) -n 's,.*gdal-\([0-9][^>]*\)\.tar.*,\1,p' | \
     head -1
 endef

--- a/src/gdb.mk
+++ b/src/gdb.mk
@@ -11,7 +11,7 @@ $(PKG)_URL_2    := https://ftpmirror.gnu.org/$(PKG)/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc dlfcn-win32 expat libiconv mman-win32 readline zlib
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://ftp.gnu.org/gnu/gdb/?C=M;O=D' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://ftp.gnu.org/gnu/gdb/?C=M;O=D' | \
     $(SED) -n 's,.*<a href="gdb-\([0-9][^"]*\)\.tar.*,\1,p' | \
     $(SORT) -V | \
     tail -1

--- a/src/gdk-pixbuf.mk
+++ b/src/gdk-pixbuf.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://download.gnome.org/sources/gdk-pixbuf/$(call SHORT_PK
 $(PKG)_DEPS     := cc glib jasper jpeg libiconv libpng tiff
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://gitlab.gnome.org/GNOME/gdk-pixbuf/tags' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://gitlab.gnome.org/GNOME/gdk-pixbuf/tags' | \
     $(SED) -n "s,.*<a [^>]\+>v\?\([0-9]\+\.[0-9.]\+\)<.*,\1,p" | \
     grep -v '^2\.9' | \
     head -1

--- a/src/geoip-database.mk
+++ b/src/geoip-database.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://deb.debian.org/debian/pool/main/g/$(PKG)/$($(PKG)_FIL
 $(PKG)_TARGETS  := $(BUILD)
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://packages.debian.org/jessie/all/geoip-database/download' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://packages.debian.org/jessie/all/geoip-database/download' | \
     $(SED) -n 's,.*geoip-database_\([0-9\-]*\)_all.deb.*,\1,p' | \
     head -1
 endef

--- a/src/geos.mk
+++ b/src/geos.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://download.osgeo.org/geos/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://download.osgeo.org/geos/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://download.osgeo.org/geos/' | \
     $(SED) -n 's,.*geos-\([0-9][^>]*\)\.tar.*,\1,p' | \
     tail -1
 endef

--- a/src/gettext.mk
+++ b/src/gettext.mk
@@ -17,7 +17,7 @@ $(PKG)_TARGETS       := $(BUILD) $(MXE_TARGETS)
 $(PKG)_DEPS_$(BUILD) := libiconv
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://ftp.gnu.org/gnu/gettext/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://ftp.gnu.org/gnu/gettext/' | \
     grep 'gettext-' | \
     $(SED) -n 's,.*gettext-\([0-9][^>]*\)\.tar.*,\1,p' | \
     $(SORT) -Vr | \

--- a/src/ghostscript.mk
+++ b/src/ghostscript.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://github.com/ArtifexSoftware/ghostpdl-downloads/release
 $(PKG)_DEPS     := cc dbus fontconfig freetype lcms libiconv libidn libpaper libpng openjpeg tiff zlib
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://api.github.com/repos/ArtifexSoftware/ghostpdl-downloads/releases' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://api.github.com/repos/ArtifexSoftware/ghostpdl-downloads/releases' | \
     $(SED) -n 's,.*"ghostscript-\([0-9\.]*\)\.tar.xz".*,\1,p' | \
     head -1
 endef

--- a/src/giflib.mk
+++ b/src/giflib.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://$(SOURCEFORGE_MIRROR)/project/giflib/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://sourceforge.net/projects/giflib/files/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://sourceforge.net/projects/giflib/files/' | \
     grep '<a href.*giflib.*bz2/download' | \
     $(SED) -n 's,.*giflib-\([0-9][^>]*\)\.tar.*,\1,p' | \
     head -1

--- a/src/glew.mk
+++ b/src/glew.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://$(SOURCEFORGE_MIRROR)/project/glew/glew/$($(PKG)_VERS
 $(PKG)_DEPS     := cc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://sourceforge.net/projects/glew/files/glew/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://sourceforge.net/projects/glew/files/glew/' | \
     $(SED) -n 's,.*/\([0-9][^A-Za-z"]*\)/".*,\1,p' | \
     head -1
 endef

--- a/src/glfw2.mk
+++ b/src/glfw2.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://$(SOURCEFORGE_MIRROR)/project/glfw/glfw/$($(PKG)_VERS
 $(PKG)_DEPS     := cc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://sourceforge.net/projects/glfw/files/glfw/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://sourceforge.net/projects/glfw/files/glfw/' | \
     $(SED) -n 's,.*/\([0-9][^"]*\)/".*,\1,p' | \
     grep '^2\.' | \
     $(SORT) -V | \

--- a/src/glib-networking.mk
+++ b/src/glib-networking.mk
@@ -10,7 +10,7 @@ $(PKG)_URL      := https://download.gnome.org/sources/$(PKG)/$(call SHORT_PKG_VE
 $(PKG)_DEPS     := cc gnutls glib
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://gitlab.gnome.org/GNOME/glib-networking/-/tags' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://gitlab.gnome.org/GNOME/glib-networking/-/tags' | \
     $(SED) -n "s,.*glib-networking-\([0-9]\+\.[0-9]*[0-9]*\.[^']*\)\.tar.*,\1,p" | \
     $(SORT) -Vr | \
     head -1

--- a/src/glib.mk
+++ b/src/glib.mk
@@ -15,7 +15,7 @@ $(PKG)_TARGETS  := $(BUILD) $(MXE_TARGETS)
 $(PKG)_DEPS_$(BUILD) := autotools gettext libffi libiconv zlib
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://gitlab.gnome.org/GNOME/glib/tags' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://gitlab.gnome.org/GNOME/glib/tags' | \
     $(SED) -n "s,.*<a [^>]\+>v\?\([0-9]\+\.[0-9.]\+\)<.*,\1,p" | \
     $(SORT) -Vr | \
     head -1

--- a/src/glibmm.mk
+++ b/src/glibmm.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://download.gnome.org/sources/glibmm/$(call SHORT_PKG_VE
 $(PKG)_DEPS     := cc glib libsigc++
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://gitlab.gnome.org/GNOME/glibmm/tags' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://gitlab.gnome.org/GNOME/glibmm/tags' | \
     $(SED) -n "s,.*<a [^>]\+>v\?\([0-9]\+\.[0-9.]\+\)<.*,\1,p" | \
     $(SORT) -Vr | \
     head -1

--- a/src/glpk.mk
+++ b/src/glpk.mk
@@ -15,7 +15,7 @@ $(PKG)_DEPS     := cc gmp
 # libmysqlclient and odbc not supported on windows (see INSTALL and configure.ac)
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://ftp.gnu.org/gnu/glpk/?C=M;O=D' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://ftp.gnu.org/gnu/glpk/?C=M;O=D' | \
     $(SED) -n 's,.*<a href="glpk-\([0-9][^"]*\)\.tar.*,\1,p' | \
     head -1
 endef

--- a/src/gmp.mk
+++ b/src/gmp.mk
@@ -15,7 +15,7 @@ $(PKG)_DEPS     := cc
 $(PKG)_DEPS_$(BUILD) :=
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://gmplib.org/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://gmplib.org/' | \
     grep '<a href="' | \
     $(SED) -n 's,.*gmp-\([0-9][^>]*\)\.tar.*,\1,p' | \
     $(SORT) -V | \

--- a/src/gnutls.mk
+++ b/src/gnutls.mk
@@ -12,7 +12,7 @@ $(PKG)_URL_2    := https://www.mirrorservice.org/sites/ftp.gnupg.org/gcrypt/gnut
 $(PKG)_DEPS     := cc gettext gmp libidn2 libtasn1 libunistring nettle zlib
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- https://gnupg.org/ftp/gcrypt/gnutls/v3.6/ | \
+    $(WGET) -q -O- -t 2 --timeout=6 https://gnupg.org/ftp/gcrypt/gnutls/v3.6/ | \
     $(SED) -n 's,.*gnutls-\([1-9]\+\.[0-9]\+.[0-9]\+\)\..*,\1,p' | \
     $(SORT) -V | \
     tail -1

--- a/src/gpgme.mk
+++ b/src/gpgme.mk
@@ -13,7 +13,7 @@ $(PKG)_URL_2    := https://www.mirrorservice.org/sites/ftp.gnupg.org/gcrypt/gpgm
 $(PKG)_DEPS     := cc gettext libgpg_error libassuan
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://gnupg.org/ftp/gcrypt/gpgme/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://gnupg.org/ftp/gcrypt/gpgme/' | \
     $(SED) -n 's,.*gpgme-\([1-9]\.[1-9][0-9][^>]*\)\.tar.*,\1,p' | \
     head -1
 endef

--- a/src/graphicsmagick.mk
+++ b/src/graphicsmagick.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://$(SOURCEFORGE_MIRROR)/project/$(PKG)/$(PKG)/$($(PKG)_
 $(PKG)_DEPS     := cc bzip2 freetype jasper jpeg lcms libltdl libpng libxml2 pthreads tiff zlib
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://sourceforge.net/projects/graphicsmagick/files/graphicsmagick/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://sourceforge.net/projects/graphicsmagick/files/graphicsmagick/' | \
     $(SED) -n 's,.*/projects/.*/\([0-9][^"]*\)/".*,\1,p' | \
     head -1
 endef

--- a/src/gsl.mk
+++ b/src/gsl.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://ftp.gnu.org/gnu/$(PKG)/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://ftp.gnu.org/gnu/$(PKG)/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://ftp.gnu.org/gnu/$(PKG)/' | \
     $(SED) -n 's,.*<a href="gsl-\([0-9.]\+\).tar.gz".*,\1,p' | \
     $(SORT) -V | \
     tail -1

--- a/src/gsoap.mk
+++ b/src/gsoap.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://$(SOURCEFORGE_MIRROR)/project/gsoap2/gsoap-$(call SHO
 $(PKG)_DEPS     := cc libgcrypt libntlm openssl
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://sourceforge.net/projects/gsoap2/files/gsoap-2.8/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://sourceforge.net/projects/gsoap2/files/gsoap-2.8/' | \
     $(SED) -n 's,.*gsoap_\([0-9][^>]*\)\.zip.*,\1,p' | \
     head -1
 endef

--- a/src/gstreamer.mk
+++ b/src/gstreamer.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://gstreamer.freedesktop.org/src/$(PKG)/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc glib libxml2 pthreads
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://cgit.freedesktop.org/gstreamer/gstreamer/refs/tags' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://cgit.freedesktop.org/gstreamer/gstreamer/refs/tags' | \
     $(SED) -n "s,.*<a href='[^']*/tag/?h=[^0-9]*\\([0-9]\..[02468]\.[0-9][^']*\\)'.*,\\1,p" | \
     $(SORT) -Vr | \
     head -1

--- a/src/gta.mk
+++ b/src/gta.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://download.savannah.gnu.org/releases/gta/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc bzip2 xz zlib
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://git.savannah.gnu.org/gitweb/?p=gta.git;a=tags' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://git.savannah.gnu.org/gitweb/?p=gta.git;a=tags' | \
     grep '<a [^>]*class="list subject"' | \
     $(SED) -n 's,.*<a[^>]*>libgta-\([0-9.]*\)<.*,\1,p' | \
     head -1

--- a/src/gtk2.mk
+++ b/src/gtk2.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://download.gnome.org/sources/gtk+/$(call SHORT_PKG_VERS
 $(PKG)_DEPS     := cc atk cairo gdk-pixbuf gettext glib jasper jpeg libpng pango tiff
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://gitlab.gnome.org/GNOME/gtk+/tags' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://gitlab.gnome.org/GNOME/gtk+/tags' | \
     $(SED) -n "s,.*<a [^>]\+>v\?\([0-9]\+\.[0-9.]\+\)<.*,\1,p" | \
     grep -v '^2\.9' | \
     grep '^2\.' | \

--- a/src/gtk3.mk
+++ b/src/gtk3.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://download.gnome.org/sources/gtk+/$(call SHORT_PKG_VERS
 $(PKG)_DEPS     := cc atk cairo gdk-pixbuf gettext glib jasper jpeg libepoxy libpng pango tiff
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://gitlab.gnome.org/GNOME/gtk+/tags' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://gitlab.gnome.org/GNOME/gtk+/tags' | \
     $(SED) -n "s,.*<a [^>]\+>v\?\([0-9]\+\.[0-9.]\+\)<.*,\1,p" | \
     grep '^3\.' | \
     grep -v '^3\.9[0-9]' | \

--- a/src/gtkglarea.mk
+++ b/src/gtkglarea.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://mirrors.ircam.fr/pub/GNOME/sources/gtkglarea/2.0/$($(
 $(PKG)_DEPS     := cc freeglut gtk2
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://mirrors.ircam.fr/pub/GNOME/sources/gtkglarea/2.0' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://mirrors.ircam.fr/pub/GNOME/sources/gtkglarea/2.0' | \
     $(SED) -n 's,.*gtkglarea-\(2[^>]*\)\.tar.*,\1,ip' | \
     $(SORT) | \
     tail -1

--- a/src/gtkglext.mk
+++ b/src/gtkglext.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://$(SOURCEFORGE_MIRROR)/project/gtkglext/gtkglext/$($(P
 $(PKG)_DEPS     := cc gtk2
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://gitlab.gnome.org/Archive/gtkglext/tags' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://gitlab.gnome.org/Archive/gtkglext/tags' | \
     $(SED) -n "s,.*<a [^>]\+>v\?\([0-9]\+\.[0-9.]\+\)<.*,\1,p" | \
     $(SORT) -V | \
     tail -1

--- a/src/gtkglextmm.mk
+++ b/src/gtkglextmm.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://$(SOURCEFORGE_MIRROR)/project/gtkglext/gtkglextmm/$($
 $(PKG)_DEPS     := cc gtkglext gtkmm2
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://gitlab.gnome.org/Archive/gtkglextmm/tags' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://gitlab.gnome.org/Archive/gtkglextmm/tags' | \
     $(SED) -n "s,.*<a [^>]\+>v\?\([0-9]\+\.[0-9.]\+\)<.*,\1,p" | \
     $(SORT) -V | \
     tail -1

--- a/src/gtkimageview.mk
+++ b/src/gtkimageview.mk
@@ -14,7 +14,7 @@ $(PKG)_URL      := https://distfiles.macports.org/$(PKG)/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc gtk2
 
 define $(PKG)_UPDATE_DISABLED
-    $(WGET) -q -O- "http://trac.bjourne.webfactional.com/chrome/common/releases/?C=M;O=D" | \
+    $(WGET) -q -O- -t 2 --timeout=6 "http://trac.bjourne.webfactional.com/chrome/common/releases/?C=M;O=D" | \
     grep -i '<a href="gtkimageview.*tar' | \
     $(SED) -n 's,.*gtkimageview-\([0-9][^>]*\)\.tar.*,\1,p' | \
     head -1

--- a/src/gtkmm2.mk
+++ b/src/gtkmm2.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://download.gnome.org/sources/gtkmm/$(call SHORT_PKG_VER
 $(PKG)_DEPS     := cc atkmm cairomm gtk2 libsigc++ pangomm
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://gitlab.gnome.org/GNOME/gtkmm/tags' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://gitlab.gnome.org/GNOME/gtkmm/tags' | \
     $(SED) -n "s,.*<a [^>]\+>v\?\([0-9]\+\.[0-9.]\+\)<.*,\1,p" | \
     grep -v '^2\.9' | \
     grep '^2\.' | \

--- a/src/gtkmm3.mk
+++ b/src/gtkmm3.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://download.gnome.org/sources/gtkmm/$(call SHORT_PKG_VER
 $(PKG)_DEPS     := cc atkmm cairomm gtk3 libsigc++ pangomm
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://gitlab.gnome.org/GNOME/gtkmm/tags' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://gitlab.gnome.org/GNOME/gtkmm/tags' | \
     $(SED) -n "s,.*<a [^>]\+>v\?\([0-9]\+\.[0-9.]\+\)<.*,\1,p" | \
     grep '^3\.' | \
     grep -v "^[0-9]\+\.9[0-9]" | \

--- a/src/gtksourceview.mk
+++ b/src/gtksourceview.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://download.gnome.org/sources/gtksourceview/$(call SHORT
 $(PKG)_DEPS     := cc gtk2 libxml2
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://gitlab.gnome.org/GNOME/gtksourceview/tags?&search=GTKSOURCEVIEW_2' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://gitlab.gnome.org/GNOME/gtksourceview/tags?&search=GTKSOURCEVIEW_2' | \
     $(SED) -n "s,.*<a [^>]\+>GTKSOURCEVIEW_\(2_[0-9_]\+\)<.*,\1,p" | \
     $(SED) "s,_,.,g;" | \
     grep -v '^2\.9[0-9]\.' | \

--- a/src/gtksourceviewmm2.mk
+++ b/src/gtksourceviewmm2.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://download.gnome.org/sources/gtksourceviewmm/$(call SHO
 $(PKG)_DEPS     := cc gtkmm2 gtksourceview
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://gitlab.gnome.org/GNOME/gtksourceviewmm/tags' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://gitlab.gnome.org/GNOME/gtksourceviewmm/tags' | \
     $(SED) -n "s,.*<a [^>]\+>gtksourceviewmm-\(2\.10[0-9.]\+\)<.*,\1,p" | \
     sort -V | \
     tail -1

--- a/src/guile.mk
+++ b/src/guile.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://ftp.gnu.org/gnu/$(PKG)/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc gc gettext gmp libffi libgnurx libiconv libltdl libunistring readline
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://git.savannah.gnu.org/gitweb/?p=guile.git;a=tags' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://git.savannah.gnu.org/gitweb/?p=guile.git;a=tags' | \
     grep '<a [^>]*class="list subject"' | \
     $(SED) -n 's,.*<a[^>]*>[^0-9>]*\([0-9][^< ]*\)\.<.*,\1,p' | \
     grep -v 2.* | \

--- a/src/hdf4.mk
+++ b/src/hdf4.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://support.hdfgroup.org/ftp/HDF/releases/HDF$($(PKG)_VER
 $(PKG)_DEPS     := cc jpeg portablexdr zlib
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://www.hdfgroup.org/ftp/HDF/HDF_Current/src/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://www.hdfgroup.org/ftp/HDF/HDF_Current/src/' | \
     grep '<a href.*hdf.*bz2' | \
     $(SED) -n 's,.*hdf-\([0-9][^>]*\)\.tar.*,\1,p' | \
     head -1

--- a/src/hdf5.mk
+++ b/src/hdf5.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-$(call SH
 $(PKG)_DEPS     := cc pthreads zlib
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://www.hdfgroup.org/ftp/HDF5/current/src/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://www.hdfgroup.org/ftp/HDF5/current/src/' | \
     grep '<a href.*hdf5.*bz2' | \
     $(SED) -n 's,.*hdf5-\([0-9][^>]*\)\.tar.*,\1,p' | \
     head -1

--- a/src/icu4c.mk
+++ b/src/icu4c.mk
@@ -13,7 +13,7 @@ $(PKG)_URL      := https://sourceforge.net/projects/icu/files/ICU4C/$($(PKG)_VER
 $(PKG)_DEPS     := cc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://sourceforge.net/projects/icu/files/ICU4C/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://sourceforge.net/projects/icu/files/ICU4C/' | \
     $(SED) -n 's,.*/projects/.*/.*/.*/\([0-9]\+[^"]*\)/".*,\1,p' | \
     $(SORT) -Vr | \
     head -1

--- a/src/id3lib.mk
+++ b/src/id3lib.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://$(SOURCEFORGE_MIRROR)/project/$(PKG)/$(PKG)/$($(PKG)_
 $(PKG)_DEPS     := cc zlib
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://sourceforge.net/projects/id3lib/files/id3lib/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://sourceforge.net/projects/id3lib/files/id3lib/' | \
     $(SED) -n 's,.*/\([0-9][0-9.]*\)/".*,\1,p' | \
     head -1
 endef

--- a/src/ilmbase.mk
+++ b/src/ilmbase.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://download.savannah.nongnu.org/releases/openexr/$($(PKG
 $(PKG)_DEPS     := cc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://www.openexr.com/downloads.html' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://www.openexr.com/downloads.html' | \
     grep 'ilmbase-' | \
     $(SED) -n 's,.*/ilmbase-\([0-9][^>]*\)\.tar.*,\1,p' | \
     head -1

--- a/src/isl.mk
+++ b/src/isl.mk
@@ -19,7 +19,7 @@ $(PKG)_DEPS_$(BUILD) := gmp
 # while in gcc4 series specific versions are required:
 # https://web.archive.org/web/20141031011459/https://gcc.gnu.org/install/prerequisites.html
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://gcc.gnu.org/pub/gcc/infrastructure/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://gcc.gnu.org/pub/gcc/infrastructure/' | \
     $(SED) -n 's,.*isl-\([0-9][^>]*\)\.tar.*,\1,p' | \
     $(SORT) -V |
     tail -1

--- a/src/itpp.mk
+++ b/src/itpp.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://$(SOURCEFORGE_MIRROR)/project/$(PKG)/$(PKG)/$($(PKG)_
 $(PKG)_DEPS     := cc fftw openblas
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://sourceforge.net/projects/itpp/files/itpp/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://sourceforge.net/projects/itpp/files/itpp/' | \
     $(SED) -n 's,.*/\([0-9][0-9.]*\)/".*,\1,p' | \
     head -1
 endef

--- a/src/jack.mk
+++ b/src/jack.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://dl.dropboxusercontent.com/u/28869550/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc libgnurx libsamplerate libsndfile portaudio pthreads readline
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'http://jackaudio.org/downloads/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'http://jackaudio.org/downloads/' | \
     $(SED) -n 's,.*jack-\([0-9][^"]*\)\.tar.*,\1,p' | \
     head -1
 endef

--- a/src/jansson.mk
+++ b/src/jansson.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := http://www.digip.org/$(PKG)/releases/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'http://www.digip.org/jansson/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'http://www.digip.org/jansson/' | \
     $(SED) -n 's,.*/jansson-\([0-9][^>]*\)\.tar\.bz2.*,\1,p' | \
     tail -1
 endef

--- a/src/jpeg.mk
+++ b/src/jpeg.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://www.ijg.org/files/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://www.ijg.org/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://www.ijg.org/' | \
     $(SED) -n 's,.*jpegsrc\.v\([0-9][^>]*\)\.tar.*,\1,p' | \
     head -1
 endef

--- a/src/json-c.mk
+++ b/src/json-c.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://$(PKG)_releases.s3.amazonaws.com/releases/$($(PKG)_FI
 $(PKG)_DEPS     := cc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://json-c_releases.s3.amazonaws.com' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://json-c_releases.s3.amazonaws.com' | \
     $(SED) -r 's,<Key>,\n<Key>,g' | \
     $(SED) -n 's,.*releases/json-c-\([0-9.]*\).tar.gz.*,\1,p' | \
     $(SORT) -V | \

--- a/src/json-glib.mk
+++ b/src/json-glib.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://download.gnome.org/sources/json-glib/$(call SHORT_PKG
 $(PKG)_DEPS     := cc glib
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://gitlab.gnome.org/GNOME/json-glib/tags' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://gitlab.gnome.org/GNOME/json-glib/tags' | \
     $(SED) -n "s,.*<a [^>]\+>v\?\([0-9]\+\.[0-9.]\+\)<.*,\1,p" | \
     head -1
 endef

--- a/src/json_spirit.mk
+++ b/src/json_spirit.mk
@@ -18,7 +18,7 @@ define $(PKG)_UPDATE
     echo 'TODO: json_spirit automatic update explicitly disabled. Please ' >&2;
     echo '      manually check and update.' >&2;
     echo 'Latest:' >&2;
-    $(WGET) -q -O- 'https://www.codeproject.com/Articles/20027/JSON-Spirit-A-C-JSON-Parser-Generator-Implemented' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://www.codeproject.com/Articles/20027/JSON-Spirit-A-C-JSON-Parser-Generator-Implemented' | \
     $(SED) -n 's,.*/JSON_Spirit/json_spirit_v\([0-9.]*\)[.]zip.*".*,\1,p' | \
     head -1 >&2;
     echo 'Current:' >&2;

--- a/src/lame.mk
+++ b/src/lame.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://$(SOURCEFORGE_MIRROR)/project/$(PKG)/$(PKG)/$(call SH
 $(PKG)_DEPS     := cc $(BUILD)~gettext
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://sourceforge.net/p/lame/svn/HEAD/tree/tags' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://sourceforge.net/p/lame/svn/HEAD/tree/tags' | \
     grep RELEASE_ | \
     $(SED) -n 's,.*RELEASE__\([0-9_][^<]*\)<.*,\1,p' | \
     tr '_' '.' | \

--- a/src/lcms.mk
+++ b/src/lcms.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://$(SOURCEFORGE_MIRROR)/project/$(PKG)/$(PKG)/$(subst a
 $(PKG)_DEPS     := cc jpeg tiff zlib
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://sourceforge.net/projects/lcms/files/lcms/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://sourceforge.net/projects/lcms/files/lcms/' | \
     $(SED) -n 's,.*/projects/.*/\([0-9][^"]*\)/".*,\1,p' | \
     head -1
 endef

--- a/src/lcms1.mk
+++ b/src/lcms1.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://$(SOURCEFORGE_MIRROR)/project/lcms/lcms/$($(PKG)_VERS
 $(PKG)_DEPS     := cc jpeg tiff zlib
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://sourceforge.net/projects/lcms/files/lcms/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://sourceforge.net/projects/lcms/files/lcms/' | \
     $(SED) -n 's,.*/\([0-9][^"]*\)/".*,\1,p' | \
     grep '^1\.' | \
     head -1

--- a/src/lensfun.mk
+++ b/src/lensfun.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://$(SOURCEFORGE_MIRROR)/project/lensfun/$($(PKG)_VERSIO
 $(PKG)_DEPS     := cc glib libgnurx libpng
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://sourceforge.net/projects/lensfun/files/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://sourceforge.net/projects/lensfun/files/' | \
     $(SED) -n 's,.*/projects/.*/\([0-9][^"]*\)/".*,\1,p' | \
     $(SORT) -V | \
     tail -1

--- a/src/levmar.mk
+++ b/src/levmar.mk
@@ -12,7 +12,7 @@ $(PKG)_UA       := MXE
 $(PKG)_DEPS     := cc openblas
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- "https://www.ics.forth.gr/~lourakis/levmar/"  | \
+    $(WGET) -q -O- -t 2 --timeout=6 "https://www.ics.forth.gr/~lourakis/levmar/"  | \
     $(SED) -n 's_.*Latest:.*levmar-\([0-9]\.[0-9]\).*_\1_ip' | \
     head -1;
 endef

--- a/src/libaacs.mk
+++ b/src/libaacs.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://download.videolan.org/pub/videolan/$(PKG)/$($(PKG)_VE
 $(PKG)_DEPS     := cc libgcrypt libgpg_error
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://download.videolan.org/pub/videolan/libaacs/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://download.videolan.org/pub/videolan/libaacs/' | \
     $(SED) -n 's,<a href="\([0-9][^<]*\)/".*,\1,p' | \
     $(SORT) -Vr | \
     head -1

--- a/src/libarchive.mk
+++ b/src/libarchive.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://www.libarchive.org/downloads/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc bzip2 libiconv libxml2 nettle openssl xz zlib
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://www.libarchive.org/downloads/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://www.libarchive.org/downloads/' | \
     $(SED) -n 's,.*libarchive-\([0-9][^<]*\)\.tar.*,\1,p' | \
     $(SORT) -V | \
     tail -1

--- a/src/libassuan.mk
+++ b/src/libassuan.mk
@@ -13,7 +13,7 @@ $(PKG)_URL_2    := https://www.mirrorservice.org/sites/ftp.gnupg.org/gcrypt/liba
 $(PKG)_DEPS     := cc gettext libgpg_error
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://gnupg.org/ftp/gcrypt/libassuan/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://gnupg.org/ftp/gcrypt/libassuan/' | \
     $(SED) -n 's,.*libassuan-\([1-9]\.[1-9][0-9][^>]*\)\.tar.*,\1,p' | \
     head -1
 endef

--- a/src/libbluray.mk
+++ b/src/libbluray.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://download.videolan.org/pub/videolan/libbluray/$($(PKG)
 $(PKG)_DEPS     := cc freetype libxml2
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://download.videolan.org/pub/videolan/libbluray/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://download.videolan.org/pub/videolan/libbluray/' | \
     $(SED) -n 's,<a href="\([0-9][^<]*\)/".*,\1,p' | \
     $(SORT) -Vr | \
     head -1

--- a/src/libbs2b.mk
+++ b/src/libbs2b.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://$(SOURCEFORGE_MIRROR)/project/bs2b/libbs2b/$($(PKG)_V
 $(PKG)_DEPS     := cc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://sourceforge.net/projects/bs2b/files/libbs2b/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://sourceforge.net/projects/bs2b/files/libbs2b/' | \
     $(SED) -n 's,.*<a href="/projects/bs2b/files/libbs2b/\([0-9][^"]*\)/".*,\1,p' | \
     head -1
 endef

--- a/src/libcaca.mk
+++ b/src/libcaca.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := http://caca.zoy.org/files/$(PKG)/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc freeglut ncurses zlib
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'http://caca.zoy.org/wiki/libcaca' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'http://caca.zoy.org/wiki/libcaca' | \
     $(SED) -n 's,.*/libcaca-\([0-9][^"]*\)\.tar.*,\1,p' | \
     $(SORT) -rV | \
     head -1

--- a/src/libcddb.mk
+++ b/src/libcddb.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://$(SOURCEFORGE_MIRROR)/project/libcddb/libcddb/$($(PKG
 $(PKG)_DEPS     := cc libgnurx libiconv
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://downloads.sourceforge.net/project/libcddb/libcddb/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://downloads.sourceforge.net/project/libcddb/libcddb/' | \
     $(SED) -n 's,.*libcddb-\([0-9][^>]*\)\.tar.*,\1,p' | \
     sort | uniq | \
     head -1

--- a/src/libcroco.mk
+++ b/src/libcroco.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://download.gnome.org/sources/libcroco/$(call SHORT_PKG_
 $(PKG)_DEPS     := cc glib libxml2
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://gitlab.gnome.org/GNOME/libcroco/tags' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://gitlab.gnome.org/GNOME/libcroco/tags' | \
     $(SED) -n "s,.*<a [^>]\+>v\?\([0-9]\+\.[0-9.]\+\)<.*,\1,p" | \
     head -1
 endef

--- a/src/libdnet.mk
+++ b/src/libdnet.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://$(SOURCEFORGE_MIRROR)/project/$(PKG)/$(PKG)/$(PKG)-$(
 $(PKG)_DEPS     := cc winpcap
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://sourceforge.net/projects/libdnet/files/libdnet/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://sourceforge.net/projects/libdnet/files/libdnet/' | \
     $(SED) -n 's,.*/libdnet-\([0-9][^"]*\)/".*,\1,p' | \
     head -1
 endef

--- a/src/libdvbpsi.mk
+++ b/src/libdvbpsi.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://download.videolan.org/pub/libdvbpsi/$($(PKG)_VERSION)
 $(PKG)_DEPS     := cc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://download.videolan.org/pub/libdvbpsi/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://download.videolan.org/pub/libdvbpsi/' | \
     $(SED) -n 's,.*<a href="\([0-9][^<]*\)/".*,\1,p' | \
     $(SORT) -Vr | \
     head -1

--- a/src/libdvdcss.mk
+++ b/src/libdvdcss.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://download.videolan.org/pub/libdvdcss/$($(PKG)_VERSION)
 $(PKG)_DEPS     := cc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://download.videolan.org/pub/libdvdcss/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://download.videolan.org/pub/libdvdcss/' | \
     $(SED) -n 's,.*<a href="\([0-9][^<]*\)/".*,\1,p' | \
     $(SORT) -Vr | \
     head -1

--- a/src/libdvdnav.mk
+++ b/src/libdvdnav.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://download.videolan.org/pub/videolan/$(PKG)/$($(PKG)_VE
 $(PKG)_DEPS     := cc libdvdread
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://download.videolan.org/pub/videolan/libdvdnav/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://download.videolan.org/pub/videolan/libdvdnav/' | \
     $(SED) -n 's,.*href="\([0-9][^<]*\)/".*,\1,p' | \
     grep -v 'alpha\|beta\|rc' | \
     $(SORT) -V | \

--- a/src/libdvdread.mk
+++ b/src/libdvdread.mk
@@ -14,7 +14,7 @@ $(PKG)_URL      := https://download.videolan.org/pub/videolan/$(PKG)/$($(PKG)_VE
 $(PKG)_DEPS     := cc libdvdcss
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://download.videolan.org/pub/videolan/libdvdread/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://download.videolan.org/pub/videolan/libdvdread/' | \
     $(SED) -n 's,.*href="\([0-9][^<]*\)/".*,\1,p' | \
     grep -v 'alpha\|beta\|rc' | \
     $(SORT) -V | \

--- a/src/libftdi.mk
+++ b/src/libftdi.mk
@@ -19,7 +19,7 @@ define $(PKG)_UPDATE
 endef
 
 define $(PKG)_UPDATE_DISABLED
-    $(WGET) -q -O- 'https://www.intra2net.com/en/developer/libftdi/download.php' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://www.intra2net.com/en/developer/libftdi/download.php' | \
     $(SED) -n 's,.*libftdi-\([0-9][^>]*\)\.tar.*,\1,p' | \
     head -1
 endef

--- a/src/libftdi1.mk
+++ b/src/libftdi1.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://www.intra2net.com/en/developer/libftdi/download/$($(P
 $(PKG)_DEPS     := cc libusb1
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://www.intra2net.com/en/developer/libftdi/download.php' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://www.intra2net.com/en/developer/libftdi/download.php' | \
     $(SED) -n 's,.*libftdi1-\([0-9][^>]*\)\.tar.*,\1,p' | \
     head -1
 endef

--- a/src/libgcrypt.mk
+++ b/src/libgcrypt.mk
@@ -12,7 +12,7 @@ $(PKG)_URL_2    := https://www.mirrorservice.org/sites/ftp.gnupg.org/gcrypt/libg
 $(PKG)_DEPS     := cc libgpg_error
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://gnupg.org/ftp/gcrypt/libgcrypt/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://gnupg.org/ftp/gcrypt/libgcrypt/' | \
     $(SED) -n 's,.*libgcrypt-\([0-9][^>]*\)\.tar.*,\1,p' | \
     $(SORT) -V | \
     tail -1

--- a/src/libgdamm.mk
+++ b/src/libgdamm.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://download.gnome.org/sources/libgdamm/$(call SHORT_PKG_
 $(PKG)_DEPS     := cc glibmm libgda
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://gitlab.gnome.org/GNOME/libgdamm/tags' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://gitlab.gnome.org/GNOME/libgdamm/tags' | \
     $(SED) -n "s,.*<a [^>]\+>v\?\([0-9]\+\.[0-9.]\+\)<.*,\1,p" | \
     grep -v "^[0-9]\+\.9[0-9]" | \
     head -1

--- a/src/libgee.mk
+++ b/src/libgee.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://download.gnome.org/sources/libgee/$(call SHORT_PKG_VE
 $(PKG)_DEPS     := cc glib
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://gitlab.gnome.org/GNOME/libgee/tags' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://gitlab.gnome.org/GNOME/libgee/tags' | \
     $(SED) -n "s,.*<a [^>]\+>v\?\([0-9]\+\.[0-9.]\+\)<.*,\1,p" | \
     $(SORT) -Vr | \
     head -1

--- a/src/libgeotiff.mk
+++ b/src/libgeotiff.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://download.osgeo.org/geotiff/libgeotiff/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc jpeg proj tiff zlib
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://trac.osgeo.org/geotiff/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://trac.osgeo.org/geotiff/' | \
     $(SED) -n 's,.*libgeotiff-\([0-9][^>]*\)\.tar.*,\1,p' | \
     head -1
 endef

--- a/src/libglade.mk
+++ b/src/libglade.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://download.gnome.org/sources/libglade/2.6/$($(PKG)_FILE
 $(PKG)_DEPS     := cc atk glib gtk2 libxml2
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://download.gnome.org/sources/libglade/2.6/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://download.gnome.org/sources/libglade/2.6/' | \
     $(SED) -n 's,.*"libglade-\([0-9][^"]*\)\.tar.gz.*,\1,p' | \
     tail -1
 endef

--- a/src/libgpg_error.mk
+++ b/src/libgpg_error.mk
@@ -13,7 +13,7 @@ $(PKG)_URL_2    := https://www.mirrorservice.org/sites/ftp.gnupg.org/gcrypt/libg
 $(PKG)_DEPS     := cc gettext
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://gnupg.org/ftp/gcrypt/libgpg-error/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://gnupg.org/ftp/gcrypt/libgpg-error/' | \
     $(SED) -n 's,.*libgpg-error-\([1-9]\.[1-9][0-9][^>]*\)\.tar.*,\1,p' | \
     head -1
 endef

--- a/src/libgsasl.mk
+++ b/src/libgsasl.mk
@@ -13,7 +13,7 @@ $(PKG)_URL_2    := https://download.savannah.nongnu.org/releases/gsasl/$($(PKG)_
 $(PKG)_DEPS     := cc libgcrypt libiconv libidn libntlm
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://git.savannah.gnu.org/gitweb/?p=gsasl.git;a=tags' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://git.savannah.gnu.org/gitweb/?p=gsasl.git;a=tags' | \
     grep '<a [^<]*class="list subject"' | \
     $(SED) -n 's,.*<a[^>]*>\([0-9]*\.[0-9]*[02468]\.[^<]*\)<.*,\1,p' | \
     head -1

--- a/src/libgsf.mk
+++ b/src/libgsf.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://download.gnome.org/sources/libgsf/$(call SHORT_PKG_VE
 $(PKG)_DEPS     := cc bzip2 glib libxml2 zlib
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://gitlab.gnome.org/GNOME/libgsf/tags' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://gitlab.gnome.org/GNOME/libgsf/tags' | \
     $(SED) -n "s,.*<a [^>]\+>v\?\([0-9]\+\.[0-9.]\+\)<.*,\1,p" | \
     head -1
 endef

--- a/src/libiconv.mk
+++ b/src/libiconv.mk
@@ -14,7 +14,7 @@ $(PKG)_TARGETS  := $(BUILD) $(MXE_TARGETS)
 $(PKG)_DEPS_$(BUILD) :=
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://www.gnu.org/software/libiconv/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://www.gnu.org/software/libiconv/' | \
     grep 'libiconv-' | \
     $(SED) -n 's,.*libiconv-\([0-9][^>]*\)\.tar.*,\1,p' | \
     head -1

--- a/src/libid3tag.mk
+++ b/src/libid3tag.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://$(SOURCEFORGE_MIRROR)/project/mad/$(PKG)/$($(PKG)_VER
 $(PKG)_DEPS     := cc zlib
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://sourceforge.net/projects/mad/files/libid3tag/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://sourceforge.net/projects/mad/files/libid3tag/' | \
     $(SED) -n 's,.*/projects/.*/\([0-9][^"]*\)/".*,\1,p' | \
     head -1
 endef

--- a/src/libidn.mk
+++ b/src/libidn.mk
@@ -13,7 +13,7 @@ $(PKG)_URL_2    := https://ftpmirror.gnu.org/libidn/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc gettext libiconv
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://git.savannah.gnu.org/gitweb/?p=libidn.git;a=tags' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://git.savannah.gnu.org/gitweb/?p=libidn.git;a=tags' | \
     $(SED) -n 's,.*<a[^>]*>\(Release \)\?\([0-9][^<]*\)<.*,\2,p' | \
     head -1
 endef

--- a/src/libidn2.mk
+++ b/src/libidn2.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://ftp.gnu.org/gnu/libidn/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc libiconv libunistring
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- https://gitlab.com/libidn/libidn2/tags | \
+    $(WGET) -q -O- -t 2 --timeout=6 https://gitlab.com/libidn/libidn2/tags | \
     $(SED) -n 's,.*libidn2-\([0-9][^t]*\).tar.gz.*,\1,p' | \
     head -1
 endef

--- a/src/libircclient.mk
+++ b/src/libircclient.mk
@@ -13,7 +13,7 @@ $(PKG)_URL      := https://$(SOURCEFORGE_MIRROR)/project/$(PKG)/$(PKG)/$($(PKG)_
 $(PKG)_DEPS     := cc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://sourceforge.net/projects/libircclient/files/libircclient/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://sourceforge.net/projects/libircclient/files/libircclient/' | \
     $(SED) -n 's,.*/projects/.*/\([0-9][^"]*\)/".*,\1,p' | \
     head -1
 endef

--- a/src/libjpeg-turbo.mk
+++ b/src/libjpeg-turbo.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://$(SOURCEFORGE_MIRROR)/project/$(PKG)/$($(PKG)_VERSION
 $(PKG)_DEPS     := cc yasm
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://sourceforge.net/projects/$(PKG)/files/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://sourceforge.net/projects/$(PKG)/files/' | \
     $(SED) -n 's,.*/projects/.*/\([0-9][^"%]*\)/".*,\1,p' | \
     sort -V | \
     tail -1

--- a/src/liblo.mk
+++ b/src/liblo.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://$(SOURCEFORGE_MIRROR)/project/$(PKG)/$(PKG)/$($(PKG)_
 $(PKG)_DEPS     := cc pthreads
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://sourceforge.net/projects/liblo/files/liblo/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://sourceforge.net/projects/liblo/files/liblo/' | \
     $(SED) -n 's,.*/projects/.*/\([0-9][^"]*\)/".*,\1,p' | \
     head -1
 endef

--- a/src/liblqr-1.mk
+++ b/src/liblqr-1.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://liblqr.wdfiles.com/local--files/en:download-page/$($(
 $(PKG)_DEPS     := cc glib
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://liblqr.wikidot.com/en:download-page' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://liblqr.wikidot.com/en:download-page' | \
     $(SED) -n 's,.*liblqr-1-\([0-9][^>]*\)\.tar.*,\1,p' | \
     head -1
 endef

--- a/src/libmad.mk
+++ b/src/libmad.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://$(SOURCEFORGE_MIRROR)/project/mad/$(PKG)/$($(PKG)_VER
 $(PKG)_DEPS     := cc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://sourceforge.net/projects/mad/files/libmad/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://sourceforge.net/projects/mad/files/libmad/' | \
     $(SED) -n 's,.*/projects/.*/\([0-9][^"]*\)/".*,\1,p' | \
     head -1
 endef

--- a/src/libmicrohttpd.mk
+++ b/src/libmicrohttpd.mk
@@ -13,7 +13,7 @@ $(PKG)_URL_2    := https://ftpmirror.gnu.org/libmicrohttpd/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc plibc pthreads
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://ftp.gnu.org/gnu/libmicrohttpd/?C=M;O=D' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://ftp.gnu.org/gnu/libmicrohttpd/?C=M;O=D' | \
     $(SED) -n 's,.*<a href="libmicrohttpd-\([0-9][^"]*\)\.tar.*,\1,p' | \
     $(SORT) -V | \
     tail -1

--- a/src/libmikmod.mk
+++ b/src/libmikmod.mk
@@ -13,7 +13,7 @@ $(PKG)_URL_2    := https://$(SOURCEFORGE_MIRROR)/project/mikmod/outdated_version
 $(PKG)_DEPS     := cc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://sourceforge.net/projects/mikmod/files/libmikmod/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://sourceforge.net/projects/mikmod/files/libmikmod/' | \
     $(SED) -n 's,.*<a href="/projects/mikmod/files/libmikmod/\([0-9][^>]*\)/".*,\1,p' | \
     $(SORT) -Vr | \
     head -1

--- a/src/libmms.mk
+++ b/src/libmms.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://$(SOURCEFORGE_MIRROR)/project/$(PKG)/$(PKG)/$($(PKG)_
 $(PKG)_DEPS     := cc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://sourceforge.net/projects/libmms/files/libmms/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://sourceforge.net/projects/libmms/files/libmms/' | \
     $(SED) -n 's,.*/projects/.*/\([0-9][^"]*\)/".*,\1,p' | \
     head -1
 endef

--- a/src/libmng.mk
+++ b/src/libmng.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://$(SOURCEFORGE_MIRROR)/project/$(PKG)/$(PKG)-devel/$($
 $(PKG)_DEPS     := cc jpeg lcms zlib
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://sourceforge.net/projects/libmng/files/libmng-devel/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://sourceforge.net/projects/libmng/files/libmng-devel/' | \
     $(SED) -n 's,.*/projects/.*/\([0-9][^"]*\)/".*,\1,p' | \
     head -1
 endef

--- a/src/libmodplug.mk
+++ b/src/libmodplug.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://$(SOURCEFORGE_MIRROR)/project/modplug-xmms/$(PKG)/$($
 $(PKG)_DEPS     := cc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://sourceforge.net/projects/modplug-xmms/files/libmodplug/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://sourceforge.net/projects/modplug-xmms/files/libmodplug/' | \
     $(SED) -n 's,.*/projects/.*/\([0-9][^"]*\)/".*,\1,p' | \
     head -1
 endef

--- a/src/libmpcdec.mk
+++ b/src/libmpcdec.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://files.musepack.net/source/$(PKG)-$($(PKG)_VERSION).ta
 $(PKG)_DEPS     := cc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'http://svn.musepack.net/libmpcdec/tags/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'http://svn.musepack.net/libmpcdec/tags/' | \
     $(SED) -n "s,.*>release-\([0-9]\+\.[0-9]\+\.[0-9]\+\).*,\1,p" | \
     $(SORT) -Vr | \
     head -1

--- a/src/libmpeg2.mk
+++ b/src/libmpeg2.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://libmpeg2.sourceforge.io/files/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://libmpeg2.sourceforge.io/downloads.html' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://libmpeg2.sourceforge.io/downloads.html' | \
     $(SED) -n 's,.*files/libmpeg2-\([0-9][^"]*\)\.tar.*,\1,p' | \
     head -1
 endef

--- a/src/libmysqlclient.mk
+++ b/src/libmysqlclient.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://dev.mysql.com/get/Downloads/Connector-C/$($(PKG)_FILE
 $(PKG)_DEPS     := cc openssl zlib
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://dev.mysql.com/downloads/connector/c/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://dev.mysql.com/downloads/connector/c/' | \
     $(SED) -n 's,.*mysql-connector-c-\([0-9\.]\+\)-win.*,\1,p' | \
     head -1
 endef

--- a/src/libnice.mk
+++ b/src/libnice.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://nice.freedesktop.org/releases/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc glib
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://cgit.freedesktop.org/libnice/libnice/refs/tags' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://cgit.freedesktop.org/libnice/libnice/refs/tags' | \
     grep '<a href=' | \
     $(SED) -n 's,.*<a[^>]*>\([0-9]*\.[0-9]*\.[^<]*\)<.*,\1,p' | \
     $(SORT) -Vr | \

--- a/src/libntlm.mk
+++ b/src/libntlm.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://www.nongnu.org/libntlm/releases/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://www.nongnu.org/libntlm/releases/'  | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://www.nongnu.org/libntlm/releases/'  | \
     $(SED) -n 's,.*libntlm-\([0-9]\+\)\(\.[0-9]\+\)*\..*,\1\2,p' |\
     tail -1
 endef

--- a/src/liboauth.mk
+++ b/src/liboauth.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://$(SOURCEFORGE_MIRROR)/project/$(PKG)/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc curl openssl
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://sourceforge.net/projects/liboauth/files/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://sourceforge.net/projects/liboauth/files/' | \
     $(SED) -n 's,.*liboauth-\([0-9][^>]*\)\.tar.*,\1,p' | \
     head -1
 endef

--- a/src/libodbc++.mk
+++ b/src/libodbc++.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://$(SOURCEFORGE_MIRROR)/project/libodbcxx/libodbc++/$($
 $(PKG)_DEPS     := cc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- "https://sourceforge.net/projects/libodbcxx/files/libodbc%2B%2B" | \
+    $(WGET) -q -O- -t 2 --timeout=6 "https://sourceforge.net/projects/libodbcxx/files/libodbc%2B%2B" | \
     grep 'libodbcxx/files/libodbc%2B%2B/' | \
     $(SED) -n 's,.*/\([0-9][^>]*\)/.*,\1,p' | \
     head -1

--- a/src/liboil.mk
+++ b/src/liboil.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := http://$(PKG).freedesktop.org/download/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://cgit.freedesktop.org/liboil/refs/tags' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://cgit.freedesktop.org/liboil/refs/tags' | \
     $(SED) -n "s,.*<a href='[^']*/tag/?h=[^0-9]*\\([0-9][^']*\\)'.*,\\1,p" | \
     head -1
 endef

--- a/src/libotr.mk
+++ b/src/libotr.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://otr.cypherpunks.ca/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc libgcrypt libgpg_error libiconv
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://otr.cypherpunks.ca/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://otr.cypherpunks.ca/' | \
     $(SED) -n 's,.*<a href="libotr-\([0-9][^>]*\)\.tar\.gz">.*,\1,p' | \
     head -1
 endef

--- a/src/libpano13.mk
+++ b/src/libpano13.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://$(SOURCEFORGE_MIRROR)/project/panotools/$(PKG)/$($(PK
 $(PKG)_DEPS     := cc jpeg libpng tiff zlib
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://sourceforge.net/api/file/index/project-id/96188/rss?path=/libpano13' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://sourceforge.net/api/file/index/project-id/96188/rss?path=/libpano13' | \
     $(SED) -n 's,.*libpano13-\([0-9].*\)\.tar.*,\1,p' | \
     grep -v beta | \
     grep -v rc | \

--- a/src/libpaper.mk
+++ b/src/libpaper.mk
@@ -12,7 +12,7 @@ $(PKG)_URL_2    := https://mirrorservice.org/sites/ftp.debian.org/debian/pool/ma
 $(PKG)_DEPS     := cc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://packages.debian.org/unstable/source/libpaper' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://packages.debian.org/unstable/source/libpaper' | \
     $(SED) -n 's,.*libpaper_\([0-9][^>]*\)\.tar.*,\1,p' | \
     head -1
 endef

--- a/src/libpng.mk
+++ b/src/libpng.mk
@@ -12,7 +12,7 @@ $(PKG)_URL_2    := https://ftp-osl.osuosl.org/pub/libpng/src/libpng16/$($(PKG)_F
 $(PKG)_DEPS     := cc zlib
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://sourceforge.net/p/libpng/code/ref/master/tags/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://sourceforge.net/p/libpng/code/ref/master/tags/' | \
     $(SED) -n 's,.*<a[^>]*>v\([0-9][^<]*\)<.*,\1,p' | \
     grep -v alpha | \
     grep -v beta | \

--- a/src/librsvg.mk
+++ b/src/librsvg.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://download.gnome.org/sources/librsvg/$(call SHORT_PKG_V
 $(PKG)_DEPS     := cc cairo gdk-pixbuf glib libcroco libgsf pango
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://gitlab.gnome.org/GNOME/librsvg/tags' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://gitlab.gnome.org/GNOME/librsvg/tags' | \
     $(SED) -n "s,.*<a [^>]\+>v\?\([0-9]\+\.[0-9.]\+\)<.*,\1,p" | \
     head -1
 endef

--- a/src/libsamplerate.mk
+++ b/src/libsamplerate.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := http://www.mega-nerd.com/SRC/$(PKG)-$($(PKG)_VERSION).tar.gz
 $(PKG)_DEPS     := cc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'http://www.mega-nerd.com/SRC/download.html' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'http://www.mega-nerd.com/SRC/download.html' | \
     $(SED) -n 's,.*$(PKG)-\([0-9][^>]*\)\.tar.*,\1,p' | \
     grep -v 'alpha' | \
     grep -v 'beta' | \

--- a/src/libshout.mk
+++ b/src/libshout.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://downloads.xiph.org/releases/$(PKG)/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc ogg openssl speex theora vorbis
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://icecast.org/download/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://icecast.org/download/' | \
     $(SED) -n 's,.*libshout-\([0-9][^>]*\)\.tar.*,\1,p' | \
     head -1
 endef

--- a/src/libsndfile.mk
+++ b/src/libsndfile.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := http://www.mega-nerd.com/libsndfile/files/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc flac ogg vorbis
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'http://www.mega-nerd.com/libsndfile/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'http://www.mega-nerd.com/libsndfile/' | \
     grep '<META NAME="Version"' | \
     $(SED) -n 's,.*CONTENT="libsndfile-\([0-9][^"]*\)">.*,\1,p' | \
     head -1

--- a/src/libspatialindex.mk
+++ b/src/libspatialindex.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://download.osgeo.org/libspatialindex/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc pthreads
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://download.osgeo.org/libspatialindex/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://download.osgeo.org/libspatialindex/' | \
     $(SED) -n 's,.*spatialindex-src-\([0-9][^>]*\)\.tar.*,\1,p' | \
     tail -1
 endef

--- a/src/libspectre.mk
+++ b/src/libspectre.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://libspectre.freedesktop.org/releases/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc cairo ghostscript
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://libspectre.freedesktop.org/releases/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://libspectre.freedesktop.org/releases/' | \
     $(SED) -n 's:.*>LATEST-libspectre-::p' | \
     $(SED) -n 's:<.*::p'
 endef

--- a/src/libssh.mk
+++ b/src/libssh.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://git.libssh.org/projects/libssh.git/snapshot/libssh-$(
 $(PKG)_DEPS     := cc libgcrypt zlib
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://git.libssh.org/projects/libssh.git/refs/tags' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://git.libssh.org/projects/libssh.git/refs/tags' | \
     $(SED) -n "s,.*>libssh-\([0-9]*\.[^<]*\)\.tar.*,\1,p" | \
     $(SORT) -Vr | \
     head -1

--- a/src/libssh2.mk
+++ b/src/libssh2.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://libssh2.org/download/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc libgcrypt zlib
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://libssh2.org/download/?C=M;O=D' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://libssh2.org/download/?C=M;O=D' | \
     grep 'libssh2-' | \
     $(SED) -n 's,.*libssh2-\([0-9][^>]*\)\.tar.*,\1,p' | \
     head -1

--- a/src/libsvm.mk
+++ b/src/libsvm.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://www.csie.ntu.edu.tw/~cjlin/$(PKG)/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://www.csie.ntu.edu.tw/~cjlin/libsvm/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://www.csie.ntu.edu.tw/~cjlin/libsvm/' | \
     $(SED) -n 's,.*>v\([0-9][^<]*\)<.*,\1,p' | \
     head -1
 endef

--- a/src/libtasn1.mk
+++ b/src/libtasn1.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://ftp.gnu.org/gnu/libtasn1/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- https://ftp.gnu.org/gnu/libtasn1/ | \
+    $(WGET) -q -O- -t 2 --timeout=6 https://ftp.gnu.org/gnu/libtasn1/ | \
     $(SED) -n 's,.*libtasn1-\([1-9]\+\.[0-9]\+\)\..*,\1,p' | \
     $(SORT) -V | \
     tail -1

--- a/src/libtool.mk
+++ b/src/libtool.mk
@@ -14,7 +14,7 @@ $(PKG)_DEPS     :=
 $(PKG)_TARGETS  := $(BUILD)
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://ftp.gnu.org/gnu/libtool/?C=M;O=D' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://ftp.gnu.org/gnu/libtool/?C=M;O=D' | \
     $(SED) -n 's,.*<a href="libtool-\([0-9][^"]*\)\.tar.*,\1,p' | \
     head -1
 endef

--- a/src/libtorrent-rasterbar.mk
+++ b/src/libtorrent-rasterbar.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://github.com/arvidn/libtorrent/releases/download/libtor
 $(PKG)_DEPS     := cc boost openssl
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://github.com/arvidn/libtorrent/releases' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://github.com/arvidn/libtorrent/releases' | \
     $(SED) -n 's,.*libtorrent-rasterbar-\([0-9][^"]*\)\.tar.*,\1,p' | \
     head -1
 endef

--- a/src/libunistring.mk
+++ b/src/libunistring.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://ftp.gnu.org/gnu/$(PKG)/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc libiconv
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://ftp.gnu.org/gnu/libunistring/?C=M;O=D' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://ftp.gnu.org/gnu/libunistring/?C=M;O=D' | \
     $(SED) -n 's,.*<a href="libunistring-\([0-9][^"]*\)\.tar.*,\1,p' | \
     $(SORT) -V | \
     tail -1

--- a/src/libusb.mk
+++ b/src/libusb.mk
@@ -19,7 +19,7 @@ define $(PKG)_UPDATE
 endef
 
 define $(PKG)_UPDATE_DISABLED
-    $(WGET) -q -O- 'https://sourceforge.net/projects/libusb-win32/files/libusb-win32-releases/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://sourceforge.net/projects/libusb-win32/files/libusb-win32-releases/' | \
     $(SED) -n 's,.*/\([0-9][^"]*\)/".*,\1,p' | \
     head -1
 endef

--- a/src/libusb1.mk
+++ b/src/libusb1.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://$(SOURCEFORGE_MIRROR)/project/libusb/libusb-1.0/libus
 $(PKG)_DEPS     := cc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://sourceforge.net/projects/libusb/files/libusb-1.0/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://sourceforge.net/projects/libusb/files/libusb-1.0/' | \
     grep -i 'libusb/files/libusb-1.0' | \
     $(SED) -n 's,.*/libusb-1.0/libusb-\([0-9\.]*\)/.*,\1,p' | \
     head -1

--- a/src/libvpx.mk
+++ b/src/libvpx.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://storage.googleapis.com/downloads.webmproject.org/rele
 $(PKG)_DEPS     := cc pthreads yasm
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://storage.googleapis.com/downloads.webmproject.org/releases/webm/index.html' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://storage.googleapis.com/downloads.webmproject.org/releases/webm/index.html' | \
     $(SED) -n 's,.*libvpx-\([0-9][^>]*\)\.tar.*,\1,p' | \
     $(SORT) -Vr | \
     head -1

--- a/src/libwebp.mk
+++ b/src/libwebp.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://storage.googleapis.com/downloads.webmproject.org/rele
 $(PKG)_DEPS     := cc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://developers.google.com/speed/webp/download' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://developers.google.com/speed/webp/download' | \
     $(SED) -n 's,.*<a href="//storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-\([0-9][^"]*\)\.tar.gz">Download</a> |,\1,p' | \
     $(SORT) -V | \
     tail -1

--- a/src/libxml++.mk
+++ b/src/libxml++.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://download.gnome.org/sources/libxml++/$(call SHORT_PKG_
 $(PKG)_DEPS     := cc glibmm libxml2
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://gitlab.gnome.org/GNOME/libxml++/tags' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://gitlab.gnome.org/GNOME/libxml++/tags' | \
     $(SED) -n "s,.*<a [^>]\+>v\?\([0-9]\+\.[0-9.]\+\)<.*,\1,p" | \
     head -1
 endef

--- a/src/libxml2.mk
+++ b/src/libxml2.mk
@@ -12,7 +12,7 @@ $(PKG)_URL_2    := https://ftp.osuosl.org/pub/blfs/conglomeration/libxml2/$($(PK
 $(PKG)_DEPS     := cc xz zlib
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://gitlab.gnome.org/GNOME/libxml2/tags' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://gitlab.gnome.org/GNOME/libxml2/tags' | \
     $(SED) -n "s,.*<a [^>]\+>v\([0-9,\.]\+\)<.*,\\1,p" | \
     head -1
 endef

--- a/src/libxslt.mk
+++ b/src/libxslt.mk
@@ -12,7 +12,7 @@ $(PKG)_URL_2    := ftp://xmlsoft.org/libxslt/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc libgcrypt libxml2
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://gitlab.gnome.org/GNOME/libxslt/tags' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://gitlab.gnome.org/GNOME/libxslt/tags' | \
     $(SED) -n "s,.*<a [^>]\+>v\([0-9,\.]\+\)<.*,\\1,p" | \
     head -1
 endef

--- a/src/log4cxx.mk
+++ b/src/log4cxx.mk
@@ -12,7 +12,7 @@ $(PKG)_URL_2    := https://www.apache.org/dist/logging/log4cxx/$($(PKG)_VERSION)
 $(PKG)_DEPS     := cc apr-util
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://logging.apache.org/log4cxx/download.html' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://logging.apache.org/log4cxx/download.html' | \
     $(SED) -n 's,.*log4cxx-\([0-9.]*\)\.tar.*,\1,p' | \
     head -1
 endef

--- a/src/lua.mk
+++ b/src/lua.mk
@@ -16,7 +16,7 @@ $(PKG)_DEPS     := cc
 $(PKG)_DEPS_$(BUILD) :=
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://www.lua.org/download.html' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://www.lua.org/download.html' | \
     $(SED) -n 's,.*lua-\([0-9][^>]*\)\.tar.*,\1,p' | \
     head -1
 endef

--- a/src/luabind.mk
+++ b/src/luabind.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://$(SOURCEFORGE_MIRROR)/luabind/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc boost lua
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://sourceforge.net/projects/luabind/files/luabind/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://sourceforge.net/projects/luabind/files/luabind/' | \
     $(SED) -n 's,.*<a href="/projects/luabind/files/luabind/\([0-9][^>]*\)/.*,\1,p' | \
     head -1
 endef

--- a/src/lzma.mk
+++ b/src/lzma.mk
@@ -14,7 +14,7 @@ $(PKG)_DEPS_$(BUILD) :=
 $(PKG)_TARGETS  := $(BUILD) $(MXE_TARGETS)
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://www.7-zip.org/sdk.html' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://www.7-zip.org/sdk.html' | \
     $(SED) -n 's,.*lzma\([0-9][^"]*\)\.7z.*,\1,p' | \
     head -1
 endef

--- a/src/lzo.mk
+++ b/src/lzo.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://www.oberhumer.com/opensource/lzo/download/$($(PKG)_FI
 $(PKG)_DEPS     := cc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://www.oberhumer.com/opensource/lzo/download/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://www.oberhumer.com/opensource/lzo/download/' | \
     grep 'lzo-' | \
     grep -v 'minilzo-' | \
     $(SED) -n 's,.*lzo-\([0-9][^>]*\)\.tar.*,\1,p' | \

--- a/src/matio.mk
+++ b/src/matio.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://$(SOURCEFORGE_MIRROR)/project/$(PKG)/$(PKG)/$($(PKG)_
 $(PKG)_DEPS     := cc hdf5 zlib
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://sourceforge.net/projects/matio/files/matio/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://sourceforge.net/projects/matio/files/matio/' | \
     $(SED) -n 's,.*/projects/.*/\([0-9][^"]*\)/".*,\1,p' | \
     head -1
 endef

--- a/src/mdbtools.mk
+++ b/src/mdbtools.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://github.com/brianb/$(PKG)/tarball/$($(PKG)_VERSION)/$(
 $(PKG)_DEPS     := cc glib
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://github.com/brianb/mdbtools/tags' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://github.com/brianb/mdbtools/tags' | \
     grep '<a href="/brianb/mdbtools/archive/' | \
     $(SED) -n 's,.*href="/brianb/mdbtools/archive/\([0-9][^"_]*\)\.tar.*,\1,p' | \
     head -1

--- a/src/mingw-w64.mk
+++ b/src/mingw-w64.mk
@@ -13,7 +13,7 @@ $(PKG)_TYPE     := script
 $(PKG)_DEPS     :=
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://sourceforge.net/projects/mingw-w64/files/mingw-w64/mingw-w64-release/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://sourceforge.net/projects/mingw-w64/files/mingw-w64/mingw-w64-release/' | \
     $(SED) -n 's,.*mingw-w64-v\([0-9.]*\)\.tar.*,\1,p' | \
     $(SORT) -V | \
     tail -1

--- a/src/mpfr.mk
+++ b/src/mpfr.mk
@@ -15,7 +15,7 @@ $(PKG)_DEPS     := cc gmp
 $(PKG)_DEPS_$(BUILD) := gmp
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://www.mpfr.org/mpfr-current/#download' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://www.mpfr.org/mpfr-current/#download' | \
     grep 'mpfr-' | \
     $(SED) -n 's,.*mpfr-\([0-9][^<]*\)/.*,\1,p' | \
     head -1

--- a/src/mpg123.mk
+++ b/src/mpg123.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://$(SOURCEFORGE_MIRROR)/project/mpg123/$(PKG)/$($(PKG)_
 $(PKG)_DEPS     := cc sdl
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://sourceforge.net/projects/mpg123/files/mpg123/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://sourceforge.net/projects/mpg123/files/mpg123/' | \
     $(SED) -n 's,.*/projects/.*/\([0-9][^"]*\)/".*,\1,p' | \
     head -1
 endef

--- a/src/nasm.mk
+++ b/src/nasm.mk
@@ -13,7 +13,7 @@ $(PKG)_TARGETS  := $(BUILD)
 $(PKG)_DEPS     :=
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://www.nasm.us/pub/nasm/releasebuilds/?C=M;O=D' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://www.nasm.us/pub/nasm/releasebuilds/?C=M;O=D' | \
     $(SED) -n 's,.*href="\([0-9\.]*[^a-z]\)/".*,\1,p' | \
     head -1
 endef

--- a/src/ncurses.mk
+++ b/src/ncurses.mk
@@ -17,7 +17,7 @@ $(PKG)_DEPS     := cc libgnurx $(BUILD)~$(PKG)
 $(PKG)_DEPS_$(BUILD) :=
 
 define $(PKG)_UPDATE_RELEASE
-    $(WGET) -q -O- 'https://ftp.gnu.org/gnu/ncurses/?C=M;O=D' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://ftp.gnu.org/gnu/ncurses/?C=M;O=D' | \
     $(SED) -n 's,.*<a href="ncurses-\([0-9][^"]*\)\.tar.*,\1,p' | \
     head -1
 endef

--- a/src/neon.mk
+++ b/src/neon.mk
@@ -13,7 +13,7 @@ $(PKG)_URL_2    := https://mirrorservice.org/sites/distfiles.macports.org/$(PKG)
 $(PKG)_DEPS     := cc expat gettext openssl
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://mirrorservice.org/sites/distfiles.macports.org/$(PKG)/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://mirrorservice.org/sites/distfiles.macports.org/$(PKG)/' | \
     $(SED) -n 's,.*/\([0-9][^"]*\)/"\.tar.*,\1,p' | \
     sort | uniq | \
     head -1

--- a/src/netpbm.mk
+++ b/src/netpbm.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://$(SOURCEFORGE_MIRROR)/project/netpbm/super_stable/$($
 $(PKG)_DEPS     := cc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://sourceforge.net/projects/netpbm/files/super_stable/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://sourceforge.net/projects/netpbm/files/super_stable/' | \
     $(SED) -n 's,.*netpbm-\([0-9][^>]*\)\.tgz.*,\1,p' | \
     head -1
 endef

--- a/src/nettle.mk
+++ b/src/nettle.mk
@@ -12,7 +12,7 @@ $(PKG)_DEPS     := cc gmp
 $(PKG)_OO_DEPS   = $(BUILD)~autotools
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://www.lysator.liu.se/~nisse/archive/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://www.lysator.liu.se/~nisse/archive/' | \
     $(SED) -n 's,.*nettle-\([0-9][^>]*\)\.tar.*,\1,p' | \
     grep -v 'pre' | \
     grep -v 'rc' | \

--- a/src/nlopt.mk
+++ b/src/nlopt.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://ab-initio.mit.edu/$(PKG)/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://ab-initio.mit.edu/wiki/index.php/NLopt' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://ab-initio.mit.edu/wiki/index.php/NLopt' | \
     $(SED) -n 's,.*<a href=".*nlopt-\([0-9.]\+\).tar.gz".*,\1,p' | \
     $(SORT) -V | \
     tail -1

--- a/src/nsis.mk
+++ b/src/nsis.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://$(SOURCEFORGE_MIRROR)/project/nsis/NSIS 3/$($(PKG)_VE
 $(PKG)_DEPS     := cc scons-local
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://nsis.sourceforge.io/Download' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://nsis.sourceforge.io/Download' | \
     $(SED) -n 's,.*nsis-\([0-9.]\+\)-src.tar.*,\1,p' | \
     tail -1
 endef

--- a/src/ocaml-cairo.mk
+++ b/src/ocaml-cairo.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://debian.inf.tu-dresden.de/debian/pool/main/c/cairo-oca
 $(PKG)_DEPS     := cc ocaml-core ocaml-findlib ocaml-lablgtk2
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://debian.inf.tu-dresden.de/debian/pool/main/c/cairo-ocaml/?C=M;O=D' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://debian.inf.tu-dresden.de/debian/pool/main/c/cairo-ocaml/?C=M;O=D' | \
     $(SED) -n 's,.*cairo-ocaml_\([0-9][^>]*\)\.orig\.tar.*,\1,ip' | \
     head -1
 endef

--- a/src/ocaml-camlimages.mk
+++ b/src/ocaml-camlimages.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://bitbucket.org/camlspotter/camlimages/get/v$($(PKG)_VE
 $(PKG)_DEPS     := cc freetype giflib libpng ocaml-findlib ocaml-lablgtk2 tiff
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://bitbucket.org/camlspotter/camlimages/downloads' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://bitbucket.org/camlspotter/camlimages/downloads' | \
     $(SED) -n 's,.*get/v\([0-9][^>]*\)\.tar.*,\1,ip' | \
     head -1
 endef

--- a/src/ocaml-findlib.mk
+++ b/src/ocaml-findlib.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := http://download.camlcity.org/download/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc ocaml-core
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'http://download.camlcity.org/download' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'http://download.camlcity.org/download' | \
     $(SED) -n 's,.*findlib-\([0-9][^>]*\)\.tar.*,\1,ip' | \
     $(SORT) | \
     tail -1

--- a/src/ocaml-flexdll.mk
+++ b/src/ocaml-flexdll.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := http://alain.frisch.fr/flexdll/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc ocaml-native
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'http://alain.frisch.fr/flexdll/?C=M;O=D' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'http://alain.frisch.fr/flexdll/?C=M;O=D' | \
     $(SED) -n 's,.*flexdll-\([0-9][^>]*\)\.tar.gz.*,\1,ip' | \
     head -1
 endef

--- a/src/ocaml-lablgl.mk
+++ b/src/ocaml-lablgl.mk
@@ -13,7 +13,7 @@ $(PKG)_URL_2    := https://forge.ocamlcore.org/frs/download.php/1254/$($(PKG)_FI
 $(PKG)_DEPS     := cc gtkglarea ocaml-findlib
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'http://wwwfun.kurims.kyoto-u.ac.jp/soft/lsl/lablgl.html' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'http://wwwfun.kurims.kyoto-u.ac.jp/soft/lsl/lablgl.html' | \
     $(SED) -n 's,.*lablgl-\([^>]*\)\.tar.*,\1,ip' | \
     head -1
 endef

--- a/src/ocaml-lablgtk2.mk
+++ b/src/ocaml-lablgtk2.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://forge.ocamlcore.org/frs/download.php/979/$($(PKG)_FIL
 $(PKG)_DEPS     := cc gtk2 gtkglarea gtksourceview libglade ocaml-findlib ocaml-lablgl
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://forge.ocamlcore.org/frs/?group_id=220' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://forge.ocamlcore.org/frs/?group_id=220' | \
     $(SED) -n 's,.*lablgtk-\(2[^>]*\)\.tar.*,\1,ip' | \
     $(SORT) | \
     tail -1

--- a/src/ocaml-native.mk
+++ b/src/ocaml-native.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://caml.inria.fr/pub/distrib/ocaml-$(call SHORT_PKG_VERS
 $(PKG)_DEPS     := cc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://caml.inria.fr/download.en.html' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://caml.inria.fr/download.en.html' | \
     $(SED) -n 's,.*ocaml-\([0-9][^>]*\)\.tar.*,\1,p' | \
     head -1
 endef

--- a/src/ocaml-xml-light.mk
+++ b/src/ocaml-xml-light.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := http://tech.motion-twin.com/zip/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc ocaml-findlib
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'http://tech.motion-twin.com/xmllight.html' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'http://tech.motion-twin.com/xmllight.html' | \
     $(SED) -n 's,.*xml-light-\(.*\)\.zip.*,\1,ip' | \
     head -1
 endef

--- a/src/ogg.mk
+++ b/src/ogg.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://downloads.xiph.org/releases/ogg/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://www.xiph.org/downloads/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://www.xiph.org/downloads/' | \
     $(SED) -n 's,.*libogg-\([0-9][^>]*\)\.tar.*,\1,p' | \
     head -1
 endef

--- a/src/old.mk
+++ b/src/old.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://blitiri.com.ar/p/old/files/$($(PKG)_VERSION)/$($(PKG)
 $(PKG)_DEPS     := cc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://blitiri.com.ar/p/old/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://blitiri.com.ar/p/old/' | \
     grep 'old-' | \
     $(SED) -n 's,.*old-\([0-9][^>]*\)\.tar.*,\1,p' | \
     head -1

--- a/src/openal.mk
+++ b/src/openal.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://openal-soft.org/openal-releases/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc portaudio
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://openal-soft.org/openal-releases/?C=M;O=D' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://openal-soft.org/openal-releases/?C=M;O=D' | \
     $(SED) -n 's,.*"openal-soft-\([0-9][^"]*\)\.tar.*,\1,p' | \
     $(SORT) -V | \
     tail -1

--- a/src/opencore-amr.mk
+++ b/src/opencore-amr.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://$(SOURCEFORGE_MIRROR)/project/$(PKG)/$(PKG)/$($(PKG)_
 $(PKG)_DEPS     := cc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://sourceforge.net/projects/opencore-amr/files/opencore-amr/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://sourceforge.net/projects/opencore-amr/files/opencore-amr/' | \
     $(SED) -n 's,.*opencore-amr-\([0-9][^"]*\)\.tar.*,\1,p' | \
     head -1
 endef

--- a/src/opencsg.mk
+++ b/src/opencsg.mk
@@ -13,7 +13,7 @@ $(PKG)_DEPS     := cc freeglut glew qtbase
 $(PKG)_QT_DIR   := qt5
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'http://www.opencsg.org/#download' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'http://www.opencsg.org/#download' | \
     grep 'OpenCSG-' | \
     $(SED) -n 's,.*OpenCSG-\([0-9][^>]*\)\.tar.*,\1,p' | \
     head -1

--- a/src/opencv.mk
+++ b/src/opencv.mk
@@ -14,7 +14,7 @@ $(PKG)_DEPS     := cc eigen ffmpeg jasper jpeg libpng libwebp \
                    openblas openexr protobuf tiff xz zlib
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://sourceforge.net/projects/opencvlibrary/files/opencv-unix/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://sourceforge.net/projects/opencvlibrary/files/opencv-unix/' | \
     $(SED) -n 's,.*/projects/.*/\([0-9][^"]*\)/".*,\1,p' | \
     head -1
 endef

--- a/src/openexr.mk
+++ b/src/openexr.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://download.savannah.nongnu.org/releases/openexr/$($(PKG
 $(PKG)_DEPS     := cc ilmbase pthreads zlib
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://www.openexr.com/downloads.html' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://www.openexr.com/downloads.html' | \
     grep 'openexr-' | \
     $(SED) -n 's,.*openexr-\([0-9][^>]*\)\.tar.*,\1,p' | \
     head -1

--- a/src/openscenegraph.mk
+++ b/src/openscenegraph.mk
@@ -12,7 +12,7 @@ $(PKG)_DEPS     := cc boost curl dcmtk freetype gdal giflib gstreamer \
                    tiff zlib
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'http://www.openscenegraph.org/index.php/download-section/stable-releases' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'http://www.openscenegraph.org/index.php/download-section/stable-releases' | \
     $(SED) -n 's,.*OpenSceneGraph/tree/OpenSceneGraph-\([0-9]*\.[0-9]*[02468]\.[^<]*\)">.*,\1,p' | \
     $(SORT) -V | \
     tail -1

--- a/src/openssl.mk
+++ b/src/openssl.mk
@@ -12,7 +12,7 @@ $(PKG)_URL_2    := https://www.openssl.org/source/old/$(call tr,$([a-z]),,$($(PK
 $(PKG)_DEPS     := cc zlib
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://www.openssl.org/source/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://www.openssl.org/source/' | \
     $(SED) -n 's,.*openssl-\([0-9][0-9a-z.]*\)\.tar.*,\1,p' | \
     $(SORT) -V | \
     tail -1

--- a/src/opus.mk
+++ b/src/opus.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://archive.mozilla.org/pub/$(PKG)/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://archive.mozilla.org/pub/opus/?C=M;O=D' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://archive.mozilla.org/pub/opus/?C=M;O=D' | \
     $(SED) -n 's,.*opus-\([0-9][^>]*\)\.tar.*,\1,p' | \
     grep -v 'alpha' | \
     grep -v 'beta' | \

--- a/src/opusfile.mk
+++ b/src/opusfile.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://archive.mozilla.org/pub/opus/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc ogg opus
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://archive.mozilla.org/pub/opus/?C=M;O=D' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://archive.mozilla.org/pub/opus/?C=M;O=D' | \
     $(SED) -n 's,.*opusfile-\([0-9][^>]*\)\.tar.*,\1,p' | \
     grep -v 'alpha' | \
     grep -v 'beta' | \

--- a/src/pango.mk
+++ b/src/pango.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://download.gnome.org/sources/pango/$(call SHORT_PKG_VER
 $(PKG)_DEPS     := cc cairo fontconfig freetype glib harfbuzz
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://gitlab.gnome.org/GNOME/pango/tags' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://gitlab.gnome.org/GNOME/pango/tags' | \
     $(SED) -n "s,.*<a [^>]\+>v\?\([0-9]\+\.[0-9.]\+\)<.*,\1,p" | \
     head -1
 endef

--- a/src/pangomm.mk
+++ b/src/pangomm.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://download.gnome.org/sources/pangomm/$(call SHORT_PKG_V
 $(PKG)_DEPS     := cc cairomm glibmm pango
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://gitlab.gnome.org/GNOME/pangomm/tags' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://gitlab.gnome.org/GNOME/pangomm/tags' | \
     $(SED) -n "s,.*<a [^>]\+>v\?\([0-9]\+\.[0-9.]\+\)<.*,\1,p" | \
     head -1
 endef

--- a/src/pcl.mk
+++ b/src/pcl.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://github.com/PointCloudLibrary/pcl/archive/$($(PKG)_FIL
 $(PKG)_DEPS     := cc boost eigen flann vtk
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- "https://github.com/PointCloudLibrary/pcl/releases" | \
+    $(WGET) -q -O- -t 2 --timeout=6 "https://github.com/PointCloudLibrary/pcl/releases" | \
     grep '<a href=.*tar' | \
     $(SED) -n 's,.*pcl-\([0-9][^>]*\)\.tar.*,\1,p' | \
     head -1

--- a/src/pcre.mk
+++ b/src/pcre.mk
@@ -13,7 +13,7 @@ $(PKG)_URL_2    := https://$(SOURCEFORGE_MIRROR)/project/pcre/pcre/$($(PKG)_VERS
 $(PKG)_DEPS     := cc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://ftp.pcre.org/pub/pcre/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://ftp.pcre.org/pub/pcre/' | \
     $(SED) -n 's,.*pcre-\([0-9]\+\)\(\.[0-9]\+\)*\.zip.*,\1\2,p' | \
     tail -1
 endef

--- a/src/pcre2.mk
+++ b/src/pcre2.mk
@@ -13,7 +13,7 @@ $(PKG)_URL_2    := https://$(SOURCEFORGE_MIRROR)/project/pcre/pcre2/$($(PKG)_VER
 $(PKG)_DEPS     := cc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://ftp.pcre.org/pub/pcre/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://ftp.pcre.org/pub/pcre/' | \
     $(SED) -n 's,.*pcre2-\([0-9]\+\)\(\.[0-9]\+\)*\.zip.*,\1\2,p' | \
     tail -1
 endef

--- a/src/pdcurses.mk
+++ b/src/pdcurses.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://$(SOURCEFORGE_MIRROR)/project/pdcurses/pdcurses/$($(P
 $(PKG)_DEPS     := cc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://sourceforge.net/projects/pdcurses/files/pdcurses/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://sourceforge.net/projects/pdcurses/files/pdcurses/' | \
     $(SED) -n 's,.*/projects/.*/\([0-9][^"]*\)/".*,\1,p' | \
     head -1
 endef

--- a/src/pdflib_lite.mk
+++ b/src/pdflib_lite.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://www.pdflib.com/binaries/PDFlib/$(subst .,,$(word 1,$(
 $(PKG)_DEPS     := cc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://www.pdflib.com/download/free-software/pdflib-lite-7/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://www.pdflib.com/download/free-software/pdflib-lite-7/' | \
     $(SED) -n 's,.*PDFlib-Lite-\([0-9][^>]*\)\.tar.*,\1,p' | \
     head -1
 endef

--- a/src/pfstools.mk
+++ b/src/pfstools.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://$(SOURCEFORGE_MIRROR)/project/$(PKG)/$(PKG)/$($(PKG)_
 $(PKG)_DEPS     := cc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://sourceforge.net/projects/pfstools/files/pfstools/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://sourceforge.net/projects/pfstools/files/pfstools/' | \
     $(SED) -n 's,.*/projects/.*/\([0-9][^"]*\)/".*,\1,p' | \
     head -1
 endef

--- a/src/physfs.mk
+++ b/src/physfs.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://icculus.org/physfs/downloads/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc zlib
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://icculus.org/physfs/downloads/?M=D' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://icculus.org/physfs/downloads/?M=D' | \
     $(SED) -n 's,.*<a href="physfs-\([0-9][^"]*\)\.tar.*,\1,pI' | \
     $(SORT) -V | \
     tail -1

--- a/src/pixman.mk
+++ b/src/pixman.mk
@@ -12,7 +12,7 @@ $(PKG)_URL_2    := https://xorg.freedesktop.org/archive/individual/lib/$($(PKG)_
 $(PKG)_DEPS     := cc libpng
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://cairographics.org/snapshots/?C=M;O=D' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://cairographics.org/snapshots/?C=M;O=D' | \
     $(SED) -n 's,.*"pixman-\([0-9][^"]*\)\.tar.*,\1,p' | \
     head -1
 endef

--- a/src/plib.mk
+++ b/src/plib.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://$(SOURCEFORGE_MIRROR)/project/$(PKG)/$(PKG)/$($(PKG)_
 $(PKG)_DEPS     := cc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- "https://sourceforge.net/projects/plib/files/plib/" | \
+    $(WGET) -q -O- -t 2 --timeout=6 "https://sourceforge.net/projects/plib/files/plib/" | \
     grep 'plib/files/plib' | \
     $(SED) -n 's,.*plib/\([0-9][^>]*\)/.*,\1,p' | \
     head -1

--- a/src/plotmm.mk
+++ b/src/plotmm.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://$(SOURCEFORGE_MIRROR)/project/$(PKG)/$(PKG)/$($(PKG)_
 $(PKG)_DEPS     := cc gtkmm2
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://sourceforge.net/projects/plotmm/files/plotmm/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://sourceforge.net/projects/plotmm/files/plotmm/' | \
     $(SED) -n 's,.*/projects/.*/\([0-9][^"]*\)/".*,\1,p' | \
     head -1
 endef

--- a/src/plotutils.mk
+++ b/src/plotutils.mk
@@ -12,7 +12,7 @@ $(PKG)_URL_2    := https://ftp.gnu.org/gnu/$(PKG)/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc libpng pthreads
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://ftp.gnu.org/gnu/plotutils/?C=M;O=D' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://ftp.gnu.org/gnu/plotutils/?C=M;O=D' | \
     grep '<a href="plotutils-' | \
     $(SED) -n 's,.*plotutils-\([0-9][^<]*\)\.tar.*,\1,p' | \
     head -1

--- a/src/poco.mk
+++ b/src/poco.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://pocoproject.org/releases/$(PKG)-$(word 1,$(subst p, ,
 $(PKG)_DEPS     := cc expat openssl pcre sqlite zlib
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://pocoproject.org/download/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://pocoproject.org/download/' | \
     $(SED) -n 's,.*poco-\([0-9][^>/]*\)\.tar.*,\1,p' | \
     head -1
 endef

--- a/src/polarssl.mk
+++ b/src/polarssl.mk
@@ -16,7 +16,7 @@ $(PKG)_DEPS     := cc zlib
 # On the releases page of polarssl for update
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- https://polarssl.org/tech-updates/releases | \
+    $(WGET) -q -O- -t 2 --timeout=6 https://polarssl.org/tech-updates/releases | \
     $(SED) -n "s,.*releases/polarssl\-\([0-9]\.[0-9].[0-9]\)-released.*,\1,p" | \
     head -1
 endef

--- a/src/popt.mk
+++ b/src/popt.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://deb.debian.org/debian/pool/main/p/$(PKG)/$(PKG)_$($(P
 $(PKG)_DEPS     := cc gettext libiconv
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://web.archive.org/web/20170922140539/rpm5.org/files/popt/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://web.archive.org/web/20170922140539/rpm5.org/files/popt/' | \
     grep 'popt-' | \
     $(SED) -n 's,.*popt-\([0-9][^>]*\)\.tar.*,\1,p' | \
     tail -1

--- a/src/portablexdr.mk
+++ b/src/portablexdr.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://people.redhat.com/~rjones/portablexdr/files/$($(PKG)_
 $(PKG)_DEPS     := cc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- "https://people.redhat.com/~rjones/portablexdr/files/?C=M;O=D" | \
+    $(WGET) -q -O- -t 2 --timeout=6 "https://people.redhat.com/~rjones/portablexdr/files/?C=M;O=D" | \
     grep -i '<a href=.*tar' | \
     $(SED) -n 's,.*portablexdr-\([0-9][^>]*\)\.tar.*,\1,p' | \
     head -1

--- a/src/portaudio.mk
+++ b/src/portaudio.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := http://www.portaudio.com/archives/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'http://www.portaudio.com/download.html' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'http://www.portaudio.com/download.html' | \
     $(SED) -n 's,.*pa_stable_v\([0-9][^>]*\)\.tgz.*,\1,p' | \
     head -1
 endef

--- a/src/portmidi.mk
+++ b/src/portmidi.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://$(SOURCEFORGE_MIRROR)/project/portmedia/$(PKG)/$($(PK
 $(PKG)_DEPS     := cc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- "https://sourceforge.net/projects/portmedia/files/portmidi/" | \
+    $(WGET) -q -O- -t 2 --timeout=6 "https://sourceforge.net/projects/portmedia/files/portmidi/" | \
     grep -i 'portmedia/files/portmidi' | \
     $(SED) -n 's,.*portmidi/\([0-9]*\)/.*,\1,p' | \
     head -1

--- a/src/postgresql.mk
+++ b/src/postgresql.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://ftp.postgresql.org/pub/source/v$($(PKG)_VERSION)/$($(
 $(PKG)_DEPS     := cc openssl pthreads zlib
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://git.postgresql.org/gitweb?p=postgresql.git;a=tags' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://git.postgresql.org/gitweb?p=postgresql.git;a=tags' | \
     grep 'refs/tags/REL9[0-9_]*"' | \
     $(SED) 's,.*refs/tags/REL\(.*\)".*,\1,g;' | \
     $(SED) 's,_,.,g' | \

--- a/src/proj.mk
+++ b/src/proj.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://download.osgeo.org/proj/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://proj4.org/download.html' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://proj4.org/download.html' | \
     $(SED) -n 's,.*proj-\([0-9][^>]*\)\.tar.*,\1,p' | \
     head -1
 endef

--- a/src/qdbm.mk
+++ b/src/qdbm.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://fallabs.com/qdbm/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc bzip2 libiconv lzo zlib
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://fallabs.com/qdbm/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://fallabs.com/qdbm/' | \
     grep 'qdbm-' | \
     $(SED) -n 's,.*qdbm-\([0-9][^>]*\)\.tar.*,\1,p' | \
     head -1

--- a/src/qscintilla2.mk
+++ b/src/qscintilla2.mk
@@ -13,7 +13,7 @@ $(PKG)_URL      := https://www.riverbankcomputing.com/static/Downloads/QScintill
 $(PKG)_DEPS     := cc qtbase
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://www.riverbankcomputing.com/software/qscintilla/download' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://www.riverbankcomputing.com/software/qscintilla/download' | \
     grep QScintilla_gpl | \
     head -n 1 | \
     $(SED) -n 's,.*QScintilla_gpl-\([0-9][^>]*\)\.tar.*,\1,p'

--- a/src/qt.mk
+++ b/src/qt.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://download.qt.io/official_releases/qt/4.8/$($(PKG)_VERS
 $(PKG)_DEPS     := cc dbus freetds jpeg libmng libpng openssl postgresql sqlite tiff zlib
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- https://download.qt.io/official_releases/qt/4.8/ | \
+    $(WGET) -q -O- -t 2 --timeout=6 https://download.qt.io/official_releases/qt/4.8/ | \
     $(SED) -n 's,.*href="\(4\.[0-9]\.[^/]*\)/".*,\1,p' | \
     grep -iv -- '-rc' | \
     $(SORT) -V | \

--- a/src/qtbase.mk
+++ b/src/qtbase.mk
@@ -14,7 +14,7 @@ $(PKG)_DEPS_$(BUILD) :=
 $(PKG)_TARGETS  := $(BUILD) $(MXE_TARGETS)
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- https://download.qt.io/official_releases/qt/5.8/ | \
+    $(WGET) -q -O- -t 2 --timeout=6 https://download.qt.io/official_releases/qt/5.8/ | \
     $(SED) -n 's,.*href="\(5\.[0-9]\.[^/]*\)/".*,\1,p' | \
     grep -iv -- '-rc' | \
     sort |

--- a/src/quazip.mk
+++ b/src/quazip.mk
@@ -11,7 +11,7 @@ $(PKG)_GH_CONF  := stachenov/quazip/tags
 $(PKG)_DEPS     := cc qtbase zlib
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://github.com/stachenov/quazip/tags' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://github.com/stachenov/quazip/tags' | \
     grep '<a href="/stachenov/quazip/archive/' | \
     $(SED) -n 's,.*href="/stachenov/quazip/archive/\([0-9][^"_]*\)\.tar.*,\1,p' | \
     head -1

--- a/src/qwt.mk
+++ b/src/qwt.mk
@@ -12,7 +12,7 @@ $(PKG)_QT_DIR   := qt5
 $(PKG)_DEPS     := cc qtbase qtsvg
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://sourceforge.net/projects/qwt/files/qwt/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://sourceforge.net/projects/qwt/files/qwt/' | \
     $(SED) -n 's,.*/projects/.*/\([0-9][^"]*\)/".*,\1,p' | \
     head -1
 endef

--- a/src/ragel.mk
+++ b/src/ragel.mk
@@ -13,7 +13,7 @@ $(PKG)_TARGETS  := $(BUILD)
 $(PKG)_DEPS     :=
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://www.colm.net/open-source/ragel/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://www.colm.net/open-source/ragel/' | \
     $(SED) -n 's,.*ragel-\([0-9.]*\)\.tar.*,\1,p' | \
     $(SORT) -V | \
     tail -1

--- a/src/readline.mk
+++ b/src/readline.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://ftp.gnu.org/gnu/readline/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc termcap
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://tiswww.case.edu/php/chet/readline/rltop.html' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://tiswww.case.edu/php/chet/readline/rltop.html' | \
     grep 'readline-' | \
     $(SED) -n 's,.*readline-\([0-9][^>]*\)\.tar.*,\1,p' | \
     head -1

--- a/src/sdl.mk
+++ b/src/sdl.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://www.libsdl.org/release/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc libiconv
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://hg.libsdl.org/SDL/tags' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://hg.libsdl.org/SDL/tags' | \
     $(SED) -n 's,.*release-\([0-9][^<]*\).*,\1,p' | \
     grep '^1\.' | \
     $(SORT) -V | \

--- a/src/sdl2.mk
+++ b/src/sdl2.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://www.libsdl.org/release/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc libiconv libsamplerate
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://hg.libsdl.org/SDL/tags' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://hg.libsdl.org/SDL/tags' | \
     $(SED) -n 's,.*release-\([0-9][^<]*\).*,\1,p' | \
     head -1
 endef

--- a/src/sdl2_gfx.mk
+++ b/src/sdl2_gfx.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://www.ferzkopp.net/Software/SDL2_gfx/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc sdl2
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://www.ferzkopp.net/joomla/content/view/19/14/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://www.ferzkopp.net/joomla/content/view/19/14/' | \
     grep 'href.*tar\.' | \
     $(SED) -n 's,.*SDL2_gfx-\([0-9][^>]*\)\.tar.*,\1,p' | \
     head -1

--- a/src/sdl2_image.mk
+++ b/src/sdl2_image.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://www.libsdl.org/projects/SDL_image/release/$($(PKG)_FI
 $(PKG)_DEPS     := cc jpeg libpng libwebp sdl2 tiff
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://hg.libsdl.org/SDL_image/tags' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://hg.libsdl.org/SDL_image/tags' | \
     $(SED) -n 's,.*release-\([0-9][^<]*\).*,\1,p' | \
     head -1
 endef

--- a/src/sdl2_mixer.mk
+++ b/src/sdl2_mixer.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://www.libsdl.org/projects/SDL_mixer/release/$($(PKG)_FI
 $(PKG)_DEPS     := cc libmodplug mpg123 ogg opusfile sdl2 smpeg2 vorbis
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://hg.libsdl.org/SDL_mixer/tags' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://hg.libsdl.org/SDL_mixer/tags' | \
     $(SED) -n 's,.*release-\([0-9][^<]*\).*,\1,p' | \
     head -1
 endef

--- a/src/sdl2_net.mk
+++ b/src/sdl2_net.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://www.libsdl.org/projects/SDL_net/release/$($(PKG)_FILE
 $(PKG)_DEPS     := cc sdl2
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://www.libsdl.org/projects/SDL_net/release/?C=M;O=D' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://www.libsdl.org/projects/SDL_net/release/?C=M;O=D' | \
     $(SED) -n 's,.*SDL_net-\([0-9][^>]*\)\.tar.*,\1,p' | \
     head -1
 endef

--- a/src/sdl2_ttf.mk
+++ b/src/sdl2_ttf.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://www.libsdl.org/projects/SDL_ttf/release/$($(PKG)_FILE
 $(PKG)_DEPS     := cc freetype sdl2
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://hg.libsdl.org/SDL_ttf/tags' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://hg.libsdl.org/SDL_ttf/tags' | \
     $(SED) -n 's,.*release-\([0-9][^<]*\).*,\1,p' | \
     head -1
 endef

--- a/src/sdl_gfx.mk
+++ b/src/sdl_gfx.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://www.ferzkopp.net/Software/SDL_gfx-2.0/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc sdl
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://www.ferzkopp.net/joomla/content/view/19/14/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://www.ferzkopp.net/joomla/content/view/19/14/' | \
     grep 'href.*tar\.' | \
     $(SED) -n 's,.*SDL_gfx-\([0-9][^>]*\)\.tar.*,\1,p' | \
     head -1

--- a/src/sdl_image.mk
+++ b/src/sdl_image.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://www.libsdl.org/projects/SDL_image/release/$($(PKG)_FI
 $(PKG)_DEPS     := cc jpeg libpng libwebp sdl tiff
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://hg.libsdl.org/SDL_image/tags' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://hg.libsdl.org/SDL_image/tags' | \
     $(SED) -n 's,.*release-\([0-9][^<]*\).*,\1,p' | \
     grep '^1\.' | \
     $(SORT) -V | \

--- a/src/sdl_mixer.mk
+++ b/src/sdl_mixer.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://www.libsdl.org/projects/SDL_mixer/release/$($(PKG)_FI
 $(PKG)_DEPS     := cc libmodplug ogg sdl smpeg vorbis
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://hg.libsdl.org/SDL_mixer/tags' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://hg.libsdl.org/SDL_mixer/tags' | \
     $(SED) -n 's,.*release-\([0-9][^<]*\).*,\1,p' | \
     grep '^1\.' | \
     $(SORT) -V | \

--- a/src/sdl_net.mk
+++ b/src/sdl_net.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://www.libsdl.org/projects/SDL_net/release/$($(PKG)_FILE
 $(PKG)_DEPS     := cc sdl
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://www.libsdl.org/projects/SDL_net/release/?C=M;O=D' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://www.libsdl.org/projects/SDL_net/release/?C=M;O=D' | \
     $(SED) -n 's,.*SDL_net-\([0-9][^>]*\)\.tar.*,\1,p' | \
     head -1
 endef

--- a/src/sdl_pango.mk
+++ b/src/sdl_pango.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://$(SOURCEFORGE_MIRROR)/project/sdlpango/SDL_Pango/$($(
 $(PKG)_DEPS     := cc pango sdl
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://sourceforge.net/projects/sdlpango/files/SDL_Pango/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://sourceforge.net/projects/sdlpango/files/SDL_Pango/' | \
     $(SED) -n 's,.*/projects/.*/\([0-9][^"]*\)/".*,\1,p' | \
     head -1
 endef

--- a/src/sdl_rwhttp.mk
+++ b/src/sdl_rwhttp.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://github.com/mgerhardy/SDL_rwhttp/releases/download/$(c
 $(PKG)_DEPS     := cc curl sdl2 sdl2_net
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://github.com/mgerhardy/SDL_rwhttp/tags' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://github.com/mgerhardy/SDL_rwhttp/tags' | \
     grep '<a href="/mgerhardy/SDL_rwhttp/archive/' | \
     $(SED) -n 's,.*href="/mgerhardy/SDL_rwhttp/archive/\([0-9][^"_]*\)\.tar.*,\1,p' | \
     head -1

--- a/src/sdl_sound.mk
+++ b/src/sdl_sound.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://icculus.org/SDL_sound/downloads/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc flac libmikmod ogg sdl speex vorbis
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://hg.icculus.org/icculus/SDL_sound/tags' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://hg.icculus.org/icculus/SDL_sound/tags' | \
     $(SED) -n 's,.*release-\([0-9][^<]*\).*,\1,p' | \
     head -1
 endef

--- a/src/sdl_ttf.mk
+++ b/src/sdl_ttf.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://www.libsdl.org/projects/SDL_ttf/release/$($(PKG)_FILE
 $(PKG)_DEPS     := cc freetype sdl
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://hg.libsdl.org/SDL_ttf/tags' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://hg.libsdl.org/SDL_ttf/tags' | \
     $(SED) -n 's,.*release-\([0-9][^<]*\).*,\1,p' | \
     head -1
 endef

--- a/src/smpeg.mk
+++ b/src/smpeg.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://deb.debian.org/debian/pool/main/s/$(PKG)/$($(PKG)_FIL
 $(PKG)_DEPS     := cc sdl
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://packages.debian.org/unstable/source/smpeg' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://packages.debian.org/unstable/source/smpeg' | \
     $(SED) -n 's,.*smpeg_\([0-9][^>]*\)\.orig\.tar.*,\1,p' | \
     head -1
 endef

--- a/src/smpeg2.mk
+++ b/src/smpeg2.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://www.libsdl.org/projects/smpeg/release/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc sdl2
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://www.libsdl.org/projects/smpeg/release' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://www.libsdl.org/projects/smpeg/release' | \
     $(SED) -n 's,.*smpeg2-\([0-9][^>]*\)\.tar.*,\1,p' | \
     head -1
 endef

--- a/src/sox.mk
+++ b/src/sox.mk
@@ -13,7 +13,7 @@ $(PKG)_DEPS     := cc file flac lame libltdl libmad libpng libsndfile \
                    opencore-amr opus twolame vorbis wavpack
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://sourceforge.net/projects/sox/files/sox/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://sourceforge.net/projects/sox/files/sox/' | \
     $(SED) -n 's,.*projects/.*/\([0-9][^"]*\)/".*,\1,p' | \
     head -1
 endef

--- a/src/spatialite.mk
+++ b/src/spatialite.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://www.gaia-gis.it/gaia-sins/libspatialite-sources/$($(P
 $(PKG)_DEPS     := cc dlfcn-win32 freexl geos libiconv libxml2 proj sqlite zlib
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://www.gaia-gis.it/gaia-sins/libspatialite-sources/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://www.gaia-gis.it/gaia-sins/libspatialite-sources/' | \
     $(SED) -n 's,.*libspatialite-\([0-9][^>]*\)\.tar.*,\1,p' | \
     tail -1
 endef

--- a/src/speex.mk
+++ b/src/speex.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://downloads.xiph.org/releases/speex/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://git.xiph.org/?p=speex.git;a=tags' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://git.xiph.org/?p=speex.git;a=tags' | \
     grep '<a class="list name"' | \
     $(SED) -n 's,.*<a[^>]*>Speex-\([0-9][^<]*\)<.*,\1,p' | \
     head -1

--- a/src/speexdsp.mk
+++ b/src/speexdsp.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://downloads.xiph.org/releases/speex/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://git.xiph.org/?p=speexdsp.git;a=tags' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://git.xiph.org/?p=speexdsp.git;a=tags' | \
     grep '<a class="list name"' | \
     $(SED) -n 's,.*<a[^>]*>SpeexDSP-\([0-9][^<]*\)<.*,\1,p' | \
     head -1

--- a/src/sqlite.mk
+++ b/src/sqlite.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://www.sqlite.org/2019/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://www.sqlite.org/download.html' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://www.sqlite.org/download.html' | \
     $(SED) -n 's,.*sqlite-autoconf-\([0-9][^>]*\)\.tar.*,\1,p' | \
     head -1
 endef

--- a/src/subversion.mk
+++ b/src/subversion.mk
@@ -12,7 +12,7 @@ $(PKG)_URL_2    := https://www.apache.org/dist/subversion/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc apr apr-util openssl sqlite
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://subversion.apache.org/download.cgi' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://subversion.apache.org/download.cgi' | \
     $(SED) -n 's,.*#recommended-release">\([0-9][^<]*\)<.*,\1,p' | \
     head -1
 endef

--- a/src/suitesparse.mk
+++ b/src/suitesparse.mk
@@ -12,7 +12,7 @@ $(PKG)_URL_2    := https://distfiles.macports.org/SuiteSparse/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc intel-tbb metis openblas
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'http://faculty.cse.tamu.edu/davis/suitesparse.html' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'http://faculty.cse.tamu.edu/davis/suitesparse.html' | \
     $(SED) -n 's,.*SuiteSparse-\([0-9][^"]*\)\.tar.*,\1,p' | \
     head -1
 endef

--- a/src/t4k_common.mk
+++ b/src/t4k_common.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://$(SOURCEFORGE_MIRROR)/project/tuxmath/$(PKG)/$($(PKG)
 $(PKG)_DEPS     := cc libpng librsvg libxml2 pthreads sdl sdl_image sdl_mixer sdl_net sdl_pango sdl_ttf
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://alioth.debian.org/frs/?group_id=31080' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://alioth.debian.org/frs/?group_id=31080' | \
     $(SED) -n 's,.*t4k_common-\([0-9][^>]*\)\.tar.*,\1,p' | \
     head -1
 endef

--- a/src/tcl.mk
+++ b/src/tcl.mk
@@ -16,7 +16,7 @@ $(PKG)_SOURCE_SUBDIR  = $(if $(findstring mingw,$(TARGET)),win,unix)
 $(PKG)_CONFIGURE_OPTS = $(if $(findstring mingw,$(TARGET)),CFLAGS=-D__MINGW_EXCPT_DEFINE_PSDK)
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://sourceforge.net/projects/tcl/files/Tcl/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://sourceforge.net/projects/tcl/files/Tcl/' | \
     $(SED) -n 's,.*/projects/.*/\([0-9][^"]*\)/".*,\1,p' | \
     head -1
 endef

--- a/src/tclap.mk
+++ b/src/tclap.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://$(SOURCEFORGE_MIRROR)/project/tclap/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://sourceforge.net/projects/tclap/files/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://sourceforge.net/projects/tclap/files/' | \
     $(SED) -n 's,.*/projects/.*/\([0-9][^"]*\)/".*,\1,p' | \
     head -1
 endef

--- a/src/teem.mk
+++ b/src/teem.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://$(SOURCEFORGE_MIRROR)/project/$(PKG)/$(PKG)/$($(PKG)_
 $(PKG)_DEPS     := cc bzip2 levmar libpng pthreads zlib
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- "https://sourceforge.net/projects/teem/files/teem/" | \
+    $(WGET) -q -O- -t 2 --timeout=6 "https://sourceforge.net/projects/teem/files/teem/" | \
     grep 'teem/files/teem' | \
     $(SED) -n 's,.*teem/\([0-9][^>]*\)/.*,\1,p' | \
     head -1

--- a/src/termcap.mk
+++ b/src/termcap.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://ftp.gnu.org/gnu/termcap/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://ftp.gnu.org/gnu/termcap/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://ftp.gnu.org/gnu/termcap/' | \
     grep 'termcap-' | \
     $(SED) -n 's,.*termcap-\([0-9][^>]*\)\.tar.*,\1,p' | \
     head -1

--- a/src/theora.mk
+++ b/src/theora.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://downloads.xiph.org/releases/theora/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc ogg vorbis
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://www.xiph.org/downloads/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://www.xiph.org/downloads/' | \
     $(SED) -n 's,.*libtheora-\([0-9][^>]*\)\.tar.*,\1,p' | \
     head -1
 endef

--- a/src/tiff.mk
+++ b/src/tiff.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://download.osgeo.org/libtiff/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc jpeg libwebp xz zlib
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'http://simplesystems.org/libtiff/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'http://simplesystems.org/libtiff/' | \
     $(SED) -n 's,.*>v\([0-9][^<]*\)<.*,\1,p' | \
     head -1
 endef

--- a/src/tinyxml.mk
+++ b/src/tinyxml.mk
@@ -13,7 +13,7 @@ $(PKG)_DEPS     := cc
 $(PKG)_MESSAGE  :=*** tinyxml is deprecated - please use tinyxml2 ***
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://sourceforge.net/projects/tinyxml/files/tinyxml/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://sourceforge.net/projects/tinyxml/files/tinyxml/' | \
     $(SED) -n 's,.*/projects/.*/\([0-9][^"]*\)/".*,\1,p' | \
     head -1
 endef

--- a/src/tre.mk
+++ b/src/tre.mk
@@ -13,7 +13,7 @@ $(PKG)_URL_2    := https://deb.debian.org/debian/pool/main/t/$(PKG)/$(PKG)_$($(P
 $(PKG)_DEPS     := cc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://laurikari.net/tre/download.html' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://laurikari.net/tre/download.html' | \
     $(SED) -n 's,.*tre-\([a-z0-9][^>]*\)\.tar.*,\1,p' | \
     head -1
 endef

--- a/src/twolame.mk
+++ b/src/twolame.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://$(SOURCEFORGE_MIRROR)/project/$(PKG)/$(PKG)/$($(PKG)_
 $(PKG)_DEPS     := cc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://sourceforge.net/projects/$(PKG)/files/$(PKG)/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://sourceforge.net/projects/$(PKG)/files/$(PKG)/' | \
     $(SED) -n 's,^.*twolame/\([0-9][^"]*\)/".*$$,\1,p' | \
     head -n 1
 endef

--- a/src/ucl.mk
+++ b/src/ucl.mk
@@ -14,7 +14,7 @@ $(PKG)_DEPS_$(BUILD) :=
 $(PKG)_TARGETS  := $(BUILD) $(MXE_TARGETS)
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://www.oberhumer.com/opensource/ucl/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://www.oberhumer.com/opensource/ucl/' | \
     $(SED) -n 's,.*ucl-\([0-9][^"]*\)\.tar.*,\1,p' | \
     head -1
 endef

--- a/src/unrtf.mk
+++ b/src/unrtf.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://ftp.gnu.org/gnu/$(PKG)/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc libiconv
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://hg.savannah.gnu.org/hgweb/unrtf/tags' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://hg.savannah.gnu.org/hgweb/unrtf/tags' | \
     $(SED) -n "s,^release_,,p" | \
     head -1
 endef

--- a/src/upx.mk
+++ b/src/upx.mk
@@ -14,7 +14,7 @@ $(PKG)_DEPS_$(BUILD) := ucl zlib lzma
 $(PKG)_TARGETS  := $(BUILD) $(MXE_TARGETS)
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://upx.sourceforge.io/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://upx.sourceforge.io/' | \
     $(SED) -n 's,.*upx-\([0-9][^"]*\)\-src.tar.*,\1,p' | \
     head -1
 endef

--- a/src/vo-aacenc.mk
+++ b/src/vo-aacenc.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://$(SOURCEFORGE_MIRROR)/project/opencore-amr/$(PKG)/$($
 $(PKG)_DEPS     := cc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://sourceforge.net/projects/opencore-amr/files/vo-aacenc/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://sourceforge.net/projects/opencore-amr/files/vo-aacenc/' | \
     $(SED) -n 's,.*aacenc-\([0-9.]*\)\.tar.*,\1,p' | \
     $(SORT) -V | \
     tail -1

--- a/src/vo-amrwbenc.mk
+++ b/src/vo-amrwbenc.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://$(SOURCEFORGE_MIRROR)/project/opencore-amr/$(PKG)/$($
 $(PKG)_DEPS     := cc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://sourceforge.net/projects/opencore-amr/files/vo-amrwbenc/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://sourceforge.net/projects/opencore-amr/files/vo-amrwbenc/' | \
     $(SED) -n 's,.*amrwbenc-\([0-9.]*\)\.tar.*,\1,p' | \
     $(SORT) -V | \
     tail -1

--- a/src/vorbis.mk
+++ b/src/vorbis.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://downloads.xiph.org/releases/vorbis/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc ogg
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://www.xiph.org/downloads/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://www.xiph.org/downloads/' | \
     $(SED) -n 's,.*libvorbis-\([0-9][^>]*\)\.tar.*,\1,p' | \
     head -1
 endef

--- a/src/vtk.mk
+++ b/src/vtk.mk
@@ -14,7 +14,7 @@ $(PKG)_TARGETS       := $(BUILD) $(MXE_TARGETS)
 $(PKG)_DEPS_$(BUILD) := cmake
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://vtk.org/gitweb?p=VTK.git;a=tags' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://vtk.org/gitweb?p=VTK.git;a=tags' | \
     grep 'refs/tags/v[0-9.]*"' | \
     $(SED) 's,.*refs/tags/v\(.*\)".*,\1,g;' | \
     grep -v rc | \

--- a/src/waf.mk
+++ b/src/waf.mk
@@ -13,7 +13,7 @@ $(PKG)_TARGETS  := $(BUILD)
 $(PKG)_TYPE     := source-only
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://waf.io/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://waf.io/' | \
     $(SED) -n 's,.*waf-\([0-9][^>]*\)\.tar.*,\1,p' | \
     head -1
 endef

--- a/src/wavpack.mk
+++ b/src/wavpack.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := http://www.wavpack.com/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'http://www.wavpack.com/downloads.html' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'http://www.wavpack.com/downloads.html' | \
     grep '<a href="wavpack-.*\.tar\.bz2">' | \
     head -n 1 | \
     $(SED) -e 's/^.*<a href="wavpack-\([0-9.]*\)\.tar\.bz2">.*$$/\1/'

--- a/src/wget.mk
+++ b/src/wget.mk
@@ -10,7 +10,7 @@ $(PKG)_URL      := https://ftp.gnu.org/gnu/$(PKG)/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc gnutls libidn2 libntlm pcre2 pthreads
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://git.savannah.gnu.org/cgit/wget.git/refs/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://git.savannah.gnu.org/cgit/wget.git/refs/' | \
     $(SED) -n "s,.*<a href='/cgit/wget.git/tag/?h=v\([0-9.]*\)'>.*,\1,p" | \
     head -1
 endef

--- a/src/winpcap.mk
+++ b/src/winpcap.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://www.winpcap.org/install/bin/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://www.winpcap.org/devel.htm' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://www.winpcap.org/devel.htm' | \
     $(SED) -n 's,.*WpcapSrc_\([0-9][^>]*\)\.zip.*,\1,p' | \
     head -1
 endef

--- a/src/wxwidgets.mk
+++ b/src/wxwidgets.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://$(SOURCEFORGE_MIRROR)/project/wxwindows/$($(PKG)_VERS
 $(PKG)_DEPS     := cc expat jpeg libiconv libpng sdl tiff zlib
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://sourceforge.net/projects/wxwindows/files/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://sourceforge.net/projects/wxwindows/files/' | \
     $(SED) -n 's,.*/projects/.*/\([0-9][^"]*\)/".*,\1,p' | \
     sort -V | \
     tail -1

--- a/src/x264.mk
+++ b/src/x264.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://download.videolan.org/pub/videolan/$(PKG)/snapshots/$
 $(PKG)_DEPS     := cc liblsmash $(BUILD)~nasm
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://git.videolan.org/?p=x264.git;a=shortlog' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://git.videolan.org/?p=x264.git;a=shortlog' | \
     $(SED) -n 's,.*\([0-9]\{4\}\)-\([0-9]\{2\}\)-\([0-9]\{2\}\).*,\1\2\3-2245,p' | \
     $(SORT) | \
     tail -1

--- a/src/x265.mk
+++ b/src/x265.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://bitbucket.org/multicoreware/x265/downloads/$($(PKG)_F
 $(PKG)_DEPS     := cc yasm
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- https://ftp.videolan.org/pub/videolan/x265/ | \
+    $(WGET) -q -O- -t 2 --timeout=6 https://ftp.videolan.org/pub/videolan/x265/ | \
     $(SED) -n 's,.*">x265_\([0-9][^<]*\)\.t.*,\1,p' | \
     tail -1
 endef

--- a/src/xapian-core.mk
+++ b/src/xapian-core.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://oligarchy.co.uk/xapian/$($(PKG)_VERSION)/$($(PKG)_FIL
 $(PKG)_DEPS     := cc zlib
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- https://xapian.org/download | \
+    $(WGET) -q -O- -t 2 --timeout=6 https://xapian.org/download | \
     $(SED) -n 's,.*<a HREF="https://oligarchy.co.uk/xapian/\([^/]*\)/xapian-core[^"]*">.*,\1,p' | \
     head -1
 endef

--- a/src/xerces.mk
+++ b/src/xerces.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://archive.apache.org/dist/xerces/c/$(word 1,$(subst ., 
 $(PKG)_DEPS     := cc curl libiconv pthreads
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://www.apache.org/dist/xerces/c/3/sources/?C=M;O=D' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://www.apache.org/dist/xerces/c/3/sources/?C=M;O=D' | \
     $(SED) -n 's,.*<a href="xerces-c-\([0-9][^"]*\)\.tar.*,\1,p' | \
     grep -v rc | \
     head -1

--- a/src/xmlrpc-c.mk
+++ b/src/xmlrpc-c.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://github.com/mirror/$(PKG)/tarball/$($(PKG)_VERSION)/$(
 $(PKG)_DEPS     := cc curl pthreads
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://github.com/mirror/xmlrpc-c/commits/master' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://github.com/mirror/xmlrpc-c/commits/master' | \
     grep 'title="Release' | \
     $(SED) -n 's,.*/mirror/xmlrpc-c/commit/\([^"]\{7\}\)[^"]\{33\}".*Release \([0-9]*\),\1 \2,p' | \
     $(SORT) -V -k 2 | \

--- a/src/xmlwrapp.mk
+++ b/src/xmlwrapp.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://$(SOURCEFORGE_MIRROR)/project/$(PKG)/$(PKG)/$($(PKG)_
 $(PKG)_DEPS     := cc boost libxml2 libxslt
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://sourceforge.net/projects/xmlwrapp/files/xmlwrapp/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://sourceforge.net/projects/xmlwrapp/files/xmlwrapp/' | \
     $(SED) -n 's,.*/projects/.*/\([0-9][^"]*\)/".*,\1,p' | \
     head -1
 endef

--- a/src/xorg-macros.mk
+++ b/src/xorg-macros.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://xorg.freedesktop.org/releases/individual/util/util-ma
 $(PKG)_DEPS     :=
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://cgit.freedesktop.org/xorg/util/macros/refs/tags' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://cgit.freedesktop.org/xorg/util/macros/refs/tags' | \
     $(SED) -n "s,.*<a href='[^']*/tag/?h=util-macros-\\([0-9.]*\\)'.*,\\1,p" | \
     $(SORT) -V | \
     tail -1

--- a/src/xvidcore.mk
+++ b/src/xvidcore.mk
@@ -11,7 +11,7 @@ $(PKG)_URL      := https://downloads.xvid.com/downloads/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc pthreads yasm
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://labs.xvid.com/source/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://labs.xvid.com/source/' | \
     $(SED) -n 's,.*xvidcore-\([0-9][^ ]*\)\.tar.*,\1,p' | \
     head -1
 endef

--- a/src/xz.mk
+++ b/src/xz.mk
@@ -12,7 +12,7 @@ $(PKG)_URL      := https://tukaani.org/xz/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://tukaani.org/xz/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://tukaani.org/xz/' | \
     $(SED) -n 's,.*xz-\([0-9][^>]*\)\.tar.*,\1,p' | \
     head -1
 endef

--- a/src/zlib.mk
+++ b/src/zlib.mk
@@ -15,7 +15,7 @@ $(PKG)_TARGETS  := $(BUILD) $(MXE_TARGETS)
 $(PKG)_DEPS_$(BUILD) :=
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://zlib.net/' | \
+    $(WGET) -q -O- -t 2 --timeout=6 'https://zlib.net/' | \
     $(SED) -n 's,.*zlib-\([0-9][^>]*\)\.tar.*,\1,ip' | \
     head -1
 endef


### PR DESCRIPTION
The default timeout for wget is 15 minutes.
It's pretty annoying having to wait 15 minutes for `make update` to continue for each update where the site is actually down.
Right now that's the case for wavpack.
This sets the timeout to 6 seconds and tries to 2, so it doesn't try more than 2 times.
