### PR TITLE
libgcrypt: update to 1.9.3 and fix static linking

### DIFF
--- a/src/libgcrypt.mk
+++ b/src/libgcrypt.mk
@@ -3,8 +3,8 @@
 PKG             := libgcrypt
 $(PKG)_WEBSITE  := https://directory.fsf.org/wiki/Libgcrypt
 $(PKG)_IGNORE   :=
-$(PKG)_VERSION  := 1.9.2
-$(PKG)_CHECKSUM := b2c10d091513b271e47177274607b1ffba3d95b188bbfa8797f948aec9053c5a
+$(PKG)_VERSION  := 1.9.3
+$(PKG)_CHECKSUM := 97ebe4f94e2f7e35b752194ce15a0f3c66324e0ff6af26659bbfb5ff2ec328fd
 $(PKG)_SUBDIR   := libgcrypt-$($(PKG)_VERSION)
 $(PKG)_FILE     := libgcrypt-$($(PKG)_VERSION).tar.bz2
 $(PKG)_URL      := https://gnupg.org/ftp/gcrypt/libgcrypt/$($(PKG)_FILE)
@@ -34,7 +34,9 @@ define $(PKG)_MAKE
      echo 'Version: $($(PKG)_VERSION)'; \
      echo 'Description: $(PKG)'; \
      echo 'Libs: ' "`$(TARGET)-libgcrypt-config --libs`"; \
-     echo 'Cflags: ' "`$(TARGET)-libgcrypt-config --cflags`";) \
+     echo 'Cflags: ' "`$(TARGET)-libgcrypt-config --cflags`"; \
+     echo 'Libs: -lws2_32'; \
+     ) \
      > '$(PREFIX)/$(TARGET)/lib/pkgconfig/$(PKG).pc'
 
     '$(TARGET)-gcc' \


### PR DESCRIPTION
Fixes #2633