### PR TITLE
Qt opengl dynamic

### DIFF
--- a/src/mesa-1-fixes.patch
+++ b/src/mesa-1-fixes.patch
@@ -1,0 +1,25 @@
+This file is part of MXE. See LICENSE.md for licensing information.
+
+Contains ad hoc patches for cross building.
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Robert Manner <robert.manner@balabit.com>
+Date: Fri, 15 Dec 2017 16:40:18 +0100
+Subject: [PATCH] scons/crossmingw.py: compiler prefix can be customized
+ through environment
+
+
+diff --git a/scons/crossmingw.py b/scons/crossmingw.py
+index 1111111..2222222 100644
+--- a/scons/crossmingw.py
++++ b/scons/crossmingw.py
+@@ -51,6 +51,9 @@ prefixes64 = SCons.Util.Split("""
+ """)
+ 
+ def find(env):
++    if os.environ['MINGW_PREFIX']:
++        return os.environ['MINGW_PREFIX']
++
+     if env['machine'] == 'x86_64':
+         prefixes = prefixes64
+     else:

--- a/src/mesa.mk
+++ b/src/mesa.mk
@@ -1,0 +1,32 @@
+PKG             := mesa
+$(PKG)_VERSION  := 18.3.6
+$(PKG)_CHECKSUM := aaf17638dcf5a90b93b6389e152fdc9ef147768b09598f24d2c5cf482fcfc705
+$(PKG)_SUBDIR   := mesa-$($(PKG)_VERSION)
+$(PKG)_FILE     := mesa-$($(PKG)_VERSION).tar.xz
+$(PKG)_URL      := ftp://ftp.freedesktop.org/pub/mesa/$($(PKG)_FILE)
+$(PKG)_DEPS     := gcc scons-local
+
+ifeq (,$(findstring x86_64,$(TARGET)))
+    MACHINE=x86_64
+else
+    MACHINE=x86
+endif
+
+define $(PKG)_BUILD
+    mkdir -p '$(BUILD_DIR).scons'
+    $(call PREPARE_PKG_SOURCE,scons-local,'$(BUILD_DIR).scons')
+    cd '$(1)' && \
+    MINGW_PREFIX='$(TARGET)-' $(SCONS_LOCAL) \
+        platform=windows \
+        toolchain=crossmingw \
+        machine=$(MACHINE) \
+        verbose=1 \
+        build=release \
+        libgl-gdi
+
+    for i in EGL GLES GLES2 GLES3 KHR; do \
+        $(INSTALL) -d "$(PREFIX)/$(TARGET)/include/$$i"; \
+        $(INSTALL) -m 644 "$(1)/include/$$i/"* "$(PREFIX)/$(TARGET)/include/$$i/"; \
+    done
+    $(INSTALL) -m 755 '$(1)/build/windows-$(MACHINE)/gallium/targets/libgl-gdi/opengl32.dll' '$(PREFIX)/$(TARGET)/bin/'
+endef

--- a/src/qtbase.mk
+++ b/src/qtbase.mk
@@ -9,7 +9,7 @@ $(PKG)_CHECKSUM := 9e7af10aece15fa9500369efde69cb220eee8ec3a6818afe01ce1e7d48482
 $(PKG)_SUBDIR   := $(PKG)-everywhere-src-$($(PKG)_VERSION)
 $(PKG)_FILE     := $(PKG)-everywhere-src-$($(PKG)_VERSION).tar.xz
 $(PKG)_URL      := https://download.qt.io/official_releases/qt/5.15/$($(PKG)_VERSION)/submodules/$($(PKG)_FILE)
-$(PKG)_DEPS     := cc dbus fontconfig freetds freetype harfbuzz jpeg libmysqlclient libpng openssl pcre2 postgresql sqlite zlib zstd $(BUILD)~zstd
+$(PKG)_DEPS     := cc dbus fontconfig freetds freetype harfbuzz jpeg libmysqlclient libpng mesa openssl pcre2 postgresql sqlite zlib zstd $(BUILD)~zstd
 $(PKG)_DEPS_$(BUILD) :=
 $(PKG)_TARGETS  := $(BUILD) $(MXE_TARGETS)
 
@@ -44,7 +44,7 @@ define $(PKG)_BUILD
             $(if $(BUILD_STATIC), -static,)$(if $(BUILD_SHARED), -shared,) \
             -prefix '$(PREFIX)/$(TARGET)/qt5' \
             -no-icu \
-            -opengl desktop \
+            -opengl dynamic \
             -no-glib \
             -accessibility \
             -nomake examples \


### PR DESCRIPTION
This is based on the work by @manner82.

With this change we build qtbase with the `--opengl=dynamic` option: that means that Qt uses a fallback logic when looking for the OpenGL libraries:

1) If the system opengl32.dll supports at least OpenGL 2.0, use that; otherwise,
2) If libEGL.dll is present, load it; otherwise,
3) If opengl32sw.dll is present, load it.

This is an improvement over the behaviour we get from the current `--opengl=desktop`, which basically crashes if step 1 is not fulfilled. And while we don't have (yet) a way to produce in MXE the libraries mentioned in steps 2 and 3, they can safely be copied from a Qt Windows installation.

The Mesa package is used to ship the header files needed by qtbase. It also produces an opengl32.dll library which _could_ be used on Windows, but seems (at least on my machine) to be way slower than the Qt provided opengl32sw.dll. It's also way fatter (78 MB vs 21 MB).

Fixes: https://github.com/mxe/mxe/issues/1685, https://github.com/mxe/mxe/issues/947