### PR TITLE
VTK+gcc-10.1 fix: XMLPUBVAR: patch the mingw block, not the cygwin

### DIFF
--- a/src/vtk-1-fixes.patch
+++ b/src/vtk-1-fixes.patch
@@ -64,7 +64,7 @@ diff --git a/ThirdParty/libxml2/vtklibxml2/include/libxml/xmlexports.h b/ThirdPa
 index 1111111..2222222 100644
 --- a/ThirdParty/libxml2/vtklibxml2/include/libxml/xmlexports.h
 +++ b/ThirdParty/libxml2/vtklibxml2/include/libxml/xmlexports.h
-@@ -135,7 +135,7 @@
+@@ -111,7 +111,7 @@
    #undef XMLCDECL
    #if defined(IN_LIBXML) && !defined(LIBXML_STATIC)
      #define XMLPUBFUN __declspec(dllexport)


### PR DESCRIPTION
(A small follow up on (completed) pull request #2506)

In a small part of the patch that is now in MXE, somehow the line
numbers got messed up. The result is that the XMLPUBVAR is now
fixed for the cygwin case, not for mingw. This patch fixes that. It adds
'extern' to the __declspec(dllexport) definition of XMLPUBVAR.

The result is what is also in upstream libxml2, and in the
stand-alone version that is shipped with mxe. For details, see:
https://github.com/GNOME/libxml2/commit/1eabc31401b7b8c3b5273993778f37eeef37a055

Please merge this fix. And sorry for the inconvenience.