### PR TITLE
add zip to the requirements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ WGET        = $(WGET_TOOL) --user-agent='$(or $($(1)_UA),$(DEFAULT_UA))' -t 2 --
 REQUIREMENTS := autoconf automake autopoint bash bison bzip2 flex \
                 $(BUILD_CC) $(BUILD_CXX) gperf intltoolize $(LIBTOOL) \
                 $(LIBTOOLIZE) lzip $(MAKE) $(OPENSSL) $(PATCH) $(PERL) python \
-                ruby $(SED) $(SORT) unzip wget xz 7za gdk-pixbuf-csource
+                ruby $(SED) $(SORT) unzip wget xz 7za gdk-pixbuf-csource zip
 
 PREFIX     := $(PWD)/usr
 LOG_DIR    := $(PWD)/log


### PR DESCRIPTION
The icu4c package build procedure uses it. If it isn't present, the build fails, e.g.

```
…
install -d '/srv/build/tmp/mxe.C0ANUJ/mxe/usr/i686-w64-mingw32.shared/bin/test-icu4c'
cp $(i686-w64-mingw32.shared-peldd --all '/srv/build/tmp/mxe.C0ANUJ/mxe/usr/i686-w64-mingw32.shared/bin/test-icu4c.exe') '/srv/build/tmp/mxe.C0ANUJ/mxe/usr/i686-w64-mingw32.shared/bin/test-icu4c'
cd '/srv/build/tmp/mxe.C0ANUJ/mxe/usr/i686-w64-mingw32.shared/bin' && zip -r test-icu4c.zip test-icu4c
bash: zip: command not found
```
