### PR TITLE
Fix the host GCC to find the driver on MinGW builds

### DIFF
--- a/plugins/gcc10/gcc10-1-driver-access-fix.diff
+++ b/plugins/gcc10/gcc10-1-driver-access-fix.diff
@@ -1,0 +1,13 @@
+diff -Nru gcc-10.2.0-orig/config/mh-mingw gcc-10.2.0-patched/config/mh-mingw
+--- gcc-10.2.0-orig/config/mh-mingw	2020-07-23 02:35:16.916379838 -0400
++++ gcc-10.2.0-patched/config/mh-mingw	2021-07-04 03:36:49.987025066 -0400
+@@ -1,7 +1,9 @@
+ # Add -D__USE_MINGW_ACCESS to enable the built compiler to work on Windows
+ # Vista (see PR33281 for details).
+ BOOT_CFLAGS += -D__USE_MINGW_ACCESS -Wno-pedantic-ms-format
++BOOT_CXXFLAGS += -D__USE_MINGW_ACCESS -Wno-pedantic-ms-format
+ CFLAGS += -D__USE_MINGW_ACCESS
++CXXFLAGS += -D__USE_MINGW_ACCESS
+ STAGE1_CXXFLAGS += -D__USE_MINGW_ACCESS
+ STAGE2_CXXFLAGS += -D__USE_MINGW_ACCESS
+ STAGE3_CXXFLAGS += -D__USE_MINGW_ACCESS

--- a/plugins/gcc10/gcc10-overlay.mk
+++ b/plugins/gcc10/gcc10-overlay.mk
@@ -32,7 +32,8 @@ $(PKG)_SUBDIR   := gcc-$($(PKG)_VERSION)
 $(PKG)_FILE     := gcc-$($(PKG)_VERSION).tar.xz
 $(PKG)_URL      := https://ftp.gnu.org/gnu/gcc/gcc-$($(PKG)_VERSION)/$($(PKG)_FILE)
 $(PKG)_URL_2    := https://www.mirrorservice.org/sites/sourceware.org/pub/gcc/releases/gcc-$($(PKG)_VERSION)/$($(PKG)_FILE)
-$(PKG)_PATCHES  := $(dir $(lastword $(MAKEFILE_LIST)))/gcc10.patch
+$(PKG)_PATCHES  := $(dir $(lastword $(MAKEFILE_LIST)))/gcc10.patch \
+                   $(dir $(lastword $(MAKEFILE_LIST)))/gcc10-1-driver-access-fix.diff
 $(PKG)_DEPS     := binutils mingw-w64 $(addprefix $(BUILD)~,gmp isl mpc mpfr zstd)
 
 _$(PKG)_CONFIGURE_OPTS = --with-zstd='$(PREFIX)/$(BUILD)'


### PR DESCRIPTION
This trivial GCC 10 patch fixes the host toolchain to find the driver (cc1, ...). This is originally from Martin Storsjo, added to GCC 11 (https://gcc.gnu.org/pipermail/gcc-patches/2021-April/567815.html), but not GCC 10.

More details: GCC 10 driver is compiled with g++ without-D__USE_MINGW_ACCESS on MinGW. That option is only added to CFLAGS, but not CXXFLAGS. Consequently, the driver will not find executables such as cc1, because access(,X_OK) will always return an error on Windows, as access() on Windows does not check for executability anymore. With __USE_MINGW_ACCESS, MinGW will use its own implementation of access() which for X_OK behaves the same as R_OK.

Reported to GCC via https://gcc.gnu.org/bugzilla/show_bug.cgi?id=101238 and https://gcc.gnu.org/pipermail/gcc-patches/2021-July/574404.html.