### PR TITLE
Fix gettext builds (gettext bug 59929)

### DIFF
--- a/src/gettext-1-fixes.patch
+++ b/src/gettext-1-fixes.patch
@@ -1,0 +1,19 @@
+Fix https://savannah.gnu.org/bugs/?59929
+'AC_INIT with proper package and version'
+
+--- gettext-0.21/libtextstyle/configure.ac
++++ gettext-0.21/libtextstyle/configure.ac
+@@ -17,11 +17,10 @@
+ dnl Process this file with autoconf to produce a configure script.
+ 
+ AC_PREREQ([2.63])
+-AC_INIT
++AC_INIT([libtextstyle],
++    m4_esyscmd([source ./version.sh; echo $VERSION_NUMBER | tr -d '\n']))
+ AC_CONFIG_SRCDIR([version.sh])
+ AC_CONFIG_AUX_DIR([build-aux])
+-. $srcdir/version.sh
+-gl_INIT_PACKAGE([libtextstyle], [$VERSION_NUMBER])
+ AM_INIT_AUTOMAKE([1.13 silent-rules])
+ AM_CONFIG_HEADER([config.h])
+ 

--- a/src/gettext.mk
+++ b/src/gettext.mk
@@ -12,6 +12,7 @@ $(PKG)_URL_2    := https://ftpmirror.gnu.org/gettext/$($(PKG)_FILE)
 # native gettext isn't technically required, but downstream
 # cross-packages may need binaries and/or *.m4 files etc.
 $(PKG)_DEPS     := cc libiconv $(BUILD)~$(PKG)
+$(PKG)_PATCHES  := $(TOP_DIR)/src/gettext-1-fixes.patch
 
 $(PKG)_TARGETS       := $(BUILD) $(MXE_TARGETS)
 $(PKG)_DEPS_$(BUILD) := libiconv


### PR DESCRIPTION
This patch fixes a gettext configury bug that prevents building MXE on my OpenSUSE Tumbleweed system with autoconf 2.69 and automake 1.16.3, producing an error about obsolete invocations of AC_INIT, AM_INIT_AUTOMAKE  It has been taken from the gettext bugtracker, see https://savannah.gnu.org/bugs/?59929 for details.