### PR TITLE
Add libsrt 1.4.2

### DIFF
--- a/src/libsrt.mk
+++ b/src/libsrt.mk
@@ -1,0 +1,21 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+PKG             := libsrt
+$(PKG)_WEBSITE  := https://github.com/Haivision/srt
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 1.4.4
+$(PKG)_CHECKSUM := 93f5f3715bd5bd522b8d65fc0d086ef2ad49db6a41ad2d7b35df2e8bd7094114
+$(PKG)_GH_CONF  := Haivision/srt/tags, v
+$(PKG)_DEPS     := cc pthreads openssl
+
+define $(PKG)_BUILD_STATIC
+    cd '$(BUILD_DIR)' && $(TARGET)-cmake '$(SOURCE_DIR)' -DUSE_STATIC_LIBSTDCXX=ON -DIFNEEDED_SRT_LDFLAGS=-lstdc++ -DENABLE_STATIC=ON -DENABLE_SHARED=OFF -DENABLE_EXAMPLES=OFF
+    $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)' $(MXE_DISABLE_CRUFT)
+    $(MAKE) -C '$(BUILD_DIR)' -j 1 install $(MXE_DISABLE_CRUFT)
+endef
+
+define $(PKG)_BUILD_SHARED
+    cd '$(BUILD_DIR)' && $(TARGET)-cmake '$(SOURCE_DIR)' -DENABLE_EXAMPLES=OFF
+    $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)' $(MXE_DISABLE_CRUFT)
+    $(MAKE) -C '$(BUILD_DIR)' -j 1 install $(MXE_DISABLE_CRUFT)
+endef


