### PR TITLE
URL_2 for expat

### DIFF
--- a/src/expat.mk
+++ b/src/expat.mk
@@ -9,6 +9,7 @@ $(PKG)_CHECKSUM := b2c160f1b60e92da69de8e12333096aeb0c3bf692d41c60794de278af7213
 $(PKG)_SUBDIR   := expat-$($(PKG)_VERSION)
 $(PKG)_FILE     := expat-$($(PKG)_VERSION).tar.bz2
 $(PKG)_URL      := https://$(SOURCEFORGE_MIRROR)/project/expat/expat/$($(PKG)_VERSION)/$($(PKG)_FILE)
+$(PKG)_URL_2    := https://github.com/libexpat/libexpat/releases/download/R_2_2_10/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc
 
 define $(PKG)_UPDATE


### PR DESCRIPTION
Failed to download expat from SourceForge. Add an alternative URL solves the problem.