### PR TITLE
The default msvcrt must be the same for mingw-w64 headers and crt.

### DIFF
--- a/src/gcc.mk
+++ b/src/gcc.mk
@@ -60,6 +60,7 @@ define $(PKG)_BUILD_mingw-w64
     cd '$(BUILD_DIR).headers' && '$(BUILD_DIR)/$(mingw-w64_SUBDIR)/mingw-w64-headers/configure' \
         --host='$(TARGET)' \
         --prefix='$(PREFIX)/$(TARGET)' \
+        --with-default-msvcrt=msvcrt \
         --enable-sdk=all \
         --enable-idl \
         --enable-secure-api \


### PR DESCRIPTION
The default msvcrt must be the same for ming-w64 headers and crt, so it is better to explicitly set both in the rules file, not just one.