### PR TITLE
fribidi: bump to version 1.0.8

### DIFF
--- a/src/fribidi.mk
+++ b/src/fribidi.mk
@@ -4,9 +4,9 @@ PKG             := fribidi
 $(PKG)_WEBSITE  := https://fribidi.org/
 $(PKG)_DESCR    := FriBidi
 $(PKG)_IGNORE   :=
-$(PKG)_VERSION  := 1.0.5
-$(PKG)_CHECKSUM := 6a64f2a687f5c4f203a46fa659f43dd43d1f8b845df8d723107e8a7e6158e4ce
-$(PKG)_GH_CONF  := fribidi/fribidi/releases, v, , , , .tar.bz2
+$(PKG)_VERSION  := 1.0.8
+$(PKG)_CHECKSUM := 94c7b68d86ad2a9613b4dcffe7bbeb03523d63b5b37918bdf2e4ef34195c1e6c
+$(PKG)_GH_CONF  := fribidi/fribidi/releases,v,,,,.tar.bz2
 $(PKG)_DEPS     := cc
 
 define $(PKG)_BUILD


### PR DESCRIPTION
Bumping the FriBiDi lib to version 1.0.8.

The latest 1.0.9 archives seems to be broken. The .tar.bz2 archive got removed, the .tar.xz seems to be corrupt and the .tar.gz and .zip archives seem to be incomplete. I'll try to contact the author, so we might be able to get an updated build.

For now, this is as current as we can get :)