### PR TITLE
fluidsynth: bump to version 2.1.2

### DIFF
--- a/src/fluidsynth-1-fixes.patch
+++ b/src/fluidsynth-1-fixes.patch
@@ -203,13 +203,25 @@ Subject: [PATCH 4/4] add readline to PC_REQUIRES when detected
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
 index 1111111..2222222 100644
---- a/CMakeLists.txt
-+++ b/CMakeLists.txt
-@@ -606,6 +606,7 @@ if ( enable-readline )
-   if ( HAVE_READLINE )
-     set ( WITH_READLINE 1 )
-     set ( READLINE_LIBS ${READLINE_LIBRARIES} )
-+    set ( PC_REQUIRES "${PC_REQUIRES} readline")
-   endif ( HAVE_READLINE )
- else ( enable-readline )
-   unset ( READLINE_LIBS CACHE )
+--- a/CMakeLists.txt	     2020-05-03 20:29:44.116701894 +0200
++++ b/CMakeLists.txt          2020-05-03 20:36:16.274435275 +0200
+@@ -611,6 +611,7 @@
+     if ( READLINE_FOUND )
+         set ( WITH_READLINE 1 )
+         set ( READLINE_LIBS ${READLINE_LIBRARIES} )
++        set ( PC_REQUIRES "${PC_REQUIRES} readline")
+     endif ( READLINE_FOUND )
+     endif ( enable-readline )
+ 
+--- a/CMakeLists	     2020-05-03 21:18:55.561159206 +0200
++++ b/CMakeLists.txt	2020-05-03 21:21:27.063145612 +0200
+@@ -584,6 +584,9 @@
+     if ( enable-sdl2 )
+         pkg_check_modules ( SDL2 sdl2 )
+         set ( SDL2_SUPPORT ${SDL2_FOUND} )
++        if ( SDL2_SUPPORT )
++          set ( PC_REQUIRES "${PC_REQUIRES} sdl2")
++        endif ()
+     else ( enable-sdl2 )
+         unset_pkg_config ( SDL2 )
+     endif ( enable-sdl2 )

--- a/src/fluidsynth.mk
+++ b/src/fluidsynth.mk
@@ -4,8 +4,8 @@ PKG             := fluidsynth
 $(PKG)_WEBSITE  := http://fluidsynth.org/
 $(PKG)_DESCR    := FluidSynth - a free software synthesizer based on the SoundFont 2 specifications
 $(PKG)_IGNORE   :=
-$(PKG)_VERSION  := 2.0.7
-$(PKG)_CHECKSUM := b68876d24c7fb34575ffa389bcfe8e61a24f1cf1da8ec6c3b2053efde98d0320
+$(PKG)_VERSION  := 2.1.2
+$(PKG)_CHECKSUM := 9206d83b8d2f7e1ec259ee01e943071de67e419aabe142b51312f8edb39c5503
 $(PKG)_GH_CONF  := FluidSynth/fluidsynth/tags,v
 $(PKG)_DEPS     := cc dbus glib jack libsndfile mman-win32 portaudio readline
 
@@ -15,10 +15,12 @@ define $(PKG)_BUILD
         -Dbuild-docs=OFF \
         -Dbuild-tests=OFF \
         -Denable-dbus=ON \
-        -Denable-jack=$(CMAKE SHARED_BOOL) \
+        -Denable-jack=$(CMAKE_SHARED_BOOL) \
         -Denable-libsndfile=ON \
         -Denable-portaudio=ON \
         -Denable-readline=ON \
+        -DBUILD_SHARED_LIBS=$(CMAKE_SHARED_BOOL) \
+        -DBUILD_STATIC_LIBS=$(CMAKE_STATIC_BOOL) \
         $($(PKG)_CONFIGURE_OPTS)
     $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)' VERBOSE=1
     $(MAKE) -C '$(BUILD_DIR)' -j 1 install VERBOSE=1


### PR DESCRIPTION
This updates fluidsynth to version 2.1.2. Additionally, I added a check for the presence of SDL2 and added it to the packages referenced in `PC_REQUIRES`. Otherwise, building fluidsynth will fail if SDL2 is installed.

