### PR TITLE
curl: build with schannel support

### DIFF
--- a/src/curl.mk
+++ b/src/curl.mk
@@ -20,7 +20,7 @@ endef
 define $(PKG)_BUILD
     cd '$(BUILD_DIR)' && $(SOURCE_DIR)/configure \
         $(MXE_CONFIGURE_OPTS) \
-        --with-winssl \
+        --with-schannel \
         --without-ssl \
         --with-libidn2 \
         --enable-sspi \


### PR DESCRIPTION
Currently, the curl package specifies `--with-winssl` at configure time. However, in current versions, this got renamed to `--with-schannel` [1]

The old `--with-winssl` parameter is no longing working, which unfortunately currently breaks SSL/TLS support entirely.

[1] https://github.com/curl/curl/blob/master/configure.ac#L146