### PR TITLE
Add brotli

### DIFF
--- a/src/brotli.mk
+++ b/src/brotli.mk
@@ -1,0 +1,16 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+PKG             := brotli
+$(PKG)_WEBSITE  := https://opensource.google.com/projects/brotli
+$(PKG)_DESCR    := Brotli compression format
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 1.0.7
+$(PKG)_CHECKSUM := 4c61bfb0faca87219ea587326c467b95acb25555b53d1a421ffa3c8a9296ee2c
+$(PKG)_GH_CONF  := google/brotli/tags, v
+$(PKG)_DEPS     := cc
+
+define $(PKG)_BUILD
+    cd '$(BUILD_DIR)' && $(TARGET)-cmake '$(SOURCE_DIR)'
+    $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)'
+    $(MAKE) -C '$(BUILD_DIR)' -j 1 install
+endef


### PR DESCRIPTION
brotli is required by recent versions of libsoup