### PR TITLE
Added libgphoto2

### DIFF
--- a/src/libgphoto2-1.patch
+++ b/src/libgphoto2-1.patch
@@ -1,0 +1,72 @@
+diff --git a/camlibs/lumix/lumix.c b/camlibs/lumix/lumix.c
+index d72da46..c8177d9 100644
+--- a/camlibs/lumix/lumix.c
++++ b/camlibs/lumix/lumix.c
+@@ -36,10 +36,15 @@
+ #include <libxml/xmlreader.h>
+ 
+ 
+-#include <sys/socket.h>
++#ifdef WIN32
++# include <winsock2.h>
++# include <ws2tcpip.h>
++#else
++# include <sys/socket.h>
++# include <netinet/in.h>
++# include <arpa/inet.h>
++#endif
+ #include <stdlib.h>
+-#include <netinet/in.h>
+-#include <arpa/inet.h>
+ 
+ 
+ #include <gphoto2/gphoto2-library.h>
+diff --git a/camlibs/st2205/Makefile-files b/camlibs/st2205/Makefile-files
+index 93a1efb..8a85bfb 100644
+--- a/camlibs/st2205/Makefile-files
++++ b/camlibs/st2205/Makefile-files
+@@ -10,3 +10,7 @@ st2205_la_LDFLAGS = $(camlib_ldflags)
+ st2205_la_DEPENDENCIES = $(camlib_dependencies)
+ st2205_la_LIBADD = $(camlib_libadd) @LIBGD_LIBS@ $(LTLIBICONV)
+ st2205_la_CFLAGS = @LIBGD_CFLAGS@
++
++# On systems such as mingw/Windows, mmap(2) is not part of the
++# standard library and needs an explicit library to link against.
++st2205_la_LIBADD += $(MMAP_LIBS)
+diff --git a/configure.ac b/configure.ac
+index 4b5e12d..c43df13 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -378,6 +378,19 @@ AC_HEADER_DIRENT
+ AC_HEADER_STDC
+ # after _HEADER_STDC
+ AC_CHECK_HEADERS([sys/param.h sys/mman.h sys/select.h locale.h memory.h getopt.h unistd.h mcheck.h limits.h sys/time.h langinfo.h])
++
++dnl If sys/mman.h is present, check whether mmap requires the mman
++dnl library (see camlibs/st2205/st2205.c st2205_malloc_page_aligned()).
++MMAP_LIBS=""
++AS_VAR_IF([ac_cv_header_sys_mman_h], [yes], [dnl
++gp_saved_LIBS="$LIBS"
++LIBS=""
++AC_SEARCH_LIBS([mmap], [mman])
++MMAP_LIBS="$LIBS"
++LIBS="$gp_saved_LIBS"
++])dnl
++AC_SUBST([MMAP_LIBS])
++
+ AC_C_INLINE([])
+ AC_C_CONST([])
+ dnl FIXME: AC_STRUCT_TIMEZONE
+diff --git a/libgphoto2/gphoto2-setting.c b/libgphoto2/gphoto2-setting.c
+index cfe2438..0a5b770 100644
+--- a/libgphoto2/gphoto2-setting.c
++++ b/libgphoto2/gphoto2-setting.c
+@@ -37,7 +37,7 @@
+ #ifdef WIN32
+ /* Win32 headers may use interface as a define; temporarily correct this */
+ #define interface struct
+-#include <Shlobj.h>
++#include <shlobj.h>
+ #undef interface
+ #endif
+ 

