### PR TITLE
Quote asterisk in shell command for portability with zsh

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -371,7 +371,7 @@ sudo apt-get update</pre>
     Note that all package and target names have underscores replaced with
     dashes. For example:
     </p>
-    <pre>apt-cache search mxe.*sdl_net</pre>
+    <pre>apt-cache search 'mxe.*sdl_net'</pre>
     <p>
     outputs:
     </p>


### PR DESCRIPTION
The shell command

    apt-cache search mxe.*sdl_net

has two issues. First, it will lead to wrong results if a file like `mxe.FOOBARsdl_net` happens to exist in the current directory. Second, it will fail in `zsh` which is more strict about failed globs.

The proposed pull request fixes that.