### PR TITLE
Set tries and timeout for wget

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ SED        := $(shell gsed --help >/dev/null 2>&1 && echo g)sed
 SORT       := $(shell gsort --help >/dev/null 2>&1 && echo g)sort
 DEFAULT_UA := $(shell wget --version | $(SED) -n 's,GNU \(Wget\) \([0-9.]*\).*,\1/\2,p')
 WGET_TOOL   = wget
-WGET        = $(WGET_TOOL) --user-agent='$(or $($(1)_UA),$(DEFAULT_UA))'
+WGET        = $(WGET_TOOL) --user-agent='$(or $($(1)_UA),$(DEFAULT_UA))' -t 2 --timeout=6
 
 REQUIREMENTS := autoconf automake autopoint bash bison bzip2 flex \
                 $(BUILD_CC) $(BUILD_CXX) gperf intltoolize $(LIBTOOL) \


### PR DESCRIPTION
The default timeout for wget is 15 minutes.
It's pretty annoying having to wait 15 minutes for make update to continue for each update where the site is actually down.
Right now that's the case for wavpack.
This sets the timeout to 6 seconds and tries to 2, so it doesn't try more than 2 times.