Please note: The `.static` targest are building fine, but the `.shared` ones are broken:
```
/home/lsm/devel/mxe/usr/x86_64-pc-linux-gnu/bin/i686-w64-mingw32.shared-gcc   -Wall -W -Wpointer-arith -Wcast-qual -Wstrict-prototypes -Wno-unused-parameter -Wdeclaration-after-statement -Werror=implicit-function-declaration -Wbad-function-cast -Wcast-align -fopenmp -O3 -DNDEBUG  -Wl,--no-undefined -shared -o libfluidsynth-2.dll -Wl,--out-implib,libfluidsynth.dll.a -Wl,--major-image-version,2,--minor-image-version,3 -Wl,--whole-archive CMakeFiles/libfluidsynth.dir/objects.a -Wl,--no-whole-archive @CMakeFiles/libfluidsynth.dir/linklibs.rsp
CMakeFiles/libfluidsynth.dir/objects.a(fluid_portaudio.c.obj):fluid_portaudio.c:(.text+0x98): undefined reference to `Pa_Initialize'
CMakeFiles/libfluidsynth.dir/objects.a(fluid_portaudio.c.obj):fluid_portaudio.c:(.text+0xa5): undefined reference to `Pa_GetDeviceCount'
CMakeFiles/libfluidsynth.dir/objects.a(fluid_portaudio.c.obj):fluid_portaudio.c:(.text+0xd8): undefined reference to `Pa_GetDeviceInfo'
CMakeFiles/libfluidsynth.dir/objects.a(fluid_portaudio.c.obj):fluid_portaudio.c:(.text+0xf1): undefined reference to `Pa_GetHostApiInfo'
CMakeFiles/libfluidsynth.dir/objects.a(fluid_portaudio.c.obj):fluid_portaudio.c:(.text+0x1a3): undefined reference to `Pa_Terminate'
CMakeFiles/libfluidsynth.dir/objects.a(fluid_portaudio.c.obj):fluid_portaudio.c:(.text+0x1c8): undefined reference to `Pa_Terminate'
CMakeFiles/libfluidsynth.dir/objects.a(fluid_portaudio.c.obj):fluid_portaudio.c:(.text+0x1d4): undefined reference to `Pa_GetErrorText'
CMakeFiles/libfluidsynth.dir/objects.a(fluid_portaudio.c.obj):fluid_portaudio.c:(.text+0x1f4): undefined reference to `Pa_GetErrorText'
CMakeFiles/libfluidsynth.dir/objects.a(fluid_portaudio.c.obj):fluid_portaudio.c:(.text+0x268): undefined reference to `Pa_Initialize'
CMakeFiles/libfluidsynth.dir/objects.a(fluid_portaudio.c.obj):fluid_portaudio.c:(.text+0x330): undefined reference to `Pa_GetDeviceCount'
CMakeFiles/libfluidsynth.dir/objects.a(fluid_portaudio.c.obj):fluid_portaudio.c:(.text+0x35b): undefined reference to `Pa_GetDeviceInfo'
CMakeFiles/libfluidsynth.dir/objects.a(fluid_portaudio.c.obj):fluid_portaudio.c:(.text+0x374): undefined reference to `Pa_GetHostApiInfo'
CMakeFiles/libfluidsynth.dir/objects.a(fluid_portaudio.c.obj):fluid_portaudio.c:(.text+0x475): undefined reference to `Pa_CloseStream'
CMakeFiles/libfluidsynth.dir/objects.a(fluid_portaudio.c.obj):fluid_portaudio.c:(.text+0x47a): undefined reference to `Pa_Terminate'
CMakeFiles/libfluidsynth.dir/objects.a(fluid_portaudio.c.obj):fluid_portaudio.c:(.text+0x49f): undefined reference to `Pa_GetDefaultOutputDevice'
CMakeFiles/libfluidsynth.dir/objects.a(fluid_portaudio.c.obj):fluid_portaudio.c:(.text+0x520): undefined reference to `Pa_OpenStream'
CMakeFiles/libfluidsynth.dir/objects.a(fluid_portaudio.c.obj):fluid_portaudio.c:(.text+0x537): undefined reference to `Pa_StartStream'
CMakeFiles/libfluidsynth.dir/objects.a(fluid_portaudio.c.obj):fluid_portaudio.c:(.text+0x5c6): undefined reference to `Pa_GetErrorText'
CMakeFiles/libfluidsynth.dir/objects.a(fluid_portaudio.c.obj):fluid_portaudio.c:(.text+0x5fc): undefined reference to `Pa_GetErrorText'
CMakeFiles/libfluidsynth.dir/objects.a(fluid_portaudio.c.obj):fluid_portaudio.c:(.text+0x621): undefined reference to `Pa_GetErrorText'
CMakeFiles/libfluidsynth.dir/objects.a(fluid_portaudio.c.obj):fluid_portaudio.c:(.text+0x63e): undefined reference to `Pa_GetErrorText'
CMakeFiles/libfluidsynth.dir/objects.a(fluid_portaudio.c.obj):fluid_portaudio.c:(.text+0x6c7): undefined reference to `Pa_CloseStream'
CMakeFiles/libfluidsynth.dir/objects.a(fluid_portaudio.c.obj):fluid_portaudio.c:(.text+0x6cc): undefined reference to `Pa_Terminate'
CMakeFiles/libfluidsynth.dir/objects.a(fluid_portaudio.c.obj):fluid_portaudio.c:(.text+0x6e5): undefined reference to `Pa_GetErrorText'
collect2: error: ld returned 1 exit status
```
I'm creating this PR in order to seek help regarding this issue from the more experienced people out there.