### PR TITLE
libcomm14cux: Update to 2.1.3

### DIFF
--- a/src/libcomm14cux.mk
+++ b/src/libcomm14cux.mk
@@ -3,9 +3,10 @@
 PKG             := libcomm14cux
 $(PKG)_WEBSITE  := https://github.com/colinbourassa/libcomm14cux/
 $(PKG)_IGNORE   :=
-$(PKG)_VERSION  := 2.1.1
-$(PKG)_CHECKSUM := 4b3d0969e2226a0f3c1250c609858e487631507ed62bf6732ce82f13f0d9fcc9
+$(PKG)_VERSION  := 2.1.3
+$(PKG)_CHECKSUM := 5c7d165ea76d036631489b6ca36431d267f08ebf1749e7c959a8787f355569a0
 $(PKG)_GH_CONF  := colinbourassa/libcomm14cux/releases/latest
+$(PKG)_URL      := https://github.com/colinbourassa/libcomm14cux/archive/$($(PKG)_VERSION).tar.gz
 $(PKG)_DEPS     := cc
 
 define $(PKG)_BUILD


### PR DESCRIPTION
This update for libcomm14cux moves to a version that uses the GNUInstallDirs module for CMake to simplify the installation process using standard definitions of install paths.

The test utility is deliberately excluded from the default build (and the MXE build) because it relies on a special piece of FTDI hardware for testing.