### PR TITLE
SDL2: Use bash instead of /bin/sh. Fixes #2541

### DIFF
--- a/src/sdl2.mk
+++ b/src/sdl2.mk
@@ -18,7 +18,7 @@ define $(PKG)_UPDATE
 endef
 
 define $(PKG)_BUILD
-    cd '$(1)' && aclocal -I acinclude && autoconf && ./configure \
+    cd '$(1)' && aclocal -I acinclude && autoconf && $(SHELL) ./configure \
         $(MXE_CONFIGURE_OPTS) \
         --enable-threads \
         --enable-directx \
@@ -27,8 +27,8 @@ define $(PKG)_BUILD
     $(SED) -i 's,defined(__MINGW64_VERSION_MAJOR),defined(__MINGW64_VERSION_MAJOR) \&\& defined(_WIN64),' '$(1)/include/SDL_cpuinfo.h'
     $(SED) -i 's,-XCClinker,,' '$(1)/sdl2.pc'
     $(SED) -i 's,-XCClinker,,' '$(1)/sdl2-config'
-    $(MAKE) -C '$(1)' -j '$(JOBS)'
-    $(MAKE) -C '$(1)' -j 1 install
+    $(MAKE) -C '$(1)' -j '$(JOBS)' SHELL=$(SHELL)
+    $(MAKE) -C '$(1)' -j 1 install SHELL=$(SHELL)
     ln -sf '$(PREFIX)/$(TARGET)/bin/sdl2-config' '$(PREFIX)/bin/$(TARGET)-sdl2-config'
 
     '$(TARGET)-gcc' \


### PR DESCRIPTION
SDL2 Fails to build when `/bin/sh` is set to `dash`.