--- a/src/libgphoto2-2.patch
+++ b/src/libgphoto2-2.patch
@@ -1,0 +1,90 @@
+diff --git a/configure b/configure
+index 0382145..da5e49d 100755
+--- a/configure
++++ b/configure
+@@ -23815,7 +23815,6 @@ fi
+ { $as_echo "$as_me:${as_lineno-$LINENO}: result: ${camlibdir}" >&5
+ $as_echo "${camlibdir}" >&6; }
+ 
+-AM_CPPFLAGS="$AM_CPPFLAGS -DCAMLIBS=\\\"\$(camlibdir)\\\""
+ 
+ 
+ # Extract the first word of "cmp", so it can be a program name with args.
+diff --git a/configure.ac b/configure.ac
+index 4b5e12d..f89055e 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -521,7 +534,6 @@ AC_ARG_WITH([camlibdir],[AS_HELP_STRING(
+ ])
+ AC_MSG_RESULT([${camlibdir}])
+ AC_SUBST([camlibdir])
+-AM_CPPFLAGS="$AM_CPPFLAGS -DCAMLIBS=\\\"\$(camlibdir)\\\""
+ 
+ 
+ dnl ---------------------------------------------------------------------------
+diff --git a/gphoto2/gphoto2-abilities-list.h b/gphoto2/gphoto2-abilities-list.h
+index 58eb3d0..e92836f 100644
+--- a/gphoto2/gphoto2-abilities-list.h
++++ b/gphoto2/gphoto2-abilities-list.h
+@@ -196,6 +196,11 @@ const char *gp_message_codeset (const char *);
+  */
+ #ifdef _GPHOTO2_INTERNAL_CODE
+ #define CAMLIBDIR_ENV "CAMLIBS"
++#ifdef WIN32
++#ifndef CAMLIBS
++#define CAMLIBS "./libgphoto2"
++#endif
++#endif
+ #endif /* _GPHOTO2_INTERNAL_CODE */
+ 
+ 
+diff --git a/gphoto2/gphoto2.h b/gphoto2/gphoto2.h
+index 9bb6ba9..7654134 100644
+--- a/gphoto2/gphoto2.h
++++ b/gphoto2/gphoto2.h
+@@ -39,7 +39,7 @@ extern "C" {
+ 
+ #ifdef WIN32
+ #ifndef CAMLIBS
+-#define CAMLIBS "."
++#define CAMLIBS "./libgphoto2"
+ #endif
+ #endif
+ 
+diff --git a/libgphoto2_port/configure b/libgphoto2_port/configure
+index 10ef797..9decad8 100755
+--- a/libgphoto2_port/configure
++++ b/libgphoto2_port/configure
+@@ -17493,7 +17493,6 @@ done
+ 
+ iolibdir="\$(libdir)/\$(PACKAGE_TARNAME)/\$(VERSION)"
+ 
+-AM_CPPFLAGS="$AM_CPPFLAGS -DIOLIBS=\\\"${iolibdir}\\\""
+ 
+ sorted_iolib_list="$(echo "${IOLIB_LIST}" | tr ' ' '\n' | sort | ${SED} '/^$/d' | tr '\n' ' ' | ${SED} 's/ $//')"
+ 
+diff --git a/libgphoto2_port/configure.ac b/libgphoto2_port/configure.ac
+index c9ab924..3ba281b 100644
+--- a/libgphoto2_port/configure.ac
++++ b/libgphoto2_port/configure.ac
+@@ -468,7 +468,6 @@ for x in ${IOLIB_LIST}; do
+ done
+ AC_SUBST(IOLIB_LTLIST)
+ AC_SUBST([iolibdir],["\$(libdir)/\$(PACKAGE_TARNAME)/\$(VERSION)"])
+-AM_CPPFLAGS="$AM_CPPFLAGS -DIOLIBS=\\\"${iolibdir}\\\""
+ 
+ sorted_iolib_list="$(echo "${IOLIB_LIST}" | tr ' ' '\n' | sort | ${SED} '/^$/d' | tr '\n' ' ' | ${SED} 's/ $//')"
+ AC_DEFINE_UNQUOTED([IOLIB_LIST], ["${sorted_iolib_list}"], [Define as string containing a list of the iolibs])
+diff --git a/libgphoto2_port/gphoto2/gphoto2-port-portability.h b/libgphoto2_port/gphoto2/gphoto2-port-portability.h
+index 1a8cdc1..bdf8147 100644
+--- a/libgphoto2_port/gphoto2/gphoto2-port-portability.h
++++ b/libgphoto2_port/gphoto2/gphoto2-port-portability.h
+@@ -38,7 +38,7 @@
+ # include <direct.h>
+ 
+ # ifndef IOLIBS
+-#  define IOLIBS			"."
++#  define IOLIBS		"./libgphoto2_port"
+ # endif
+ # define strcasecmp		_stricmp
+ # ifndef snprintf

--- a/src/libgphoto2-test.c
+++ b/src/libgphoto2-test.c
@@ -1,0 +1,16 @@
+/*
+ * This file is part of MXE. See LICENSE.md for licensing information.
+ */
+
+#include <gphoto2/gphoto2-camera.h>
+
+
+int main(int argc, char *argv[])
+{
+    Camera *camera;
+
+    gp_camera_new(&camera);
+    gp_camera_unref(camera);
+
+    return 0;
+}

--- a/src/libgphoto2.mk
+++ b/src/libgphoto2.mk
@@ -1,0 +1,23 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+PKG             := libgphoto2
+$(PKG)_WEBSITE  := https://github.com/gphoto/libgphoto2
+$(PKG)_DESCR    := libgphoto2
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 2.5.27
+$(PKG)_CHECKSUM := fd48f6f58259ba199e834010aca0af3672ca0223ed0a98ba89ec693a415f242a
+$(PKG)_GH_CONF  := gphoto/libgphoto2/releases, v
+$(PKG)_DEPS     := cc curl libltdl libxml2 libusb1 libexif
+
+define $(PKG)_BUILD
+    cd '$(BUILD_DIR)' && '$(SOURCE_DIR)/configure' \
+        PKG_CONFIG='$(PREFIX)/bin/$(TARGET)-pkg-config' \
+        $(MXE_CONFIGURE_OPTS) \
+        $(PKG_CONFIGURE_OPTS)
+    $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)'
+    $(MAKE) -C '$(BUILD_DIR)' install
+
+    '$(TARGET)-gcc' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-$(PKG).exe' \
+        `'$(TARGET)-pkg-config' libgphoto2 --cflags --libs`
+endef


### PR DESCRIPTION
The patch libgphoto2-1.patch was PR upstream:
https://github.com/gphoto/libgphoto2/pull/698

Signed-off-by: Jaroslav Škarvada <jskarvad@redhat.com>

Please read http://mxe.cc/#creating-packages

In particular, make sure that your build rules:

  * install .pc file,
  * install bin/test-pkg.exe compiled with flags by pkg-config,
  * install .dll to bin/ and .a, .dll.a to lib/,
  * use $(TARGET)-cmake instead of cmake,
  * build in `$(BUILD_DIR)` instead of `$(SOURCE_DIR)`,
  * do not run target executables with Wine,
  * do not download anything while building,
  * do not install documentation,
  * do not install .exe files except test and build systems,

and .patch files are generated by tools/patch-tool-mxe.

If you add a package, you can use tool tools/skeleton.py.

Thanks!
