### PR TITLE
Enable native zstd bins for qtbase and libs for gcc10

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -507,9 +507,9 @@ PKG_DEPS = \
                       $(filter $($($(DEP)_PKG)_TYPE),$(BUILD_PKG_TYPES))), \
                 $($(DEP)_TGT)/installed/$($(DEP)_PKG))))
 
-# order-only package deps unlikely to need target lookup
+# order-only package deps - needs target lookup for e.g. zstd native case
 PKG_OO_DEPS = \
-    $(foreach DEP,$($(PKG)_OO_DEPS), \
+    $(foreach DEP,$(value $(call LOOKUP_PKG_RULE,$(PKG),OO_DEPS,$(TARGET))), \
         $(if $(filter $(DEP),$(PKGS)), \
             $(if $(or $(value $(call LOOKUP_PKG_RULE,$(DEP),BUILD,$(TARGET))), \
                       $(filter $($(DEP)_TYPE),$(BUILD_PKG_TYPES))), \
@@ -569,7 +569,7 @@ $(foreach TARGET,$(MXE_TARGETS),\
     $(eval $(TARGET)_UC_LIB_TYPE := $(if $(findstring shared,$(TARGET)),SHARED,STATIC)))
 
 # finds a package rule defintion
-RULE_TYPES := BUILD DEPS FILE MESSAGE URL
+RULE_TYPES := BUILD DEPS FILE MESSAGE OO_DEPS URL
 # by truncating the target elements then looking for STAIC|SHARED rules:
 #
 # foo_BUILD_i686-w64-mingw32.static.win32.dw2

--- a/plugins/gcc10/gcc10-overlay.mk
+++ b/plugins/gcc10/gcc10-overlay.mk
@@ -24,6 +24,9 @@ $(PKG)_FILE     := gcc-$($(PKG)_VERSION).tar.xz
 $(PKG)_URL      := https://ftp.gnu.org/gnu/gcc/gcc-$($(PKG)_VERSION)/$($(PKG)_FILE)
 $(PKG)_URL_2    := https://www.mirrorservice.org/sites/sourceware.org/pub/gcc/releases/gcc-$($(PKG)_VERSION)/$($(PKG)_FILE)
 $(PKG)_PATCHES  := $(dir $(lastword $(MAKEFILE_LIST)))/gcc10.patch
+$(PKG)_DEPS     := binutils mingw-w64 $(addprefix $(BUILD)~,gmp isl mpc mpfr zstd)
+
+_$(PKG)_CONFIGURE_OPTS = --with-zstd='$(PREFIX)/$(BUILD)'
 
 # copy db-2-install-exe.patch to gcc7 plugin when gcc10 is default
 db_PATCHES := $(TOP_DIR)/src/db-1-fix-including-winioctl-h-lowcase.patch

--- a/src/gcc.mk
+++ b/src/gcc.mk
@@ -51,7 +51,7 @@ define $(PKG)_CONFIGURE
         --with-ld='$(PREFIX)/bin/$(TARGET)-ld' \
         --with-nm='$(PREFIX)/bin/$(TARGET)-nm' \
         $(shell [ `uname -s` == Darwin ] && echo "LDFLAGS='-Wl,-no_pie'") \
-        $($(PKG)_CONFIGURE_OPTS)
+        $(PKG_CONFIGURE_OPTS)
 endef
 
 define $(PKG)_BUILD_mingw-w64

--- a/src/qtbase.mk
+++ b/src/qtbase.mk
@@ -9,7 +9,7 @@ $(PKG)_CHECKSUM := 9e7af10aece15fa9500369efde69cb220eee8ec3a6818afe01ce1e7d48482
 $(PKG)_SUBDIR   := $(PKG)-everywhere-src-$($(PKG)_VERSION)
 $(PKG)_FILE     := $(PKG)-everywhere-src-$($(PKG)_VERSION).tar.xz
 $(PKG)_URL      := https://download.qt.io/official_releases/qt/5.15/$($(PKG)_VERSION)/submodules/$($(PKG)_FILE)
-$(PKG)_DEPS     := cc dbus fontconfig freetds freetype harfbuzz jpeg libmysqlclient libpng openssl pcre2 postgresql sqlite zlib zstd
+$(PKG)_DEPS     := cc dbus fontconfig freetds freetype harfbuzz jpeg libmysqlclient libpng openssl pcre2 postgresql sqlite zlib zstd $(BUILD)~zstd
 $(PKG)_DEPS_$(BUILD) :=
 $(PKG)_TARGETS  := $(BUILD) $(MXE_TARGETS)
 

--- a/src/zstd.mk
+++ b/src/zstd.mk
@@ -7,10 +7,15 @@ $(PKG)_IGNORE   :=
 $(PKG)_VERSION  := 1.4.5
 $(PKG)_CHECKSUM := 734d1f565c42f691f8420c8d06783ad818060fc390dee43ae0a89f86d0a4f8c2
 $(PKG)_GH_CONF  := facebook/zstd/tags,v
+$(PKG)_TARGETS  := $(BUILD) $(MXE_TARGETS)
 $(PKG)_DEPS     := cc
+
+$(PKG)_DEPS_$(BUILD) :=
+$(PKG)_OO_DEPS_$(BUILD) := $(MXE_CONF_PKGS)
 
 define $(PKG)_BUILD
     # build and install the library
+    # use cmake to ensure shared builds "do the right thing"
     cd '$(BUILD_DIR)' && $(TARGET)-cmake '$(SOURCE_DIR)/build/cmake' \
         -DZSTD_BUILD_STATIC=$(CMAKE_STATIC_BOOL) \
         -DZSTD_BUILD_SHARED=$(CMAKE_SHARED_BOOL) \
@@ -23,4 +28,20 @@ define $(PKG)_BUILD
         -W -Wall -Werror -ansi -pedantic \
         '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-$(PKG).exe' \
         `'$(TARGET)-pkg-config' lib$(PKG) --cflags --libs`
+endef
+
+define $(PKG)_BUILD_$(BUILD)
+    # build and install the library and programs
+    # use make to avoid cmake dependency for gcc10+
+    $(MAKE) -C '$(SOURCE_DIR)/lib' -j '$(JOBS)' V=1 libzstd.a
+    $(MAKE) -C '$(SOURCE_DIR)/lib' -j 1 V=1 \
+        prefix='$(PREFIX)/$(TARGET)' \
+        install-pc \
+        install-static \
+        install-includes
+    $(MAKE) -C '$(SOURCE_DIR)/programs' -j '$(JOBS)' V=1 zstd-release
+    $(MAKE) -C '$(SOURCE_DIR)/programs' -j 1 V=1 \
+        prefix='$(PREFIX)/$(TARGET)' \
+        mandir='$(BUILD_DIR)' \
+        install
 endef


### PR DESCRIPTION
WIP because the gcc detection needs more overrides to actually use zstd.

@mbunkus I'm pretty sure the [qtbase issue](https://github.com/mxe/mxe/issues/2517) can be tested without a full rebuild - those overlay plugins don't use the [undocumented](https://github.com/mxe/mxe/commit/24d37efa5dae04fbe143c33b8c6710a8606c5451#diff-fffe09b3b50640845a354114057e2a80R7) addition of [_FILE_DEPS](https://github.com/mxe/mxe/commit/24d37efa5dae04fbe143c33b8c6710a8606c5451#diff-b67911656ef5d18c4ae36cb6741b7965R528).