### PR TITLE
Devel001

### DIFF
--- a/src/biosig.mk
+++ b/src/biosig.mk
@@ -1,0 +1,96 @@
+# This file is part of MXE.
+# See index.html for further information.
+
+PKG             := biosig
+$(PKG)_WEBSITE  := http://biosig.sf.net/
+$(PKG)_DESCR    := biosig
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 1.9.5
+$(PKG)_CHECKSUM := 20e72a5a07d1bf8baa649efe437b4d3ed99944f0e4dfc1fbe23bfbe4d9749ed5
+$(PKG)_SUBDIR   := biosig4c++-$($(PKG)_VERSION)
+$(PKG)_FILE     := biosig4c++-$($(PKG)_VERSION).src.tar.gz
+$(PKG)_URL      := http://sourceforge.net/projects/biosig/files/BioSig%20for%20C_C%2B%2B/src/$($(PKG)_FILE)
+$(PKG)_DEPS     := cc suitesparse zlib libiberty libiconv libb64 lapack dcmtk tinyxml
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- 'https://biosig.sourceforge.io/download.html' | \
+        $(GREP) biosig4c | \
+        $(SED) -n 's_.*>v\([0-9]\.[0-9]\.[0-9]\)<.*_\1_p' | \
+        $(SORT) -V | \
+        tail -1
+endef
+
+define $(PKG)_BUILD_PRE
+
+    cd '$(SOURCE_DIR)' && autoreconf -fi 
+    cd '$(SOURCE_DIR)' && '$(SOURCE_DIR)'/configure $(MXE_CONFIGURE_OPTS)
+
+    # make sure NDEBUG is defined
+    $(SED) -i '/NDEBUG/ s|#||g' '$(1)'/Makefile
+
+    ### disables declaration of sopen from io.h (imported through unistd.h)
+    $(SED) -i '/ sopen/ s#^/*#//#g' $(PREFIX)/$(TARGET)/include/io.h
+
+    #$(SED) -i 's| -fstack-protector | |g' '$(1)'/Makefile
+    #$(SED) -i 's| -D_FORTIFY_SOURCE=2 | |g' '$(1)'/Makefile
+    #$(SED) -i 's| -lssp | |g' '$(1)'/Makefile
+
+    TARGET='$(TARGET)' $(MAKE) -C '$(1)' clean
+    TARGET='$(TARGET)' $(MAKE) -C '$(1)' -j '$(JOBS)' \
+		libbiosig.a libgdf.a  libphysicalunits.a \
+		libbiosig.def libgdf.def libphysicalunits.def \
+		tools
+
+endef
+
+define $(PKG)_BUILD_POST
+
+    TARGET='$(TARGET)' $(MAKE) -C '$(1)' -j '$(JOBS)' tools
+    $(INSTALL) -m644 '$(1)/save2gdf.exe'         '$(PREFIX)/$(TARGET)/bin/test-biosig.exe'
+    $(INSTALL) -m644 '$(1)'/*.exe         '$(PREFIX)/$(TARGET)/bin/'
+
+    $(INSTALL) -m644 '$(1)/biosig.h'             '$(PREFIX)/$(TARGET)/include/'
+    $(INSTALL) -m644 '$(1)/biosig2.h'            '$(PREFIX)/$(TARGET)/include/'
+    $(INSTALL) -m644 '$(1)/gdftime.h'            '$(PREFIX)/$(TARGET)/include/'
+    $(INSTALL) -m644 '$(1)/biosig-dev.h'         '$(PREFIX)/$(TARGET)/include/'
+
+    $(INSTALL) -m644 '$(1)/libbiosig.a'          '$(PREFIX)/$(TARGET)/lib/'
+    $(INSTALL) -m644 '$(1)/libbiosig.def' 	 '$(PREFIX)/$(TARGET)/lib/'
+    $(INSTALL) -m644 '$(1)/libbiosig.dll.a' 	 '$(PREFIX)/$(TARGET)/lib/'
+    $(INSTALL) -m644 '$(1)/libbiosig.dll' 	 '$(PREFIX)/$(TARGET)/bin/'
+
+    $(INSTALL) -m644 '$(1)/libgdf.a'             '$(PREFIX)/$(TARGET)/lib/'
+    $(INSTALL) -m644 '$(1)/libgdf.def' 		 '$(PREFIX)/$(TARGET)/lib/'
+    $(INSTALL) -m644 '$(1)/libgdf.dll.a' 	 '$(PREFIX)/$(TARGET)/lib/'
+    $(INSTALL) -m644 '$(1)/libgdf.dll'	 	 '$(PREFIX)/$(TARGET)/bin/'
+
+
+    $(INSTALL) -m644 '$(1)/physicalunits.h'      '$(PREFIX)/$(TARGET)/include/'
+    $(INSTALL) -m644 '$(1)/libphysicalunits.a'   '$(PREFIX)/$(TARGET)/lib/'
+    $(INSTALL) -m644 '$(1)/libphysicalunits.def' '$(PREFIX)/$(TARGET)/lib/'
+    $(INSTALL) -m644 '$(1)/libphysicalunits.dll.a' '$(PREFIX)/$(TARGET)/lib/'
+    $(INSTALL) -m644 '$(1)/libphysicalunits.dll' '$(PREFIX)/$(TARGET)/bin/'
+
+    $(INSTALL) -m644 '$(1)/libbiosig.pc'         '$(PREFIX)/$(TARGET)/lib/pkgconfig/'
+
+endef
+
+
+define $(PKG)_BUILD_i686-pc-mingw32
+	$($(PKG)_BUILD_PRE)
+	#HOME=/home/as TARGET=$(TARGET) $(MAKE) -C '$(1)' mexw32
+	$($(PKG)_BUILD_POST)
+endef
+
+define $(PKG)_BUILD_i686-w64-mingw32
+	$($(PKG)_BUILD_PRE)
+	#TARGET=$(TARGET) $(MAKE) -C '$(1)' mexw32
+	$($(PKG)_BUILD_POST)
+endef
+
+define $(PKG)_BUILD_x86_64-w64-mingw32
+	$($(PKG)_BUILD_PRE)
+	#TARGET=$(TARGET) $(MAKE) -C '$(1)' mexw64
+	$($(PKG)_BUILD_POST)
+endef
+

--- a/src/libb64.mk
+++ b/src/libb64.mk
@@ -1,0 +1,28 @@
+# This file is part of MXE.
+# See index.html for further information.
+
+PKG             := libb64
+$(PKG)_IGNORE   := 
+$(PKG)_VERSION  := 1.2.1
+$(PKG)_CHECKSUM := 20106f0ba95cfd9c35a13c71206643e3fb3e46512df3e2efb2fdbf87116314b2
+$(PKG)_SUBDIR   := libb64-$($(PKG)_VERSION)
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).zip
+$(PKG)_URL      := https://sourceforge.net/projects/$(PKG)/files/$(PKG)/$(PKG)/$($(PKG)_FILE)
+
+$(PKG)_DEPS     := cc
+
+define $(PKG)_UPDATE
+    wget -q -O- 'http://sourceforge.net/projects/libb64/files/' | \
+    $(SED) -n 's_.*libb64-\([0-9]\.[0-9]\.[0-9]\).*zip_\1_ip' | \
+    head -1
+endef
+
+define $(PKG)_BUILD
+
+    CC=$(TARGET)-gcc CXX=$(TARGET)-g++ PKG_CONFIG=$(TARGET)-pkg_config AR=$(TARGET)-ar $(MAKE) -C '$(1)/src'
+
+    cp -r '$(1)/include/b64' '$(PREFIX)/$(TARGET)/include/'
+    $(INSTALL) '$(1)/src/libb64.a' '$(PREFIX)/$(TARGET)/lib/'
+
+endef
+


### PR DESCRIPTION
Please consider including the packages libb64 and biosig into mxe. 
- libb64 is a small library for base64 encoding/decoding, used by some tools in biosig. 
- biosig provides some libraries (libbiosig, libgdf, libphysicalunits), and some cli tools (save2gdf, biosig_fhir, physicalunits). libbiosig is a library used in a number of additional tools (sigviewer, stimfit), and is important for various language bindings of biosig to octave, matlab, python, R, etc.  

I tried to follow the suggested rules below, let me know if there is anything need to be changed. 
 

Please read http://mxe.cc/#creating-packages

In particular, make sure that your build rules:

  * install .pc file
  * install bin/test-pkg.exe compiled with flags by pkg-config,
  * install .dll to bin/ and .a, .dll.a to lib/,
  * use $(TARGET)-cmake instead of cmake,
  * build in `$(BUILD_DIR)` instead of `$(SOURCE_DIR)`,
  * do not run target executables with Wine,
  * do not download anything while building,
  * do not install documentation,
  * do not install .exe files except test and build systems,

and .patch files are generated by tools/patch-tool-mxe.

If you add a package, you can use tool tools/skeleton.py.

Thanks!
