### PR TITLE
Make Tk version consistent with Tcl

### DIFF
--- a/plugins/tcl.tk/tk.mk
+++ b/plugins/tcl.tk/tk.mk
@@ -4,8 +4,8 @@ PKG             := tk
 $(PKG)_WEBSITE  := https://tcl.tk/
 $(PKG)_OWNER    := https://github.com/highperformancecoder
 $(PKG)_IGNORE   :=
-$(PKG)_VERSION  := 8.6.4
-$(PKG)_CHECKSUM := 08f99df85e5dc9c4271762163c6aabb962c8b297dc5c4c1af8bdd05fc2dd26c1
+$(PKG)_VERSION  := 8.6.9
+$(PKG)_CHECKSUM := d3f9161e8ba0f107fe8d4df1f6d3a14c30cc3512dfc12a795daa367a27660dac
 $(PKG)_SUBDIR   := tk$($(PKG)_VERSION)
 $(PKG)_FILE     := tk$($(PKG)_VERSION)-src.tar.gz
 $(PKG)_URL      := https://$(SOURCEFORGE_MIRROR)/project/tcl/Tcl/$($(PKG)_VERSION)/$($(PKG)_FILE)
@@ -26,6 +26,6 @@ define $(PKG)_BUILD
         --with-tcl='$(PREFIX)/$(TARGET)/lib' \
         $(if $(findstring x86_64,$(TARGET)), --enable-64bit) \
         CFLAGS='-D__MINGW_EXCPT_DEFINE_PSDK'
-    $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)'
-    $(MAKE) -C '$(BUILD_DIR)' -j 1 install
+    $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)' LIBS='-lmincore -lnetapi32 -lz -ltclstub86 -limm32 -lcomctl32 -luuid -lole32'
+    $(MAKE) -C '$(BUILD_DIR)' -j 1 install 
 endef

--- a/plugins/tcl.tk/tk.mk
+++ b/plugins/tcl.tk/tk.mk
@@ -27,5 +27,5 @@ define $(PKG)_BUILD
         $(if $(findstring x86_64,$(TARGET)), --enable-64bit) \
         CFLAGS='-D__MINGW_EXCPT_DEFINE_PSDK'
     $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)' LIBS='-lmincore -lnetapi32 -lz -ltclstub86 -limm32 -lcomctl32 -luuid -lole32'
-    $(MAKE) -C '$(BUILD_DIR)' -j 1 install 
+    $(MAKE) -C '$(BUILD_DIR)' -j 1 install
 endef


### PR DESCRIPTION
Tk needs to be consistent with TCL. Ever since someone added TCL back as a base package, rather than a plugin, the Tk and TCL versions became out of sync. This synchronizes them.
