### PR TITLE
gdal 2.2.4: Support for openjpeg 2.4

### DIFF
--- a/src/gdal-1-fixes.patch
+++ b/src/gdal-1-fixes.patch
@@ -14,7 +14,7 @@ diff --git a/configure.ac b/configure.ac
 index 1111111..2222222 100644
 --- a/configure.ac
 +++ b/configure.ac
-@@ -1124,7 +1124,7 @@ else
+@@ -1124,7 +1124,7 @@
  
    AC_MSG_RESULT([yes])
  
@@ -23,7 +23,95 @@ index 1111111..2222222 100644
  
    if test "${HAVE_PG}" = "yes" ; then
      LIBS=-L`$PG_CONFIG --libdir`" -lpq $LIBS"
-@@ -3557,16 +3557,21 @@ AC_ARG_WITH(spatialite-soname,
+@@ -2539,39 +2539,47 @@
+ 
+ elif test "$with_openjpeg" = "yes" -o "$with_openjpeg" = "" ; then
+ 
+-
+-  AC_CHECK_HEADERS([openjpeg-2.3/openjpeg.h])
+-  if test "$ac_cv_header_openjpeg_2_3_openjpeg_h" = "yes"; then
++  AC_CHECK_HEADERS([openjpeg-2.4/openjpeg.h])
++  if test "$ac_cv_header_openjpeg_2_4_openjpeg_h" = "yes"; then
+     AC_CHECK_LIB(openjp2,opj_stream_set_user_data_length,HAVE_OPENJPEG=yes,HAVE_OPENJPEG=no,)
+     if test "$HAVE_OPENJPEG" = "yes"; then
+-        OPENJPEG_VERSION=20300
++        OPENJPEG_VERSION=20400
+         LIBS="-lopenjp2 $LIBS"
+     fi
+   else
+-    AC_CHECK_HEADERS([openjpeg-2.2/openjpeg.h])
+-    if test "$ac_cv_header_openjpeg_2_2_openjpeg_h" = "yes"; then
+-        AC_CHECK_LIB(openjp2,opj_stream_set_user_data_length,HAVE_OPENJPEG=yes,HAVE_OPENJPEG=no,)
+-        if test "$HAVE_OPENJPEG" = "yes"; then
+-            OPENJPEG_VERSION=20200
+-            LIBS="-lopenjp2 $LIBS"
+-        fi
++    AC_CHECK_HEADERS([openjpeg-2.3/openjpeg.h])
++    if test "$ac_cv_header_openjpeg_2_3_openjpeg_h" = "yes"; then
++      AC_CHECK_LIB(openjp2,opj_stream_set_user_data_length,HAVE_OPENJPEG=yes,HAVE_OPENJPEG=no,)
++      if test "$HAVE_OPENJPEG" = "yes"; then
++          OPENJPEG_VERSION=20300
++          LIBS="-lopenjp2 $LIBS"
++      fi
+     else
+-        AC_CHECK_HEADERS([openjpeg-2.1/openjpeg.h])
+-        if test "$ac_cv_header_openjpeg_2_1_openjpeg_h" = "yes"; then
+-            AC_CHECK_LIB(openjp2,opj_stream_set_user_data_length,HAVE_OPENJPEG=yes,HAVE_OPENJPEG=no,)
+-            if test "$HAVE_OPENJPEG" = "yes"; then
+-                OPENJPEG_VERSION=20100
+-                LIBS="-lopenjp2 $LIBS"
+-            fi
+-        else
+-            AC_CHECK_HEADERS([openjpeg-2.0/openjpeg.h])
+-            if test "$ac_cv_header_openjpeg_2_0_openjpeg_h" = "yes"; then
+-                AC_CHECK_LIB(openjp2,opj_stream_set_user_data_length,HAVE_OPENJPEG=yes,HAVE_OPENJPEG=no,)
+-                if test "$HAVE_OPENJPEG" = "yes"; then
+-                    LIBS="-lopenjp2 $LIBS"
+-                fi
+-            fi
+-        fi
++      AC_CHECK_HEADERS([openjpeg-2.2/openjpeg.h])
++      if test "$ac_cv_header_openjpeg_2_2_openjpeg_h" = "yes"; then
++          AC_CHECK_LIB(openjp2,opj_stream_set_user_data_length,HAVE_OPENJPEG=yes,HAVE_OPENJPEG=no,)
++          if test "$HAVE_OPENJPEG" = "yes"; then
++              OPENJPEG_VERSION=20200
++              LIBS="-lopenjp2 $LIBS"
++          fi
++      else
++          AC_CHECK_HEADERS([openjpeg-2.1/openjpeg.h])
++          if test "$ac_cv_header_openjpeg_2_1_openjpeg_h" = "yes"; then
++              AC_CHECK_LIB(openjp2,opj_stream_set_user_data_length,HAVE_OPENJPEG=yes,HAVE_OPENJPEG=no,)
++              if test "$HAVE_OPENJPEG" = "yes"; then
++                  OPENJPEG_VERSION=20100
++                  LIBS="-lopenjp2 $LIBS"
++              fi
++          else
++              AC_CHECK_HEADERS([openjpeg-2.0/openjpeg.h])
++              if test "$ac_cv_header_openjpeg_2_0_openjpeg_h" = "yes"; then
++                  AC_CHECK_LIB(openjp2,opj_stream_set_user_data_length,HAVE_OPENJPEG=yes,HAVE_OPENJPEG=no,)
++                  if test "$HAVE_OPENJPEG" = "yes"; then
++                      LIBS="-lopenjp2 $LIBS"
++                  fi
++              fi
++          fi
++      fi
+     fi
+   fi
+ else
+@@ -2588,8 +2596,11 @@
+   elif test -r $with_openjpeg/include/openjpeg-2.3/openjpeg.h ; then
+     OPENJPEG_VERSION=20300
+     EXTRA_INCLUDES="-I$with_openjpeg/include $EXTRA_INCLUDES"
++  elif test -r $with_openjpeg/include/openjpeg-2.4/openjpeg.h ; then
++    OPENJPEG_VERSION=20400
++    EXTRA_INCLUDES="-I$with_openjpeg/include $EXTRA_INCLUDES"
+   else
+-    AC_MSG_ERROR([openjpeg.h not found in $with_openjpeg/include/openjpeg-2.0 or $with_openjpeg/include/openjpeg-2.1 or $with_openjpeg/include/openjpeg-2.2 or $with_openjpeg/include/openjpeg-2.3])
++    AC_MSG_ERROR([openjpeg.h not found in $with_openjpeg/include/openjpeg-2.0 or $with_openjpeg/include/openjpeg-2.1 or $with_openjpeg/include/openjpeg-2.2 or $with_openjpeg/include/openjpeg-2.3 or $with_openjpeg/include/openjpeg-2.4])
+   fi
+ 
+   AC_CHECK_LIB(openjp2,opj_stream_set_user_data_length,HAVE_OPENJPEG=yes,HAVE_OPENJPEG=no,-L$with_openjpeg/lib)
+@@ -3598,16 +3609,21 @@
  
  HAVE_SPATIALITE=no
  SPATIALITE_AMALGAMATION=no
@@ -93,3 +181,20 @@ index 1111111..2222222 100644
  #elif defined(__APPLE__)
  #  define LIBNAME "libproj.dylib"
  #else
+
+
+diff --git a/frmts/openjpeg/openjpegdataset.cpp b/frmts/openjpeg/openjpegdataset.cpp
+index 1111111..2222222 100644
+--- a/frmts/openjpeg/openjpegdataset.cpp
++++ b/frmts/openjpeg/openjpegdataset.cpp
+@@ -34,7 +34,9 @@
+ #pragma clang diagnostic ignored "-Wdocumentation"
+ #endif
+ 
+-#if defined(OPENJPEG_VERSION) && OPENJPEG_VERSION >= 20300
++#if defined(OPENJPEG_VERSION) && OPENJPEG_VERSION >= 20400
++#include <openjpeg-2.4/openjpeg.h>
++#elif defined(OPENJPEG_VERSION) && OPENJPEG_VERSION >= 20300
+ #include <openjpeg-2.3/openjpeg.h>
+ #elif defined(OPENJPEG_VERSION) && OPENJPEG_VERSION >= 20200
+ #include <openjpeg-2.2/openjpeg.h>


### PR DESCRIPTION
This PR updates `src/gdal-1-fixes.patch` so that it supports openjpeg 2.4. `configure.ac` and `frmts/openjpeg/openjpegdataset.cpp` will be patched.