### PR TITLE
meson-wrapper: add sys_root and pkg_config_libdir

### DIFF
--- a/plugins/meson-wrapper/conf/mxe-crossfile.meson.in
+++ b/plugins/meson-wrapper/conf/mxe-crossfile.meson.in
@@ -15,6 +15,8 @@ pkgconfig = '@PREFIX@/bin/@TARGET@-pkg-config'
 
 [properties]
 needs_exe_wrapper = true
+sys_root = '@PREFIX@/@TARGET@'
+pkg_config_libdir = '@PREFIX@/@TARGET@/lib/pkgconfig'
 
 [host_machine]
 system = 'windows'


### PR DESCRIPTION
Those are available in newer versions of meson.