### PR TITLE
Switch to pkgconf at more places in the docs

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -729,7 +729,7 @@ USE_OSGPLUGIN(&lt;plugin2&gt;)
     p7zip-full \
     patch \
     perl \
-    pkg-config \
+    pkgconf \
     python \
     ruby \
     sed \

--- a/docs/index.html
+++ b/docs/index.html
@@ -671,8 +671,8 @@ USE_OSGPLUGIN(&lt;plugin2&gt;)
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://www.freedesktop.org/wiki/Software/pkg-config/">Pkg-config</a></td>
-        <td>≥ 0.16</td>
+        <td><a href="https://pkgconf.org/">pkgconf</a></td>
+        <td></td>
     </tr>
     <tr>
         <td><a href="https://www.python.org/">Python</a></td>


### PR DESCRIPTION
Switch to pkgconf at more places in the docs. In particular, list pkgconf instead of pkg-config in the list of dependencies.

Moreover, use pkgconf instead of pkg-config for the Debian installation command. The old command switched Debian systems back from pkgconf to pkg-config, which is certainly not what we want.