### PR TITLE
Added libexif

### DIFF
--- a/src/libexif-test.c
+++ b/src/libexif-test.c
@@ -1,0 +1,15 @@
+/*
+ * This file is part of MXE. See LICENSE.md for licensing information.
+ */
+
+#include <libexif/exif-loader.h>
+
+int main(int argc, char *argv[])
+{
+    ExifLoader *l;
+
+    l = exif_loader_new();
+    exif_loader_unref(l);
+
+    return 0;
+}

--- a/src/libexif.mk
+++ b/src/libexif.mk
@@ -1,0 +1,23 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+PKG             := libexif
+$(PKG)_WEBSITE  := https://github.com/libexif/libexif
+$(PKG)_DESCR    := libexif
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 0.6.22
+$(PKG)_CHECKSUM := 46498934b7b931526fdee8fd8eb77a1dddedd529d5a6dbce88daf4384baecc54
+$(PKG)_GH_CONF  := libexif/libexif/releases, libexif-,-release,,_
+$(PKG)_DEPS     := cc
+
+define $(PKG)_BUILD
+    cd '$(SOURCE_DIR)' && autoreconf -fi
+    cd '$(BUILD_DIR)' && '$(SOURCE_DIR)/configure' \
+        $(MXE_CONFIGURE_OPTS) \
+        $(PKG_CONFIGURE_OPTS)
+    $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)'
+    $(MAKE) -C '$(BUILD_DIR)' install
+
+    '$(TARGET)-gcc' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-$(PKG).exe' \
+        `'$(TARGET)-pkg-config' libexif --cflags --libs`
+endef


### PR DESCRIPTION
Signed-off-by: Jaroslav Škarvada <jskarvad@redhat.com>

Please read http://mxe.cc/#creating-packages

In particular, make sure that your build rules:

  * install .pc file,
  * install bin/test-pkg.exe compiled with flags by pkg-config,
  * install .dll to bin/ and .a, .dll.a to lib/,
  * use $(TARGET)-cmake instead of cmake,
  * build in `$(BUILD_DIR)` instead of `$(SOURCE_DIR)`,
  * do not run target executables with Wine,
  * do not download anything while building,
  * do not install documentation,
  * do not install .exe files except test and build systems,

and .patch files are generated by tools/patch-tool-mxe.

If you add a package, you can use tool tools/skeleton.py.

Thanks!