### PR DESCRIPTION
This seems to work pretty well.  Build log:
```
cd '/usr/src/mxe/tmp-libsrt-x86_64-w64-mingw32.static/srt-1.4.2.build_' && x86_64-w64-mingw32.static-cmake '/usr/src/mxe/tmp-libsrt-x86_64-w64-mingw32.static/srt-1.4.2' -DUSE_STATIC_LIBSTDCXX=ON -DIFNEEDED_SRT_LDFLAGS=-lstdc++ -DENABLE_STATIC=ON -DENABLE_SHARED=OFF -DENABLE_EXAMPLES=OFF
== Using MXE wrapper: /usr/src/mxe/usr/bin/x86_64-w64-mingw32.static-cmake
     - cmake version 3.17.3
     - warnings for unused CMAKE_POLICY_DEFAULT variables can be ignored
== Using MXE toolchain: /usr/src/mxe/usr/x86_64-w64-mingw32.static/share/cmake/mxe-conf.cmake
== Using MXE runresult: /usr/src/mxe/usr/share/cmake/modules/TryRunResults.cmake
== Adding "-DCMAKE_BUILD_TYPE=Release"
loading initial cache file /usr/src/mxe/usr/share/cmake/modules/TryRunResults.cmake
-- The C compiler identification is GNU 9.3.0
-- The CXX compiler identification is GNU 9.3.0
-- Check for working C compiler: /usr/src/mxe/usr/bin/x86_64-w64-mingw32.static-gcc
-- Check for working C compiler: /usr/src/mxe/usr/bin/x86_64-w64-mingw32.static-gcc - works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/src/mxe/usr/bin/x86_64-w64-mingw32.static-g++
-- Check for working CXX compiler: /usr/src/mxe/usr/bin/x86_64-w64-mingw32.static-g++ - works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found PkgConfig: /usr/src/mxe/usr/bin/x86_64-w64-mingw32.static-pkg-config (found version "0.28")
-- Looking for pthread.h
-- Looking for pthread.h - found
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
-- Found Threads: TRUE
-- BUILD TYPE: Release
-- LOGGING: ENABLED
-- USE_BUSY_WAITING: OFF (default)
-- No WITH_COMPILER_PREFIX - using C++ compiler /usr/src/mxe/usr/bin/x86_64-w64-mingw32.static-g++
-- Looking for inet_pton
-- Looking for inet_pton - found
-- Checking for module 'openssl libcrypto'
--   Found openssl libcrypto, version 1.1.1h;1.1.1h
-- WARNING: pkg-config has incorrect prefix - enforcing target path prefix: /usr/src/mxe/usr/x86_64-w64-mingw32.static
-- SSL via pkg-config: -L /usr/src/mxe/usr/x86_64-w64-mingw32.static/lib -I /usr/src/mxe/usr/x86_64-w64-mingw32.static/include -l;ssl;crypto;z;ws2_32;gdi32;crypt32
-- ENCRYPTION: ENABLED, using: openssl libcrypto
-- SSL libraries: ssl;crypto;z;ws2_32;gdi32;crypt32
-- COMPILER: GNU (/usr/src/mxe/usr/bin/x86_64-w64-mingw32.static-g++) - GNU compat
-- NOTE: GNU 9.3.0 - assuming default C++11.
-- STDCXX_SYNC: OFF
-- DETECTED SYSTEM: WINDOWS;  WIN32=1; PTW32_STATIC_LIB=1
-- WINDOWS detected: adding compat sources: /usr/src/mxe/tmp-libsrt-x86_64-w64-mingw32.static/srt-1.4.2/common/win_time.cpp
-- SRT Sources: /usr/src/mxe/tmp-libsrt-x86_64-w64-mingw32.static/srt-1.4.2/srtcore/api.cpp;/usr/src/mxe/tmp-libsrt-x86_64-w64-mingw32.static/srt-1.4.2/srtcore/buffer.cpp;/usr/src/mxe/tmp-libsrt-x86_64-w64-mingw32.static/srt-1.4.2/srtcore/cache.cpp;/usr/src/mxe/tmp-libsrt-x86_64-w64-mingw32.static/srt-1.4.2/srtcore/channel.cpp;/usr/src/mxe/tmp-libsrt-x86_64-w64-mingw32.static/srt-1.4.2/srtcore/common.cpp;/usr/src/mxe/tmp-libsrt-x86_64-w64-mingw32.static/srt-1.4.2/srtcore/core.cpp;/usr/src/mxe/tmp-libsrt-x86_64-w64-mingw32.static/srt-1.4.2/srtcore/crypto.cpp;/usr/src/mxe/tmp-libsrt-x86_64-w64-mingw32.static/srt-1.4.2/srtcore/epoll.cpp;/usr/src/mxe/tmp-libsrt-x86_64-w64-mingw32.static/srt-1.4.2/srtcore/fec.cpp;/usr/src/mxe/tmp-libsrt-x86_64-w64-mingw32.static/srt-1.4.2/srtcore/handshake.cpp;/usr/src/mxe/tmp-libsrt-x86_64-w64-mingw32.static/srt-1.4.2/srtcore/list.cpp;/usr/src/mxe/tmp-libsrt-x86_64-w64-mingw32.static/srt-1.4.2/srtcore/logger_default.cpp;/usr/src/mxe/tmp-libsrt-x86_64-w64-mingw32.static/srt-1.4.2/srtcore/logger_defs.cpp;/usr/src/mxe/tmp-libsrt-x86_64-w64-mingw32.static/srt-1.4.2/srtcore/md5.cpp;/usr/src/mxe/tmp-libsrt-x86_64-w64-mingw32.static/srt-1.4.2/srtcore/packet.cpp;/usr/src/mxe/tmp-libsrt-x86_64-w64-mingw32.static/srt-1.4.2/srtcore/packetfilter.cpp;/usr/src/mxe/tmp-libsrt-x86_64-w64-mingw32.static/srt-1.4.2/srtcore/queue.cpp;/usr/src/mxe/tmp-libsrt-x86_64-w64-mingw32.static/srt-1.4.2/srtcore/congctl.cpp;/usr/src/mxe/tmp-libsrt-x86_64-w64-mingw32.static/srt-1.4.2/srtcore/srt_c_api.cpp;/usr/src/mxe/tmp-libsrt-x86_64-w64-mingw32.static/srt-1.4.2/srtcore/window.cpp;/usr/src/mxe/tmp-libsrt-x86_64-w64-mingw32.static/srt-1.4.2/srtcore/srt_compat.c;/usr/src/mxe/tmp-libsrt-x86_64-w64-mingw32.static/srt-1.4.2/srtcore/sync.cpp;/usr/src/mxe/tmp-libsrt-x86_64-w64-mingw32.static/srt-1.4.2/srtcore/sync_posix.cpp
-- APP: srt_virtual: using default C++ standard
-- ADDING TRANSITIVE LINK DEP to:srt_static :
-- INSTALL DIRS: bin=bin lib=lib shlib=lib include=include
-- APPS: ENABLED, std=
-- APP: srtsupport_virtual: using default C++ standard
-- APP: srt-live-transmit: using default C++ standard
-- APP: srt-file-transmit: using default C++ standard
CMake Warning at CMakeLists.txt:1086 (message):
  On MinGW, some C++11 apps are blocked due to lacking proper C++11 headers
  for <thread>.  FIX IF POSSIBLE.


-- DEVEL APPS (testing): DISABLED
-- Configuring done
-- Generating done
CMake Warning:
  Manually-specified variables were not used by the project:

    CMAKE_POLICY_DEFAULT_CMP0017
    CMAKE_POLICY_DEFAULT_CMP0020


-- Build files have been written to: /usr/src/mxe/tmp-libsrt-x86_64-w64-mingw32.static/srt-1.4.2.build_
make -C '/usr/src/mxe/tmp-libsrt-x86_64-w64-mingw32.static/srt-1.4.2.build_' -j '2' dist_bin_SCRIPTS= bin_PROGRAMS= sbin_PROGRAMS= noinst_PROGRAMS= check_PROGRAMS= man_MANS= man1_MANS= man2_MANS= man3_MANS= man4_MANS= man5_MANS= man6_MANS= man7_MANS= man8_MANS= man9_MANS= dist_man_MANS= dist_man1_MANS= dist_man2_MANS= dist_man3_MANS= dist_man4_MANS= dist_man5_MANS= dist_man6_MANS= dist_man7_MANS= dist_man8_MANS= dist_man9_MANS= nodist_man_MANS= nodist_man1_MANS= nodist_man2_MANS= nodist_man3_MANS= nodist_man4_MANS= nodist_man5_MANS= nodist_man6_MANS= nodist_man7_MANS= nodist_man8_MANS= nodist_man9_MANS= notrans_dist_man_MANS= MANLINKS= info_TEXINFOS= doc_DATA= dist_doc_DATA= html_DATA= dist_html_DATA=
make[2]: Entering directory '/usr/src/mxe/tmp-libsrt-x86_64-w64-mingw32.static/srt-1.4.2.build_'
make[3]: Entering directory '/usr/src/mxe/tmp-libsrt-x86_64-w64-mingw32.static/srt-1.4.2.build_'
make[4]: Entering directory '/usr/src/mxe/tmp-libsrt-x86_64-w64-mingw32.static/srt-1.4.2.build_'
make[4]: Entering directory '/usr/src/mxe/tmp-libsrt-x86_64-w64-mingw32.static/srt-1.4.2.build_'
Scanning dependencies of target srtsupport_virtual
make[4]: Leaving directory '/usr/src/mxe/tmp-libsrt-x86_64-w64-mingw32.static/srt-1.4.2.build_'
make[4]: Entering directory '/usr/src/mxe/tmp-libsrt-x86_64-w64-mingw32.static/srt-1.4.2.build_'
[  2%] Building CXX object CMakeFiles/srtsupport_virtual.dir/apps/apputil.cpp.obj
Scanning dependencies of target srt_virtual
make[4]: Leaving directory '/usr/src/mxe/tmp-libsrt-x86_64-w64-mingw32.static/srt-1.4.2.build_'
make[4]: Entering directory '/usr/src/mxe/tmp-libsrt-x86_64-w64-mingw32.static/srt-1.4.2.build_'
[  4%] Building CXX object CMakeFiles/srt_virtual.dir/srtcore/api.cpp.obj
[  6%] Building CXX object CMakeFiles/srtsupport_virtual.dir/apps/logsupport.cpp.obj
[  8%] Building CXX object CMakeFiles/srtsupport_virtual.dir/apps/logsupport_appdefs.cpp.obj
[ 10%] Building CXX object CMakeFiles/srt_virtual.dir/srtcore/buffer.cpp.obj
[ 12%] Building CXX object CMakeFiles/srtsupport_virtual.dir/apps/socketoptions.cpp.obj
[ 14%] Building CXX object CMakeFiles/srt_virtual.dir/srtcore/cache.cpp.obj
[ 17%] Building CXX object CMakeFiles/srtsupport_virtual.dir/apps/transmitmedia.cpp.obj
[ 19%] Building CXX object CMakeFiles/srt_virtual.dir/srtcore/channel.cpp.obj
/usr/src/mxe/tmp-libsrt-x86_64-w64-mingw32.static/srt-1.4.2/srtcore/channel.cpp: In member function 'void CChannel::createSocket(int)':
/usr/src/mxe/tmp-libsrt-x86_64-w64-mingw32.static/srt-1.4.2/srtcore/channel.cpp:157:10: warning: variable 'cloexec_flag' set but not used [-Wunused-but-set-variable]
  157 |     bool cloexec_flag = false;
      |          ^~~~~~~~~~~~
[ 21%] Building CXX object CMakeFiles/srt_virtual.dir/srtcore/common.cpp.obj
[ 23%] Building CXX object CMakeFiles/srtsupport_virtual.dir/apps/uriparser.cpp.obj
[ 25%] Building CXX object CMakeFiles/srt_virtual.dir/srtcore/core.cpp.obj
[ 27%] Building CXX object CMakeFiles/srtsupport_virtual.dir/apps/verbose.cpp.obj
make[4]: Leaving directory '/usr/src/mxe/tmp-libsrt-x86_64-w64-mingw32.static/srt-1.4.2.build_'
[ 27%] Built target srtsupport_virtual
[ 29%] Building CXX object CMakeFiles/srt_virtual.dir/srtcore/crypto.cpp.obj
[ 31%] Building CXX object CMakeFiles/srt_virtual.dir/srtcore/epoll.cpp.obj
/usr/src/mxe/tmp-libsrt-x86_64-w64-mingw32.static/srt-1.4.2/srtcore/epoll.cpp:253:2: warning: #warning "Unsupported system for epoll. The epoll_add_ssock() API call won't work on this platform." [-Wcpp]
  253 | #warning "Unsupported system for epoll. The epoll_add_ssock() API call won't work on this platform."
      |  ^~~~~~~
[ 34%] Building CXX object CMakeFiles/srt_virtual.dir/srtcore/fec.cpp.obj
[ 36%] Building CXX object CMakeFiles/srt_virtual.dir/srtcore/handshake.cpp.obj
[ 38%] Building CXX object CMakeFiles/srt_virtual.dir/srtcore/list.cpp.obj
[ 40%] Building CXX object CMakeFiles/srt_virtual.dir/srtcore/logger_default.cpp.obj
[ 42%] Building CXX object CMakeFiles/srt_virtual.dir/srtcore/logger_defs.cpp.obj
[ 44%] Building CXX object CMakeFiles/srt_virtual.dir/srtcore/md5.cpp.obj
[ 46%] Building CXX object CMakeFiles/srt_virtual.dir/srtcore/packet.cpp.obj
[ 48%] Building CXX object CMakeFiles/srt_virtual.dir/srtcore/packetfilter.cpp.obj
[ 51%] Building CXX object CMakeFiles/srt_virtual.dir/srtcore/queue.cpp.obj
[ 53%] Building CXX object CMakeFiles/srt_virtual.dir/srtcore/congctl.cpp.obj
[ 55%] Building CXX object CMakeFiles/srt_virtual.dir/srtcore/srt_c_api.cpp.obj
[ 57%] Building CXX object CMakeFiles/srt_virtual.dir/srtcore/window.cpp.obj
[ 59%] Building C object CMakeFiles/srt_virtual.dir/srtcore/srt_compat.c.obj
[ 61%] Building CXX object CMakeFiles/srt_virtual.dir/srtcore/sync.cpp.obj
[ 63%] Building CXX object CMakeFiles/srt_virtual.dir/srtcore/sync_posix.cpp.obj
[ 65%] Building C object CMakeFiles/srt_virtual.dir/haicrypt/cryspr.c.obj
[ 68%] Building C object CMakeFiles/srt_virtual.dir/haicrypt/cryspr-openssl.c.obj
[ 70%] Building C object CMakeFiles/srt_virtual.dir/haicrypt/hcrypt.c.obj
[ 72%] Building C object CMakeFiles/srt_virtual.dir/haicrypt/hcrypt_ctx_rx.c.obj
[ 74%] Building C object CMakeFiles/srt_virtual.dir/haicrypt/hcrypt_ctx_tx.c.obj
[ 76%] Building C object CMakeFiles/srt_virtual.dir/haicrypt/hcrypt_rx.c.obj
[ 78%] Building C object CMakeFiles/srt_virtual.dir/haicrypt/hcrypt_sa.c.obj
[ 80%] Building C object CMakeFiles/srt_virtual.dir/haicrypt/hcrypt_tx.c.obj
[ 82%] Building C object CMakeFiles/srt_virtual.dir/haicrypt/hcrypt_xpt_srt.c.obj
[ 85%] Building CXX object CMakeFiles/srt_virtual.dir/haicrypt/haicrypt_log.cpp.obj
[ 87%] Building CXX object CMakeFiles/srt_virtual.dir/common/win_time.cpp.obj
make[4]: Leaving directory '/usr/src/mxe/tmp-libsrt-x86_64-w64-mingw32.static/srt-1.4.2.build_'
[ 87%] Built target srt_virtual
make[4]: Entering directory '/usr/src/mxe/tmp-libsrt-x86_64-w64-mingw32.static/srt-1.4.2.build_'
Scanning dependencies of target srt_static
make[4]: Leaving directory '/usr/src/mxe/tmp-libsrt-x86_64-w64-mingw32.static/srt-1.4.2.build_'
make[4]: Entering directory '/usr/src/mxe/tmp-libsrt-x86_64-w64-mingw32.static/srt-1.4.2.build_'
[ 89%] Building C object CMakeFiles/srt_static.dir/cmake_object_lib_support.c.obj
[ 91%] Linking CXX static library libsrt.a
make[4]: Leaving directory '/usr/src/mxe/tmp-libsrt-x86_64-w64-mingw32.static/srt-1.4.2.build_'
[ 91%] Built target srt_static
make[4]: Entering directory '/usr/src/mxe/tmp-libsrt-x86_64-w64-mingw32.static/srt-1.4.2.build_'
make[4]: Entering directory '/usr/src/mxe/tmp-libsrt-x86_64-w64-mingw32.static/srt-1.4.2.build_'
Scanning dependencies of target srt-live-transmit
Scanning dependencies of target srt-file-transmit
make[4]: Leaving directory '/usr/src/mxe/tmp-libsrt-x86_64-w64-mingw32.static/srt-1.4.2.build_'
make[4]: Entering directory '/usr/src/mxe/tmp-libsrt-x86_64-w64-mingw32.static/srt-1.4.2.build_'
make[4]: Leaving directory '/usr/src/mxe/tmp-libsrt-x86_64-w64-mingw32.static/srt-1.4.2.build_'
make[4]: Entering directory '/usr/src/mxe/tmp-libsrt-x86_64-w64-mingw32.static/srt-1.4.2.build_'
[ 93%] Building CXX object CMakeFiles/srt-file-transmit.dir/apps/srt-file-transmit.cpp.obj
[ 95%] Building CXX object CMakeFiles/srt-live-transmit.dir/apps/srt-live-transmit.cpp.obj
[ 97%] Linking CXX executable srt-live-transmit.exe
[100%] Linking CXX executable srt-file-transmit.exe
make[4]: Leaving directory '/usr/src/mxe/tmp-libsrt-x86_64-w64-mingw32.static/srt-1.4.2.build_'
[100%] Built target srt-file-transmit
make[4]: Leaving directory '/usr/src/mxe/tmp-libsrt-x86_64-w64-mingw32.static/srt-1.4.2.build_'
[100%] Built target srt-live-transmit
make[3]: Leaving directory '/usr/src/mxe/tmp-libsrt-x86_64-w64-mingw32.static/srt-1.4.2.build_'
make[2]: Leaving directory '/usr/src/mxe/tmp-libsrt-x86_64-w64-mingw32.static/srt-1.4.2.build_'
make -C '/usr/src/mxe/tmp-libsrt-x86_64-w64-mingw32.static/srt-1.4.2.build_' -j 1 install dist_bin_SCRIPTS= bin_PROGRAMS= sbin_PROGRAMS= noinst_PROGRAMS= check_PROGRAMS= man_MANS= man1_MANS= man2_MANS= man3_MANS= man4_MANS= man5_MANS= man6_MANS= man7_MANS= man8_MANS= man9_MANS= dist_man_MANS= dist_man1_MANS= dist_man2_MANS= dist_man3_MANS= dist_man4_MANS= dist_man5_MANS= dist_man6_MANS= dist_man7_MANS= dist_man8_MANS= dist_man9_MANS= nodist_man_MANS= nodist_man1_MANS= nodist_man2_MANS= nodist_man3_MANS= nodist_man4_MANS= nodist_man5_MANS= nodist_man6_MANS= nodist_man7_MANS= nodist_man8_MANS= nodist_man9_MANS= notrans_dist_man_MANS= MANLINKS= info_TEXINFOS= doc_DATA= dist_doc_DATA= html_DATA= dist_html_DATA=
make[2]: Entering directory '/usr/src/mxe/tmp-libsrt-x86_64-w64-mingw32.static/srt-1.4.2.build_'
make[3]: Entering directory '/usr/src/mxe/tmp-libsrt-x86_64-w64-mingw32.static/srt-1.4.2.build_'
make[4]: Entering directory '/usr/src/mxe/tmp-libsrt-x86_64-w64-mingw32.static/srt-1.4.2.build_'
make[4]: Leaving directory '/usr/src/mxe/tmp-libsrt-x86_64-w64-mingw32.static/srt-1.4.2.build_'
[ 14%] Built target srtsupport_virtual
make[4]: Entering directory '/usr/src/mxe/tmp-libsrt-x86_64-w64-mingw32.static/srt-1.4.2.build_'
make[4]: Leaving directory '/usr/src/mxe/tmp-libsrt-x86_64-w64-mingw32.static/srt-1.4.2.build_'
[ 87%] Built target srt_virtual
make[4]: Entering directory '/usr/src/mxe/tmp-libsrt-x86_64-w64-mingw32.static/srt-1.4.2.build_'
make[4]: Leaving directory '/usr/src/mxe/tmp-libsrt-x86_64-w64-mingw32.static/srt-1.4.2.build_'
[ 91%] Built target srt_static
make[4]: Entering directory '/usr/src/mxe/tmp-libsrt-x86_64-w64-mingw32.static/srt-1.4.2.build_'
make[4]: Leaving directory '/usr/src/mxe/tmp-libsrt-x86_64-w64-mingw32.static/srt-1.4.2.build_'
[ 95%] Built target srt-live-transmit
make[4]: Entering directory '/usr/src/mxe/tmp-libsrt-x86_64-w64-mingw32.static/srt-1.4.2.build_'
make[4]: Leaving directory '/usr/src/mxe/tmp-libsrt-x86_64-w64-mingw32.static/srt-1.4.2.build_'
[100%] Built target srt-file-transmit
make[3]: Leaving directory '/usr/src/mxe/tmp-libsrt-x86_64-w64-mingw32.static/srt-1.4.2.build_'
Install the project...
-- Install configuration: "Release"
-- Installing: /usr/src/mxe/usr/x86_64-w64-mingw32.static/lib/libsrt.a
-- Installing: /usr/src/mxe/usr/x86_64-w64-mingw32.static/include/srt/version.h
-- Up-to-date: /usr/src/mxe/usr/x86_64-w64-mingw32.static/include/srt/srt.h
-- Up-to-date: /usr/src/mxe/usr/x86_64-w64-mingw32.static/include/srt/logging_api.h
-- Up-to-date: /usr/src/mxe/usr/x86_64-w64-mingw32.static/include/srt/access_control.h
-- Up-to-date: /usr/src/mxe/usr/x86_64-w64-mingw32.static/include/srt/platform_sys.h
-- Up-to-date: /usr/src/mxe/usr/x86_64-w64-mingw32.static/include/srt/udt.h
-- Up-to-date: /usr/src/mxe/usr/x86_64-w64-mingw32.static/include/srt/win/syslog_defs.h
-- Up-to-date: /usr/src/mxe/usr/x86_64-w64-mingw32.static/include/srt/win/unistd.h
-- Installing: /usr/src/mxe/usr/x86_64-w64-mingw32.static/lib/pkgconfig/haisrt.pc
-- Installing: /usr/src/mxe/usr/x86_64-w64-mingw32.static/lib/pkgconfig/srt.pc
-- Installing: /usr/src/mxe/usr/x86_64-w64-mingw32.static/bin/srt-live-transmit.exe
-- Up-to-date: /usr/src/mxe/usr/x86_64-w64-mingw32.static/bin/srt-live-transmit.exe
-- Installing: /usr/src/mxe/usr/x86_64-w64-mingw32.static/bin/srt-file-transmit.exe
-- Up-to-date: /usr/src/mxe/usr/x86_64-w64-mingw32.static/bin/srt-file-transmit.exe
-- Up-to-date: /usr/src/mxe/usr/x86_64-w64-mingw32.static/bin/srt-ffplay
make[2]: Leaving directory '/usr/src/mxe/tmp-libsrt-x86_64-w64-mingw32.static/srt-1.4.2.build_'
```