### PR TITLE
gdk-pixbuf: Enable dynamic modules in shared builds

### DIFF
--- a/src/gdk-pixbuf.mk
+++ b/src/gdk-pixbuf.mk
@@ -22,7 +22,8 @@ define $(PKG)_BUILD
     cd '$(1)' && autoreconf -fi -I'$(PREFIX)/$(TARGET)/share/aclocal'
     cd '$(1)' && ./configure \
         $(MXE_CONFIGURE_OPTS) \
-        --disable-modules \
+        $(if $(BUILD_STATIC), \
+           --disable-modules,) \
         --with-included-loaders \
         --without-gdiplus \
         LIBS="`'$(TARGET)-pkg-config' --libs libtiff-4`"


### PR DESCRIPTION
GTK3 makes use of svg icons, but required librsvg module cannot be build in static
gdk-pixbuf so allow dynamic modules for shared builds.
