### PR TITLE
Add a dummy lld package

### DIFF
--- a/src/lld.mk
+++ b/src/lld.mk
@@ -1,0 +1,10 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+PKG             := lld
+$(PKG)_WEBSITE  := https://lld.llvm.org
+$(PKG)_DESCR    := LLD Linker on host OS
+$(PKG)_VERSION  := system
+
+define $(PKG)_BUILD
+    ln -s /usr/bin/ld.lld '$(MXE_PREFIX_DIR)/bin/$(TARGET)-ld.lld'
+endef


### PR DESCRIPTION
Links with lld on the host OS. LLD is target-agnostic, so it "just works".
No need to build it separately for each target.

Can be used by passing -fuse-ld=lld to GCC.