### PR TITLE
Disable wmf for qtmultimedia

### DIFF
--- a/src/qtmultimedia-1.patch
+++ b/src/qtmultimedia-1.patch
@@ -1,0 +1,23 @@
+This file is part of MXE. See LICENSE.md for licensing information.
+
+From 0000000000000000000000000000000000000000 Thu May 27 00:00:00 2021
+From: Adrian Jaekel <aj@elane2k.com>
+Date: Thu, 27 May 2021 14:03:20 +0200
+Subject: [PATCH 1/1] disable wmf plugin for MXE
+
+
+diff --git a/src/plugins/plugins.pro b/src/plugins/plugins.pro
+index 1111111..2222222 100644
+--- a/src/plugins/plugins.pro
++++ b/src/plugins/plugins.pro
+@@ -35,8 +35,9 @@     SUBDIRS += audiocapture \
+                windowsaudio
+
+     qtConfig(directshow): SUBDIRS += directshow
+-    qtConfig(wmf): SUBDIRS += wmf
++#    qtConfig(wmf): SUBDIRS += wmf
++    message(MXE: wmf disabled)
+ }
+ 
+ 
+ winrt {


### PR DESCRIPTION
Windows Media Foundation plugin is not yet fully available through mingw so we are disabling it. This fixes #2657
