### PR TITLE
Add binutils 2.35.1 as a plugin

### DIFF
--- a/plugins/binutils2.35.1/binutils-overlay.mk
+++ b/plugins/binutils2.35.1/binutils-overlay.mk
@@ -1,0 +1,14 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+PKG             := binutils
+$(PKG)_WEBSITE  := https://www.gnu.org/software/binutils/
+$(PKG)_DESCR    := GNU Binutils
+$(PKG)_VERSION  := 2.35.1
+$(PKG)_CHECKSUM := 320e7a1d0f46fcd9f413f1046e216cbe23bb2bce6deb6c6a63304425e48b1942
+$(PKG)_SUBDIR   := binutils-$($(PKG)_VERSION)
+$(PKG)_FILE     := binutils-$($(PKG)_VERSION).tar.bz2
+$(PKG)_URL      := https://ftp.gnu.org/gnu/binutils/$($(PKG)_FILE)
+$(PKG)_URL_2    := https://ftpmirror.gnu.org/binutils/$($(PKG)_FILE)
+$(PKG)_DEPS     :=
+$(PKG)_PATCHES  :=
+


### PR DESCRIPTION
Add binutils 2.35.1 to help support usage of later gcc plugins
