### PR TITLE
Trivial patches (glib, VTK) that allow shared compilation with gcc-10.1

### DIFF
--- a/src/glib-2-fixes.patch
+++ b/src/glib-2-fixes.patch
@@ -1,0 +1,24 @@
+See: https://gitlab.gnome.org/GNOME/glib/-/merge_requests/1428
+
+--- a/glib/gtypes.h	2016-10-22 07:21:52.000000000 +0200
++++ b/glib/gtypes.h	2020-05-17 11:13:49.369639688 +0200
+@@ -522,7 +522,7 @@
+ #    else /* !GLIB_STATIC_COMPILATION */
+ #      ifdef GLIB_COMPILATION
+ #        ifdef DLL_EXPORT
+-#          define GLIB_VAR __declspec(dllexport)
++#          define GLIB_VAR extern __declspec(dllexport)
+ #        else /* !DLL_EXPORT */
+ #          define GLIB_VAR extern
+ #        endif /* !DLL_EXPORT */
+--- a/gobject/gparamspecs.h	2016-10-22 07:22:21.000000000 +0200
++++ b/gobject/gparamspecs.h	2020-05-17 11:16:37.803281391 +0200
+@@ -1144,7 +1144,7 @@
+ #    else /* !GOBJECT_STATIC_COMPILATION */
+ #      ifdef GOBJECT_COMPILATION
+ #        ifdef DLL_EXPORT
+-#          define GOBJECT_VAR __declspec(dllexport)
++#          define GOBJECT_VAR extern __declspec(dllexport)
+ #        else /* !DLL_EXPORT */
+ #          define GOBJECT_VAR extern
+ #        endif /* !DLL_EXPORT */

--- a/src/vtk-2-fixes.patch
+++ b/src/vtk-2-fixes.patch
@@ -1,0 +1,24 @@
+See: https://gitlab.kitware.com/vtk/vtk/issues/17774
+
+diff --git a/ThirdParty/exodusII/vtkexodusII/src/ex_create_par.c b/ThirdParty/exodusII/vtkexodusII/src/ex_create_par.c
+index 8d5d6734f0ad2df04393cf7909ef2c342785e1ac..ef439618dae7b90fdf1057f7051c6a9f0bf1f72d 100644
+--- a/ThirdParty/exodusII/vtkexodusII/src/ex_create_par.c
++++ b/ThirdParty/exodusII/vtkexodusII/src/ex_create_par.c
+@@ -216,5 +216,5 @@ int ex_create_par_int(const char *path, int cmode, int *comp_ws, int *io_ws, MPI
+  * Prevent warning in some versions of ranlib(1) because the object
+  * file has no symbols.
+  */
+-const char exodus_unused_symbol_dummy_1;
++const char exodus_unused_symbol_dummy_ex_create_par;
+ #endif
+diff --git a/ThirdParty/exodusII/vtkexodusII/src/ex_open_par.c b/ThirdParty/exodusII/vtkexodusII/src/ex_open_par.c
+index b2faa22c29489446030f537bb6b3a26feb86c50b..9df4818767d07a3020f1363fe2a8b9f2fcac634a 100644
+--- a/ThirdParty/exodusII/vtkexodusII/src/ex_open_par.c
++++ b/ThirdParty/exodusII/vtkexodusII/src/ex_open_par.c
+@@ -459,5 +459,5 @@ int ex_open_par_int(const char *path, int mode, int *comp_ws, int *io_ws, float
+  * Prevent warning in some versions of ranlib(1) because the object
+  * file has no symbols.
+  */
+-const char exodus_unused_symbol_dummy_1;
++const char exodus_unused_symbol_dummy_ex_open_par;
+ #endif

--- a/src/vtk-3-fixes.patch
+++ b/src/vtk-3-fixes.patch
@@ -1,0 +1,13 @@
+__declspec(dllexport) does not imply extern: add it. This fixes compilation with gcc-10.1
+
+--- a/ThirdParty/libxml2/vtklibxml2/include/libxml/xmlexports.h	2020-05-17 14:32:52.863037615 +0200
++++ b/ThirdParty/libxml2/vtklibxml2/include/libxml/xmlexports.h	2020-05-17 14:32:23.266063521 +0200
+@@ -111,7 +111,7 @@
+   #undef XMLCDECL
+   #if defined(IN_LIBXML) && !defined(LIBXML_STATIC)
+     #define XMLPUBFUN __declspec(dllexport)
+-    #define XMLPUBVAR __declspec(dllexport)
++    #define XMLPUBVAR __declspec(dllexport) extern
+   #else
+     #define XMLPUBFUN
+     #if !defined(LIBXML_STATIC)


### PR DESCRIPTION
Please pull in these minor changes that allow compilation with gcc-10.1 of the versions of glib and VTK that are presently shipped with MXE. The additional patches of those sources are already in upstream glib (backpport to 2.64 available) and VTK (not released yet, AFAICS). Both changes have been tested locally with gcc-5.5 and 10.1 (shared builds).

See:
 * https://gitlab.gnome.org/GNOME/glib/-/merge_requests/1428
 * https://gitlab.kitware.com/vtk/vtk/issues/17774
