### PR TITLE
Add a wxWidgets-3.1.4 plugin

### DIFF
--- a/plugins/wx314/wx314-overlay.mk
+++ b/plugins/wx314/wx314-overlay.mk
@@ -1,0 +1,71 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+PKG             := wxwidgets
+$(PKG)_WEBSITE  := https://www.wxwidgets.org/
+$(PKG)_DESCR    := wxWidgets
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 3.1.4
+$(PKG)_CHECKSUM := 3ca3a19a14b407d0cdda507a7930c2e84ae1c8e74f946e0144d2fa7d881f1a94
+$(PKG)_SUBDIR   := wxWidgets-$($(PKG)_VERSION)
+$(PKG)_FILE     := wxWidgets-$($(PKG)_VERSION).tar.bz2
+$(PKG)_URL      := https://github.com/wxWidgets/wxWidgets/releases/download/v$($(PKG)_VERSION)/$($(PKG)_FILE)
+$(PKG)_PATCHES  :=
+$(PKG)_DEPS     := cc expat jpeg libiconv libpng sdl tiff zlib
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- 'https://github.com/wxWidgets/wxWidgets/releases' | \
+    $(SED) -n 's,.*wxWidgets-\([0-9][^"]*\)\.tar.*,\1,p' | \
+    head -1
+endef
+
+define $(PKG)_CONFIGURE_OPTS
+        $(MXE_CONFIGURE_OPTS) \
+        --enable-option-checking \
+        --enable-gui \
+        --disable-stl \
+        --disable-gtktest \
+        --enable-threads \
+        --enable-backtrace \
+        --disable-universal \
+        --with-themes=all \
+        --with-msw \
+        --with-opengl \
+        --with-libpng=sys \
+        --with-libjpeg=sys \
+        --with-libtiff=sys \
+        --with-regex=yes \
+        --with-zlib=sys \
+        --with-expat=sys \
+        --with-sdl \
+        --without-gtk \
+        --without-macosx-sdk \
+        --without-libxpm \
+        --without-libmspack \
+        --without-gnomevfs \
+        --without-dmalloc \
+        CXXFLAGS='-std=gnu++11' \
+        CXXCPP='$(TARGET)-g++ -E -std=gnu++11'
+endef
+
+define $(PKG)_BUILD
+    # build the wxWidgets variant with unicode support
+    mkdir '$(1).unicode'
+    cd    '$(1).unicode' && '$(1)/configure' \
+        $($(PKG)_CONFIGURE_OPTS) \
+        --enable-unicode
+    $(MAKE) -C '$(1).unicode' -j '$(JOBS)' \
+        $(MXE_DISABLE_CRUFT)
+    -$(MAKE) -C '$(1).unicode/locale' -j '$(JOBS)' allmo \
+        $(MXE_DISABLE_CRUFT)
+    $(MAKE) -C '$(1).unicode' -j 1 install \
+        $(if $(BUILD_SHARED),DLLDEST='/../bin') \
+        $(MXE_DISABLE_CRUFT) __install_wxrc___depname=
+    $(INSTALL) -m755 '$(PREFIX)/$(TARGET)/bin/wx-config' \
+                     '$(PREFIX)/bin/$(TARGET)-wx-config'
+
+    # build test program
+    '$(TARGET)-g++' \
+        -W -Wall -pedantic -std=gnu++0x \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-wxwidgets.exe' \
+        `'$(TARGET)-wx-config' --cflags --libs`
+endef

--- a/plugins/wx314/wxwidgets-test.cpp
+++ b/plugins/wx314/wxwidgets-test.cpp
@@ -1,0 +1,19 @@
+/*
+ * This file is part of MXE. See LICENSE.md for licensing information.
+ */
+
+#include <wx/wx.h>
+
+class TestApp: public wxApp
+{
+private:
+    bool OnInit()
+    {
+        wxFrame *frame = new wxFrame(0, -1, _("Hello, World!"));
+        frame->Show(true);
+        SetTopWindow(frame);
+        return true;
+    }
+};
+
+IMPLEMENT_APP(TestApp)


### PR DESCRIPTION
This makes a recent wxWidgets version available as a plugin.

This is related to pull request #2452 that proposes to update the default
wxWidgets version in mxe. Note the following differences wrt the code in
that pull request:

 * this plugin uses the usual MXE_CONFIGURE_OPTS, addressing the
   comments of @tonytheodore
 * configure complaints about unused options that result from this choice
   produce warnings, rather than errors, by passing --enable-option-checking
   to configure (without argument). This was suggested by @janvdijk (me)
   in the audit trail of pull request #2452
 * it makes version 3.1.4 available, rather than 3.1.3
 * no patches are needed to build this version of wxWidgets with the
   default gcc or with gcc9 or gcc10 (available as plugins in mxe).

This patch allows us to do in-the-wild testing of wxWidgets, before
making 3.1.4 the default, thereby obsoleting pull request #2452.
(I think that would be a good idea, even soon, given the facts that 3.0.x
does not see much maintenance (if at all), and that 3.1.x releases have
proven to be VERY stable and reliable.)