### PR TITLE
fluidsynth: Update to version 2.0.7

### DIFF
--- a/src/fluidsynth.mk
+++ b/src/fluidsynth.mk
@@ -4,8 +4,8 @@ PKG             := fluidsynth
 $(PKG)_WEBSITE  := http://fluidsynth.org/
 $(PKG)_DESCR    := FluidSynth - a free software synthesizer based on the SoundFont 2 specifications
 $(PKG)_IGNORE   :=
-$(PKG)_VERSION  := 2.0.6
-$(PKG)_CHECKSUM := e97e63c1045e102465f1aa848f9d712c5528c58685b8d40062e4aaf6af7edb75
+$(PKG)_VERSION  := 2.0.7
+$(PKG)_CHECKSUM := b68876d24c7fb34575ffa389bcfe8e61a24f1cf1da8ec6c3b2053efde98d0320
 $(PKG)_GH_CONF  := FluidSynth/fluidsynth/tags,v
 $(PKG)_DEPS     := cc dbus glib jack libsndfile mman-win32 portaudio readline
 


### PR DESCRIPTION
This patch updates Fluidsynth to the latest release (2.0.7). I was able to successfully build the package on all supported MXE_TARGETS.