### PR TITLE
Add a plugin for targeting Windows XP

### DIFF
--- a/plugins/windows-xp/gcc-overlay.mk
+++ b/plugins/windows-xp/gcc-overlay.mk
@@ -1,0 +1,4 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+mingw-w64-headers_CONFIGURE_OPTS = --with-default-win32-winnt=0x0501
+mingw-w64-crt_CONFIGURE_OPTS = --with-default-win32-winnt=0x0501


### PR DESCRIPTION
Since commit 87a9b83dcf7d1650149e1d24f490d70405ddba1f, the minimum version of Windows for standard MXE builds is set to Windows Vista, however a number of libraries (including winpthreads) disable Vista-specific APIs when `_WIN32_WINNT` is defined to a lower version, which makes this useful to have as a plugin.