### PR TITLE
Apply binutils patches also in the host build.

### DIFF
--- a/plugins/examples/host-toolchain/binutils-host.mk
+++ b/plugins/examples/host-toolchain/binutils-host.mk
@@ -6,6 +6,7 @@ $(PKG)_VERSION   = $(binutils_VERSION)
 $(PKG)_CHECKSUM  = $(binutils_CHECKSUM)
 $(PKG)_SUBDIR    = $(binutils_SUBDIR)
 $(PKG)_FILE      = $(binutils_FILE)
+$(PKG)_PATCHES   = $(binutils_PATCHES)
 $(PKG)_URL       = $(binutils_URL)
 $(PKG)_URL_2     = $(binutils_URL_2)
 $(PKG)_DEPS     := cc


### PR DESCRIPTION
This change makes sure that binutils-host uses patches defined (in other .mk files) for binutils.

This is needed e.g. when building the host toolchain - gcc10. The gcc10 plugin defines a patch for binutils 2.36.1 to prevent linking errors such as `relocation truncated to fit: IMAGE_REL_AMD64_REL32 against undefined symbol ...`, but binutils-host needs to use that definition to make sure the patch is applied, otherwise the error appears when linking using the host linker.
