### PR TITLE
add patch to fix llvm build under gcc11

### DIFF
--- a/src/llvm-2-fixes.patch
+++ b/src/llvm-2-fixes.patch
@@ -1,0 +1,11 @@
+diff -ur a/utils/benchmark/src/benchmark_register.h b/utils/benchmark/src/benchmark_register.h
+--- a/utils/benchmark/src/benchmark_register.h	2022-02-19 21:31:50.105686911 +0000
++++ b/utils/benchmark/src/benchmark_register.h	2022-02-19 21:34:02.034890853 +0000
+@@ -2,6 +2,7 @@
+ #define BENCHMARK_REGISTER_H
+ 
+ #include <vector>
++#include <limits>
+ 
+ #include "check.h"
+ 


### PR DESCRIPTION
Fix the following build error in llvm under the new gcc11

```
[ 99%] ^[[32mBuilding CXX object utils/benchmark/src/CMakeFiles/benchmark.dir/benchmark_register.cc.obj^[[0m
cd /local2/mxe/tmp-llvm-x86_64-w64-mingw32.shared.posix/llvm-10.0.0.src.build_/utils/benchmark/src && /local2/mxe/usr/bin/x86_64-w64-mingw32.shared.posix-g++ -DHAVE_STD_REGEX -DHAVE_STEADY_CLOCK -D_FILE_OFFSET_BITS=64 -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__\
\
STDC_LIMIT_MACROS -Dbenchmark_EXPORTS @CMakeFiles/benchmark.dir/includes_CXX.rsp -Wa,-mbig-obj -Werror=date-time -Wall -Wextra -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wno-missing-field-initializers -pedantic -Wno-long-long -Wimplicit-fallthrough -Wno-maybe-un\
\
initialized -Wno-class-memaccess -Wno-redundant-move -Wno-noexcept-type -Wdelete-non-virtual-dtor -Wno-comment  -std=c++11  -Wall  -Wextra  -Wshadow  -pedantic  -pedantic-errors  -Wfloat-equal  -fstrict-aliasing  -fno-exceptions  -Wstrict-aliasing  -O2 -DNDEBUG -std=c++\
\
14 -MD -MT utils/benchmark/src/CMakeFiles/benchmark.dir/benchmark_register.cc.obj -MF CMakeFiles/benchmark.dir/benchmark_register.cc.obj.d -o CMakeFiles/benchmark.dir/benchmark_register.cc.obj -c /local2/mxe/tmp-llvm-x86_64-w64-mingw32.shared.posix/llvm-10.0.0.src/utils\
\
/benchmark/src/benchmark_register.cc
In file included from /local2/mxe/tmp-llvm-x86_64-w64-mingw32.shared.posix/llvm-10.0.0.src/utils/benchmark/src/benchmark_register.cc:15:
/local2/mxe/tmp-llvm-x86_64-w64-mingw32.shared.posix/llvm-10.0.0.src/utils/benchmark/src/benchmark_register.h: In function 'void AddRange(std::vector<T>*, T, T, int)':
/local2/mxe/tmp-llvm-x86_64-w64-mingw32.shared.posix/llvm-10.0.0.src/utils/benchmark/src/benchmark_register.h:17:30: error: 'numeric_limits' is not a member of 'std'
   17 |   static const T kmax = std::numeric_limits<T>::max();
      |                              ^~~~~~~~~~~~~~
/local2/mxe/tmp-llvm-x86_64-w64-mingw32.shared.posix/llvm-10.0.0.src/utils/benchmark/src/benchmark_register.h:17:46: error: expected primary-expression before '>' token
   17 |   static const T kmax = std::numeric_limits<T>::max();
      |                                              ^
/local2/mxe/tmp-llvm-x86_64-w64-mingw32.shared.posix/llvm-10.0.0.src/utils/benchmark/src/benchmark_register.h:17:49: error: '::max' has not been declared; did you mean 'std::max'?
   17 |   static const T kmax = std::numeric_limits<T>::max();
      |                                                 ^~~
      |                                                 std::max
In file included from /local2/mxe/usr/lib/gcc/x86_64-w64-mingw32.shared.posix/11.2.0/include/c++/algorithm:62,
                 from /local2/mxe/tmp-llvm-x86_64-w64-mingw32.shared.posix/llvm-10.0.0.src/utils/benchmark/include/benchmark/benchmark.h:175,
                 from /local2/mxe/tmp-llvm-x86_64-w64-mingw32.shared.posix/llvm-10.0.0.src/utils/benchmark/src/internal_macros.h:4,
                 from /local2/mxe/tmp-llvm-x86_64-w64-mingw32.shared.posix/llvm-10.0.0.src/utils/benchmark/src/check.h:8,
                 from /local2/mxe/tmp-llvm-x86_64-w64-mingw32.shared.posix/llvm-10.0.0.src/utils/benchmark/src/benchmark_register.h:6,
                 from /local2/mxe/tmp-llvm-x86_64-w64-mingw32.shared.posix/llvm-10.0.0.src/utils/benchmark/src/benchmark_register.cc:15:
/local2/mxe/usr/lib/gcc/x86_64-w64-mingw32.shared.posix/11.2.0/include/c++/bits/stl_algo.h:3467:5: note: 'std::max' declared here
 3467 |     max(initializer_list<_Tp> __l, _Compare __comp)
      |     ^~~
```
