### PR TITLE
Add --with-default-win32-winnt=0x0600

### DIFF
--- a/src/gcc.mk
+++ b/src/gcc.mk
@@ -70,11 +70,11 @@ define $(PKG)_BUILD_mingw-w64
     cd '$(BUILD_DIR).headers' && '$(BUILD_DIR)/$(mingw-w64_SUBDIR)/mingw-w64-headers/configure' \
         --host='$(TARGET)' \
         --prefix='$(PREFIX)/$(TARGET)' \
-        --with-default-msvcrt=msvcrt \
         --enable-sdk=all \
         --enable-idl \
         --enable-secure-api \
         --with-default-msvcrt=msvcrt \
+        --with-default-win32-winnt=0x0600 \
         $(mingw-w64-headers_CONFIGURE_OPTS)
     $(MAKE) -C '$(BUILD_DIR).headers' install
 
@@ -89,6 +89,7 @@ define $(PKG)_BUILD_mingw-w64
         --host='$(TARGET)' \
         --prefix='$(PREFIX)/$(TARGET)' \
         --with-default-msvcrt=msvcrt \
+        --with-default-win32-winnt=0x0600 \
         @gcc-crt-config-opts@ \
         $(mingw-w64-crt_CONFIGURE_OPTS)
     $(MAKE) -C '$(BUILD_DIR).crt' -j '$(JOBS)' || $(MAKE) -C '$(BUILD_DIR).crt' -j '$(JOBS)'


### PR DESCRIPTION
As of mingw-w64 v9.0.0, `_WIN32_WINNT` is set to Windows 10. Add `--with-default-win32-winnt` to configure for Vista.
Remove duplicate `--with-default-msvcrt=msvcrt`

Fixes #2662