### PR TITLE
add Qt5Network library dependencies

### DIFF
--- a/src/qtbase.mk
+++ b/src/qtbase.mk
@@ -110,6 +110,7 @@ define $(PKG)_BUILD
     $(if $(BUILD_STATIC), \
         $(SED) -i 's^set(_Qt5Core_LIB_DEPENDENCIES \"\")^set(_Qt5Core_LIB_DEPENDENCIES \"ole32;uuid;ws2_32;advapi32;shell32;user32;kernel32;mpr;version;winmm;z;pcre2-16;netapi32;userenv;zstd\")^g' '$(PREFIX)/$(TARGET)/qt5/lib/cmake/Qt5Core/Qt5CoreConfig.cmake' && \
         $(SED) -i 's^set(_Qt5Gui_LIB_DEPENDENCIES \"Qt5::Core\")^set(_Qt5Gui_LIB_DEPENDENCIES \"Qt5::Core;dwmapi;winspool;wtsapi32;jasper;mng;tiff;webpdemux;webpmux;d3d11;dxgi;dxguid;harfbuzz;cairo;gobject-2.0;fontconfig;freetype;usp10;msimg32;pixman-1;ffi;expat;bz2;png16;harfbuzz_too;freetype_too;glib-2.0;shlwapi;pcre;intl;iconv;gdi32;comdlg32;oleaut32;imm32;opengl32;mpr;userenv;version;pcre2-16;netapi32;ws2_32;advapi32;kernel32;ole32;shell32;uuid;user32;winmm;lcms2;pthread;webp;zstd;lzma;jpeg;z;m\")^g' '$(PREFIX)/$(TARGET)/qt5/lib/cmake/Qt5Gui/Qt5GuiConfig.cmake' && \
+        $(SED) -i 's^set(_Qt5Network_LIB_DEPENDENCIES \"Qt5::Core\")^set(_Qt5Network_LIB_DEPENDENCIES \"Qt5::Core;ssl;crypto;ws2_32;gdi32;crypt32;iphlpapi\")^g' '$(PREFIX)/$(TARGET)/qt5/lib/cmake/Qt5Network/Qt5NetworkConfig.cmake' && \
         $(SED) -i 's^set(_Qt5Widgets_LIB_DEPENDENCIES \"Qt5::Gui;Qt5::Core\")^set(_Qt5Widgets_LIB_DEPENDENCIES \"Qt5::Gui;Qt5::Core;gdi32;comdlg32;oleaut32;imm32;opengl32;png16;harfbuzz;ole32;uuid;ws2_32;advapi32;shell32;user32;kernel32;mpr;version;winmm;z;pcre2-16;shell32;uxtheme;dwmapi\")^g' '$(PREFIX)/$(TARGET)/qt5/lib/cmake/Qt5Widgets/Qt5WidgetsConfig.cmake',
     )
 endef


### PR DESCRIPTION
This is a simple edit, I've tested this on my own machine and it works. Without this CMake fails to link executables that require Qt5Network.