### PR TITLE
Update sqlcipher to version 4.4.3

### DIFF
--- a/src/sqlcipher-1-fixes.patch
+++ b/src/sqlcipher-1-fixes.patch
@@ -2,24 +2,17 @@ This file is part of MXE. See LICENSE.md for licensing information.
 
 Contains ad hoc patches for cross building.
 
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Your Name <you@example.com>
-Date: Wed, 27 Sep 2017 15:26:44 +0000
-Subject: [PATCH 1/1] fix dependency
 
-Source:
-https://github.com/Alexpux/MINGW-packages/blob/f083f27fb163b68673d5ac649fae353f44b49c7d/mingw-w64-sqlcipher/01-fix_dep.diff
-
-diff --git a/Makefile.in b/Makefile.in
-index 1111111..2222222 100644
---- a/Makefile.in
-+++ b/Makefile.in
-@@ -1074,7 +1074,7 @@ FTS5_SRC = \
-    $(TOP)/ext/fts5/fts5_varint.c \
-    $(TOP)/ext/fts5/fts5_vocab.c  \
- 
--fts5parse.c:	$(TOP)/ext/fts5/fts5parse.y lemon 
-+fts5parse.c:	$(TOP)/ext/fts5/fts5parse.y lemon$(BEXE)
- 	cp $(TOP)/ext/fts5/fts5parse.y .
- 	rm -f fts5parse.h
- 	./lemon$(BEXE) $(OPTS) fts5parse.y
+diff --git a/configure.ac b/configure.ac
+index ef21298..c77f794 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -312,7 +319,7 @@ fi
+ if test "$CYGWIN" = "yes"; then
+   BUILD_EXEEXT=.exe
+ else
+-  BUILD_EXEEXT=$EXEEXT
++  BUILD_EXEEXT=''
+ fi
+ if test x"$cross_compiling" = xno; then
+   TARGET_EXEEXT=$BUILD_EXEEXT

--- a/src/sqlcipher.mk
+++ b/src/sqlcipher.mk
@@ -4,16 +4,17 @@ PKG             := sqlcipher
 $(PKG)_WEBSITE  := https://www.zetetic.net/sqlcipher/
 $(PKG)_DESCR    := SQLite extension that provides 256 bit AES encryption of database files
 $(PKG)_IGNORE   :=
-$(PKG)_VERSION  := 3.4.2
-$(PKG)_CHECKSUM := 69897a5167f34e8a84c7069f1b283aba88cdfa8ec183165c4a5da2c816cfaadb
+$(PKG)_VERSION  := 4.4.3
+$(PKG)_CHECKSUM := b8df69b998c042ce7f8a99f07cf11f45dfebe51110ef92de95f1728358853133
 $(PKG)_GH_CONF  := sqlcipher/sqlcipher/tags, v
+$(PKG)_URL      := https://github.com/sqlcipher/sqlcipher/archive/refs/tags/v$($(PKG)_VERSION).tar.gz
 $(PKG)_DEPS     := cc openssl readline $(BUILD)~tcl
 
 define $(PKG)_BUILD
     # build and install the library
-    cd '$(BUILD_DIR)' && $(SOURCE_DIR)/configure \
+    cd '$(BUILD_DIR)' && autoreconf -ivf $(SOURCE_DIR) && $(SOURCE_DIR)/configure \
         "LIBS=$$($(TARGET)-pkg-config --libs libcrypto)" \
-        "CFLAGS=-DSQLITE_HAS_CODEC" \
+        "CFLAGS=-DSQLITE_HAS_CODEC -DSQLITE_ENABLE_COLUMN_METADATA" \
         config_BUILD_EXEEXT='' \
         config_TARGET_EXEEXT='.exe' \
         --enable-tempstore=yes \


### PR DESCRIPTION
Update to latest available sqlcipher version.
Add patch to fix cross building.
This patch also can be used to build sqlite package from "sqlite-src-*.zip" — Snapshot of the complete (raw) source tree for SQLite.
Instead of "sqlite-autoconf-*.tar.gz" —  C source code as an amalgamation.

Add SQLITE_ENABLE_COLUMN_METADATA compile time definition to make available functions
```
sqlite3_column_database_name()
sqlite3_column_database_name16()
sqlite3_column_table_name()
sqlite3_column_table_name16()
sqlite3_column_origin_name()
sqlite3_column_origin_name16()
```

which are used for example in QtSqlite (and based on it QtSqlcipher) plugin.
This CFLAG also declared in sqlite package.