### PR TITLE
plugins/examples/qt5-freeze: Fix qtimageformats build (fixes #2563).

### DIFF
--- a/plugins/examples/qt5-freeze/qtimageformats-2.patch
+++ b/plugins/examples/qt5-freeze/qtimageformats-2.patch
@@ -1,0 +1,23 @@
+This file is part of MXE. See LICENSE.md for licensing information.
+
+Contains ad hoc patches for cross building.
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Mark Brand <mabrand@mabrand.nl>
+Date: Wed, 29 Jul 2020 01:47:16 +0200
+Subject: [PATCH 1/1] add missing header for pow()
+
+
+diff --git a/src/plugins/imageformats/jp2/qjp2handler.cpp b/src/plugins/imageformats/jp2/qjp2handler.cpp
+index 1111111..2222222 100644
+--- a/src/plugins/imageformats/jp2/qjp2handler.cpp
++++ b/src/plugins/imageformats/jp2/qjp2handler.cpp
+@@ -46,6 +46,8 @@
+ 
+ #include <jasper/jasper.h>
+ 
++#include <math.h>
++
+ QT_BEGIN_NAMESPACE
+ 
+ class QJp2HandlerPrivate


### PR DESCRIPTION
Add missing <math.h> #include. Without this the build fails with:

 [...]qjp2handler.cpp:853:86: error: 'pow' was not declared in this scope

Taken from bd76e1080ef7ddbbfe683d6371629aecb02bc9bd.