### PR TITLE
Add woff2

### DIFF
--- a/src/woff2.mk
+++ b/src/woff2.mk
@@ -1,0 +1,16 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+PKG             := woff2
+$(PKG)_WEBSITE  := https://github.com/google/woff2
+$(PKG)_DESCR    := WOFF2 font compression library
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 1.0.2
+$(PKG)_CHECKSUM := add272bb09e6384a4833ffca4896350fdb16e0ca22df68c0384773c67a175594
+$(PKG)_GH_CONF  := google/woff2/tags, v
+$(PKG)_DEPS     := cc brotli
+
+define $(PKG)_BUILD
+    cd '$(BUILD_DIR)' && $(TARGET)-cmake '$(SOURCE_DIR)'
+    $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)'
+    $(MAKE) -C '$(BUILD_DIR)' -j 1 install
+endef


### PR DESCRIPTION
This pull request adds woff2, a library for WOFF2 font file format.
Depends on `brotli`: https://github.com/mxe/mxe/pull/2417

Build log in attachment: [woff2_i686-w64-mingw32.shared.posix.log](https://github.com/mxe/mxe/files/6046332/woff2_i686-w64-mingw32.shared.posix.log)

