### PR TITLE
boost: GCC 11 build fix

### DIFF
--- a/src/boost.mk
+++ b/src/boost.mk
@@ -69,7 +69,7 @@ define $(PKG)_BUILD
     echo 'set(Boost_THREADAPI "win32")' > '$(CMAKE_TOOLCHAIN_DIR)/$(PKG).cmake'
 
     '$(TARGET)-g++' \
-        -W -Wall -Werror -ansi -U__STRICT_ANSI__ -pedantic \
+        -W -Wall -Werror -ansi -pedantic \
         '$(PWD)/src/$(PKG)-test.cpp' -o '$(PREFIX)/$(TARGET)/bin/test-boost.exe' \
         -DBOOST_THREAD_USE_LIB \
         -lboost_serialization-mt \


### PR DESCRIPTION
GCC 11 complains about -U__STRICT_ANSI__.

    usr/lib/gcc/x86_64-w64-mingw32.static/11.1.0/include/c++/\
        x86_64-w64-mingw32.static/bits/c++config.h:558:2: \
        error: #warning "__STRICT_ANSI__ seems to have been \
        undefined; this is not supported" [-Werror=cpp]
    558 | #warning "__STRICT_ANSI__ seems to have been undefined; this is not supported"

I don't know if -U__STRICT_ANSI__ is (still) useful here for other compilers.