### PR TITLE
patch-tool-mxe: provide message when calling "git tag"

### DIFF
--- a/mxe.patch.mk
+++ b/mxe.patch.mk
@@ -27,7 +27,7 @@ define INIT_GIT
     $(call GIT_CMD,$(1)) init
     $(call GIT_CMD,$(1)) add -A -f
     $(call GIT_CMD,$(1)) commit -m "init"
-    $(call GIT_CMD,$(1)) tag dist
+    $(call GIT_CMD,$(1)) tag -m "dist" dist
 endef
 
 define IMPORT_PATCH


### PR DESCRIPTION
`git tag something` will invoke the editor. As the editor is invoked
via `make`, it doesn't have a TTY to display stuff on. In the case of
`vim`, this means `vim` hangs in the background indefinitely, as does
`make` waiting for `vim` to finish. The user has no way to interact
with that editor instance, having to kill it, which in turn causes
`git tag` and ultimately `make` to fail.

Fixes #2739.
