### PR TITLE
qca: fix build after recent changes

### DIFF
--- a/src/qca.mk
+++ b/src/qca.mk
@@ -26,7 +26,7 @@ define $(PKG)_BUILD
         'greaterThan(QT_GCC_MAJOR_VERSION, 8): QMAKE_CXXFLAGS_WARN_ON += -Wno-deprecated-copy' \
         '$(PWD)/src/qca-test.pro'
     $(MAKE) -C '$(BUILD_DIR).test-qmake' -j 1
-    $(INSTALL) -m755 '$(BUILD_DIR).test-qmake/$(BUILD_TYPE)/test-qca-qmake.exe' '$(PREFIX)/$(TARGET)/bin/'
+    $(INSTALL) -m755 '$(BUILD_DIR).test-qmake/test-qca-qmake.exe' '$(PREFIX)/$(TARGET)/bin/'
 
     # build test as cmake project
     mkdir '$(BUILD_DIR).test-cmake'


### PR DESCRIPTION
Tested for:
```
MXE_TARGETS := x86_64-w64-mingw32.shared i686-w64-mingw32.shared
MXE_PLUGIN_DIRS += plugins/gcc9
```