### PR TITLE
Fix TIFF support of GraphicsMagick

### DIFF
--- a/src/graphicsmagick-1-fixes.patch
+++ b/src/graphicsmagick-1-fixes.patch
@@ -18,7 +18,7 @@ index 1111111..2222222 100644
  Name: GraphicsMagick
  Version: @PACKAGE_VERSION@
  Description: GraphicsMagick image processing library
-+Requires.private: libxml-2.0
++Requires.private: libxml-2.0 libtiff-4
  Libs: -L${libdir} -lGraphicsMagick
 +Libs.private: @MAGICK_API_LDFLAGS@ @MAGICK_API_LIBS@
  Cflags: -I${includedir} @MAGICK_API_PC_CPPFLAGS@

--- a/src/graphicsmagick.mk
+++ b/src/graphicsmagick.mk
@@ -43,6 +43,7 @@ define $(PKG)_BUILD
         --with-zlib \
         --without-x \
         ac_cv_path_xml2_config='$(PREFIX)/$(TARGET)/bin/xml2-config' \
+        LIBS="`'$(TARGET)-pkg-config' libtiff-4 --libs | $(SED) s/-ltiff//`" \
         $(PKG_CONFIGURE_OPTS)
     $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)' bin_PROGRAMS=
     $(MAKE) -C '$(BUILD_DIR)' -j 1 install bin_PROGRAMS=


### PR DESCRIPTION
Currently, on static builds, GraphicsMagick is compiled without TIFF support, as the TIFF check fails:

```
...
checking tiff.h usability... yes
checking tiff.h presence... yes
checking for tiff.h... yes
checking tiffio.h usability... yes
checking tiffio.h presence... yes
checking for tiffio.h... yes
checking for TIFFOpen in -ltiff... no
checking for TIFFClientOpen in -ltiff... no
checking for TIFFIsByteSwapped in -ltiff... no
checking for TIFFReadRGBATile in -ltiff... no
checking for TIFFReadRGBAStrip in -ltiff... no
checking if TIFF package is complete... no -- some components failed test
...
Option            Configure option              Configured value
-----------------------------------------------------------------
Shared libraries  --enable-shared=no            no
Static libraries  --enable-static=yes           yes
...
TIFF              --with-tiff=yes               no (failed tests)
...
```

Inspection of `config.log` showed that this is due to missing linking to the indirect dependencies of libtiff, such as libwebp.

The deeper reason is that GraphicsMagick doesn't simply use pkg-config, but instead contains manual tests for its libraries, such as libtiff, and those manual checks don't take indirect dependencies into account.

This pull request ensures proper handling of the indirect dependencies through libtiff on static builds.

The improved patch is also offered to upstream: https://sourceforge.net/p/graphicsmagick/bugs/154/