### PR TITLE
docs: add Libretro/Retroarch to "used by"

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -3200,6 +3200,9 @@ endef</pre>
         <a href="https://krita.org/">Krita</a>
     </li>
     <li>
+        <a href="https://www.retroarch.com/">Libretro/RetroArch</a>
+    </li>
+    <li>
         <a href="https://lightspark.github.io/">Lightspark</a>
     </li>
     <li>


### PR DESCRIPTION
Libretro and RetroArch (https://www.retroarch.com/) now switched from Windows/msys2 to Linux/MXE for their Windows builds. Libretro is a huge project, so it's worth putting it on the list.