### PR TITLE
Add re2: fast & secure regular expression library

### DIFF
--- a/docs/packages.json
+++ b/docs/packages.json
@@ -409,6 +409,7 @@
     "qwt": {"version": "6.1.5", "website": "https://qwt.sourceforge.io/", "description": "Qwt"},
     "qwtplot3d": {"version": "d80c908", "website": "https://github.com/sintegrial/qwtplot3d", "description": "QwtPlot3D"},
     "ragel": {"version": "6.9", "website": "https://www.colm.net/open-source/ragel/", "description": "Ragel"},
+    "re2": {"version": "2020-08-01", "website": "https://github.com/google/re2/", "description": "RE2 regex library"},
     "readline": {"version": "8.0", "website": "https://tiswww.case.edu/php/chet/readline/rltop.html", "description": "Readline"},
     "rubberband": {"version": "1.8.1", "website": "https://breakfastquay.com/rubberband/", "description": "Rubberband"},
     "rucksack": {"version": "3.1.0", "website": "https://github.com/andrewrk/rucksack", "description": ""},

--- a/src/re2-test.cpp
+++ b/src/re2-test.cpp
@@ -1,0 +1,16 @@
+/*
+ * This file is part of MXE. See LICENSE.md for licensing information.
+ */
+
+#include <re2/re2.h>
+
+int main()
+{
+    std::string text("This is a test.");
+    RE2 regex(" [aeiou] ");
+
+    if (RE2::PartialMatch(text, regex))
+        return 0;
+
+    return 1;
+}

--- a/src/re2.mk
+++ b/src/re2.mk
@@ -1,0 +1,36 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+PKG             := re2
+$(PKG)_DESCR    := RE2 regex library
+$(PKG)_WEBSITE  := https://github.com/google/re2/
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 2020-08-01
+$(PKG)_CHECKSUM := 6f4c8514249cd65b9e85d3e6f4c35595809a63ad71c5d93083e4d1dcdf9e0cd6
+$(PKG)_GH_CONF  := google/re2/releases/latest
+$(PKG)_SUBDIR   := re2-$($(PKG)_VERSION)
+$(PKG)_FILE     := re2-$($(PKG)_VERSION).tar.gz
+$(PKG)_URL      := https://github.com/google/re2/archive/$($(PKG)_VERSION).tar.gz
+$(PKG)_DEPS     := cc icu4c
+
+define $(PKG)_BUILD
+    $(MAKE) $(MXE_DISABLE_CRUFT) \
+        -C '$(SOURCE_DIR)' \
+        -j '$(JOBS)' \
+	CXX=$(TARGET)-g++ \
+	AR=$(TARGET)-ar \
+	NM=$(TARGET)-nm \
+	prefix=$(PREFIX)/$(TARGET) \
+	static
+
+    $(MAKE) $(MXE_DISABLE_CRUFT) \
+        -C '$(SOURCE_DIR)' \
+        -j 1 \
+	prefix=$(PREFIX)/$(TARGET) \
+	static-install
+
+    # compile test
+    '$(TARGET)-g++' \
+        -W -Wall -Werror -ansi -pedantic \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-$(PKG).exe' \
+        `'$(TARGET)-pkg-config' re2 --cflags --libs`
+endef


### PR DESCRIPTION
Notes:

  * builds in `$(SOURCE_DIR)` as I don't think the custom Makefile they employ supports out-of-tree builds
  * only supports static builds (as I don't think the custom Makefile & the source code supports Windows-style dynamic libraries, haven't verified, though) but doesn't enforce this; shared targets will still create static libraries
  * have built successfully with `x86_64-w64-mingw.static` and `i686-w64-mingw.static`
  * have run test binaries created for both architectures successfully on Windows
