### PR TITLE
libjpeg-turbo: Install files in the correct directories

### DIFF
--- a/src/libjpeg-turbo.mk
+++ b/src/libjpeg-turbo.mk
@@ -21,9 +21,7 @@ define $(PKG)_BUILD
     cd '$(BUILD_DIR)' && $(TARGET)-cmake '$(SOURCE_DIR)' \
         -DENABLE_SHARED=$(CMAKE_SHARED_BOOL) \
         -DENABLE_STATIC=$(CMAKE_STATIC_BOOL) \
-        -DCMAKE_INSTALL_BINDIR='$(PREFIX)/$(TARGET)/bin/$(PKG)' \
-        -DCMAKE_INSTALL_INCLUDEDIR='$(PREFIX)/$(TARGET)/include/$(PKG)' \
-        -DCMAKE_INSTALL_LIBDIR='$(PREFIX)/$(TARGET)/lib/$(PKG)' \
+        -DCMAKE_INSTALL_PREFIX='$(PREFIX)/$(TARGET)' \
         -DCMAKE_ASM_NASM_COMPILER=$(TARGET)-yasm
     $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)'
     $(MAKE) -C '$(BUILD_DIR)' -j 1 install
@@ -31,5 +29,5 @@ define $(PKG)_BUILD
     '$(TARGET)-gcc' \
         -W -Wall -Werror -ansi -pedantic \
         '$(TOP_DIR)/src/jpeg-test.c' -o '$(PREFIX)/$(TARGET)/bin/test-$(PKG).exe' \
-        `'$(TARGET)-pkg-config' '$(PREFIX)/$(TARGET)/lib/$(PKG)/pkgconfig/libjpeg.pc' --cflags --libs`
+        `'$(TARGET)-pkg-config' '$(PREFIX)/$(TARGET)/lib/pkgconfig/libjpeg.pc' --cflags --libs`
 endef


### PR DESCRIPTION
Installing in */libjpeg-turbo is very strange. The package cannot be
built without crafted -I and -L, and even pkgconfig is not installed
with all the other packages.