### PR TITLE
Upgrade graphicsmagick from 1.3.33 to 1.3.36

### DIFF
--- a/src/graphicsmagick-1-fixes.patch
+++ b/src/graphicsmagick-1-fixes.patch
@@ -4,17 +4,17 @@ Contains ad hoc patches for cross building.
 
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Volker Diels-Grabsch <v@njh.eu>
-Date: Sat, 11 Dec 2010 22:50:57 +0100
-Subject: [PATCH 1/2] fix .pc file for xml2 dependency
+Date: Thu, 01 Jul 2021 00:52:06 +0200
+Subject: [PATCH 1/1] Fix .pc file and confiure.ac for xml2 dependency
 
-This patch has been taken from:
+This patch is related to:
 https://sourceforge.net/p/graphicsmagick/bugs/154/
 
 diff --git a/magick/GraphicsMagick.pc.in b/magick/GraphicsMagick.pc.in
 index 1111111..2222222 100644
 --- a/magick/GraphicsMagick.pc.in
 +++ b/magick/GraphicsMagick.pc.in
-@@ -7,5 +7,7 @@ includedir=@includedir@/GraphicsMagick
+@@ -7,6 +7,8 @@ includedir=@includedir@/GraphicsMagick
  Name: GraphicsMagick
  Version: @PACKAGE_VERSION@
  Description: GraphicsMagick image processing library
@@ -22,23 +22,55 @@ index 1111111..2222222 100644
  Libs: -L${libdir} -lGraphicsMagick
 +Libs.private: @MAGICK_API_LDFLAGS@ @MAGICK_API_LIBS@
  Cflags: -I${includedir} @MAGICK_API_PC_CPPFLAGS@
-
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Tony Theodore <tonyt@logyst.com>
-Date: Sun, 10 Feb 2013 15:24:58 +1100
-Subject: [PATCH 2/2] relax autoconf version requirement
-
-
+ 
 diff --git a/configure.ac b/configure.ac
-index 1111111..2222222 100755
+index 1111111..2222222 100644
 --- a/configure.ac
 +++ b/configure.ac
-@@ -11,7 +11,7 @@
- # Written by Bob Friesenhahn <bfriesen@GraphicsMagick.org>
- #
- 
--AC_PREREQ(2.69)
-+AC_PREREQ(2.67)
- AC_INIT(magick/magick.h)
- 
- # Specify directory where m4 macros may be found.
+@@ -2554,13 +2554,13 @@ then
+        then
+           # Sample output from xml2-config --cflags:
+           # -I/usr/include/libxml2
+-          # -I/usr/local/include/libxml2 -I/usr/local/include
++          # -I/usr/local/include/libxml2 -I/usr/local/include -DLIBXML_STATIC
+           xml2_cflags=`"$xml2_config" --cflags`
+           # Sample output from xml2-config --libs:
+           # -lxml2
+           # -L/usr/lib -R/usr/lib -lxml2 -lz -lpthread -lm -lsocket -lnsl
+-          #-L/usr/local/lib -lxml2 -lz -L/usr/local/lib -liconv -lm
+-          xml2_libs=`$xml2_config  --libs`
++          # -L/usr/local/lib -lxml2 -lz -L/usr/local/lib -liconv -lm
++          xml2_libs=`"$xml2_config" --libs`
+        fi
+       ])
+       for flag in $xml2_cflags
+@@ -2587,6 +2587,29 @@ then
+                     ;;
+         esac
+       done
++      for flag in $xml2_cflags
++      do
++        case $flag in
++             -D*)
++                # Add flag to CPPFLAGS if not already present
++                    add=yes;
++                    for test_flag in $CPPFLAGS
++                    do
++                        if test $flag = $test_flag
++                        then
++                            add=no
++                            break
++                        fi
++                    done
++                    if test $add = yes
++                    then
++                        CPPFLAGS="$CPPFLAGS $flag"
++                    fi
++                    ;;
++                *)
++                    ;;
++        esac
++      done
+       for flag in $xml2_libs
+       do
+             case $flag in

--- a/src/graphicsmagick.mk
+++ b/src/graphicsmagick.mk
@@ -4,8 +4,8 @@ PKG             := graphicsmagick
 $(PKG)_WEBSITE  := http://www.graphicsmagick.org/
 $(PKG)_DESCR    := GraphicsMagick
 $(PKG)_IGNORE   :=
-$(PKG)_VERSION  := 1.3.33
-$(PKG)_CHECKSUM := ae86f749815d3039ac431caf9fc4b65acf32bfd140d1817644d3463b6ba9d51c
+$(PKG)_VERSION  := 1.3.36
+$(PKG)_CHECKSUM := d0cbc68dee3819e9d8b3657e0881e3ae7baff1dadafb23ecc9481b47e1f880c1
 $(PKG)_SUBDIR   := GraphicsMagick-$($(PKG)_VERSION)
 $(PKG)_FILE     := GraphicsMagick-$($(PKG)_VERSION).tar.lz
 $(PKG)_URL      := https://$(SOURCEFORGE_MIRROR)/project/$(PKG)/$(PKG)/$($(PKG)_VERSION)/$($(PKG)_FILE)
@@ -18,7 +18,7 @@ define $(PKG)_UPDATE
 endef
 
 define $(PKG)_BUILD
-    # This can be removed once the patch "graphicsmagick-1-fix-xml2-config.patch" is accepted by upstream
+    # Regenerating configure script as we are patching configure.ac.
     cd '$(SOURCE_DIR)' && autoconf
     cd '$(BUILD_DIR)' && '$(SOURCE_DIR)/configure' \
          $(MXE_CONFIGURE_OPTS) \
@@ -42,9 +42,7 @@ define $(PKG)_BUILD
         --with-xml \
         --with-zlib \
         --without-x \
-        ac_cv_prog_xml2_config='$(PREFIX)/$(TARGET)/bin/xml2-config' \
         ac_cv_path_xml2_config='$(PREFIX)/$(TARGET)/bin/xml2-config' \
-        LIBS='-lgomp -fopenmp' \
         $(PKG_CONFIGURE_OPTS)
     $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)' bin_PROGRAMS=
     $(MAKE) -C '$(BUILD_DIR)' -j 1 install bin_PROGRAMS=
@@ -52,5 +50,5 @@ define $(PKG)_BUILD
     '$(TARGET)-g++' \
         -W -Wall -Werror -pedantic -std=gnu++0x \
         '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-graphicsmagick.exe' \
-        `'$(TARGET)-pkg-config' GraphicsMagick++ --cflags --libs` -llzma
+        `'$(TARGET)-pkg-config' GraphicsMagick++ --cflags --libs`
 endef


### PR DESCRIPTION
The current MXE build of GraphicsMagick is unusable for several reasons.

The attached patch fixes those issues, while also upgrading from 1.3.33 to 1.3.36.

The improved patch is also offered upstream: https://sourceforge.net/p/graphicsmagick/bugs/154/