### PR TITLE
Fix exiv2 updating

### DIFF
--- a/src/exiv2.mk
+++ b/src/exiv2.mk
@@ -4,11 +4,11 @@ PKG             := exiv2
 $(PKG)_WEBSITE  := https://www.exiv2.org/
 $(PKG)_DESCR    := Exiv2
 $(PKG)_IGNORE   :=
-$(PKG)_VERSION  := 0.25
-$(PKG)_CHECKSUM := c80bfc778a15fdb06f71265db2c3d49d8493c382e516cb99b8c9f9cbde36efa4
-$(PKG)_SUBDIR   := exiv2-$($(PKG)_VERSION)
-$(PKG)_FILE     := exiv2-$($(PKG)_VERSION).tar.gz
-$(PKG)_URL      := https://www.exiv2.org/releases/$($(PKG)_FILE)
+$(PKG)_VERSION  := 0.27.3
+$(PKG)_CHECKSUM := a79f5613812aa21755d578a297874fb59a85101e793edc64ec2c6bd994e3e778
+$(PKG)_SUBDIR   := exiv2-$($(PKG)_VERSION)-Source
+$(PKG)_FILE     := exiv2-$($(PKG)_VERSION)-Source.tar.gz
+$(PKG)_URL      := https://www.exiv2.org/builds/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc expat gettext mman-win32 zlib
 
 define $(PKG)_UPDATE
@@ -19,19 +19,8 @@ define $(PKG)_UPDATE
 endef
 
 define $(PKG)_BUILD
-    # libtool looks for a pei* format when linking shared libs
-    # apparently there's no real difference b/w pei and pe
-    # so we set the libtool cache variables
-    # https://sourceware.org/cgi-bin/cvsweb.cgi/src/bfd/libpei.h?annotate=1.25&cvsroot=src
-    cd '$(1)' && ./configure \
-        $(MXE_CONFIGURE_OPTS) \
-        --disable-visibility \
-        --disable-nls \
-        --with-expat \
-        LIBS='-lmman' \
-        $(if $(BUILD_SHARED),\
-            lt_cv_deplibs_check_method='file_magic file format (pe-i386|pe-x86-64)' \
-            lt_cv_file_magic_cmd='$$OBJDUMP -f')
-    $(MAKE) -C '$(1)/xmpsdk/src' -j '$(JOBS)'
-    $(MAKE) -C '$(1)/src'        -j '$(JOBS)' install-lib
+    $(TARGET)-cmake -S '$(SOURCE_DIR)' -B '$(BUILD_DIR)' \
+        -DEXIV2_BUILD_SAMPLES=OFF
+    $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)'
+    $(MAKE) -C '$(BUILD_DIR)' -j 1 install
 endef

--- a/src/exiv2.mk
+++ b/src/exiv2.mk
@@ -13,8 +13,8 @@ $(PKG)_DEPS     := cc expat gettext mman-win32 zlib
 
 define $(PKG)_UPDATE
     $(WGET) -q -O- 'https://www.exiv2.org/download.html' | \
-    grep 'href="exiv2-' | \
-    $(SED) -n 's,.*exiv2-\([0-9][^>]*\)\.tar.*,\1,p' | \
+    grep 'href="builds/exiv2-' | \
+    $(SED) -n 's,.*exiv2-\([0-9][^>]*\)-Source\.tar.*,\1,p' | \
     head -1
 endef
 


### PR DESCRIPTION
The Exiv2 updater didn't work anymore, which is why Exiv2 got stuck at version 0.25.

This pull request fixes the updater, and updates Exiv2 to its latest version 0.27.3.