### PR TITLE
Fix gdal - openjpeg 2.4 incompatibility

### DIFF
--- a/src/gdal-1-fixes.patch
+++ b/src/gdal-1-fixes.patch
@@ -14,7 +14,7 @@ diff --git a/configure.ac b/configure.ac
 index 1111111..2222222 100644
 --- a/configure.ac
 +++ b/configure.ac
-@@ -1124,7 +1124,7 @@ else
+@@ -1124,7 +1124,7 @@
  
    AC_MSG_RESULT([yes])
  
@@ -23,7 +23,95 @@ index 1111111..2222222 100644
  
    if test "${HAVE_PG}" = "yes" ; then
      LIBS=-L`$PG_CONFIG --libdir`" -lpq $LIBS"
-@@ -3557,16 +3557,21 @@ AC_ARG_WITH(spatialite-soname,
+@@ -2539,39 +2539,47 @@
+
+ elif test "$with_openjpeg" = "yes" -o "$with_openjpeg" = "" ; then
+
+-
+-  AC_CHECK_HEADERS([openjpeg-2.3/openjpeg.h])
+-  if test "$ac_cv_header_openjpeg_2_3_openjpeg_h" = "yes"; then
++  AC_CHECK_HEADERS([openjpeg-2.4/openjpeg.h])
++  if test "$ac_cv_header_openjpeg_2_4_openjpeg_h" = "yes"; then
+     AC_CHECK_LIB(openjp2,opj_stream_set_user_data_length,HAVE_OPENJPEG=yes,HAVE_OPENJPEG=no,)
+     if test "$HAVE_OPENJPEG" = "yes"; then
+-        OPENJPEG_VERSION=20300
++        OPENJPEG_VERSION=20400
+         LIBS="-lopenjp2 $LIBS"
+     fi
+   else
+-    AC_CHECK_HEADERS([openjpeg-2.2/openjpeg.h])
+-    if test "$ac_cv_header_openjpeg_2_2_openjpeg_h" = "yes"; then
+-        AC_CHECK_LIB(openjp2,opj_stream_set_user_data_length,HAVE_OPENJPEG=yes,HAVE_OPENJPEG=no,)
+-        if test "$HAVE_OPENJPEG" = "yes"; then
+-            OPENJPEG_VERSION=20200
+-            LIBS="-lopenjp2 $LIBS"
+-        fi
++    AC_CHECK_HEADERS([openjpeg-2.3/openjpeg.h])
++    if test "$ac_cv_header_openjpeg_2_3_openjpeg_h" = "yes"; then
++      AC_CHECK_LIB(openjp2,opj_stream_set_user_data_length,HAVE_OPENJPEG=yes,HAVE_OPENJPEG=no,)
++      if test "$HAVE_OPENJPEG" = "yes"; then
++          OPENJPEG_VERSION=20300
++          LIBS="-lopenjp2 $LIBS"
++      fi
+     else
+-        AC_CHECK_HEADERS([openjpeg-2.1/openjpeg.h])
+-        if test "$ac_cv_header_openjpeg_2_1_openjpeg_h" = "yes"; then
+-            AC_CHECK_LIB(openjp2,opj_stream_set_user_data_length,HAVE_OPENJPEG=yes,HAVE_OPENJPEG=no,)
+-            if test "$HAVE_OPENJPEG" = "yes"; then
+-                OPENJPEG_VERSION=20100
+-                LIBS="-lopenjp2 $LIBS"
+-            fi
+-        else
+-            AC_CHECK_HEADERS([openjpeg-2.0/openjpeg.h])
+-            if test "$ac_cv_header_openjpeg_2_0_openjpeg_h" = "yes"; then
+-                AC_CHECK_LIB(openjp2,opj_stream_set_user_data_length,HAVE_OPENJPEG=yes,HAVE_OPENJPEG=no,)
+-                if test "$HAVE_OPENJPEG" = "yes"; then
+-                    LIBS="-lopenjp2 $LIBS"
+-                fi
+-            fi
+-        fi
++      AC_CHECK_HEADERS([openjpeg-2.2/openjpeg.h])
++      if test "$ac_cv_header_openjpeg_2_2_openjpeg_h" = "yes"; then
++          AC_CHECK_LIB(openjp2,opj_stream_set_user_data_length,HAVE_OPENJPEG=yes,HAVE_OPENJPEG=no,)
++          if test "$HAVE_OPENJPEG" = "yes"; then
++              OPENJPEG_VERSION=20200
++              LIBS="-lopenjp2 $LIBS"
++          fi
++      else
++          AC_CHECK_HEADERS([openjpeg-2.1/openjpeg.h])
++          if test "$ac_cv_header_openjpeg_2_1_openjpeg_h" = "yes"; then
++              AC_CHECK_LIB(openjp2,opj_stream_set_user_data_length,HAVE_OPENJPEG=yes,HAVE_OPENJPEG=no,)
++              if test "$HAVE_OPENJPEG" = "yes"; then
++                  OPENJPEG_VERSION=20100
++                  LIBS="-lopenjp2 $LIBS"
++              fi
++          else
++              AC_CHECK_HEADERS([openjpeg-2.0/openjpeg.h])
++              if test "$ac_cv_header_openjpeg_2_0_openjpeg_h" = "yes"; then
++                  AC_CHECK_LIB(openjp2,opj_stream_set_user_data_length,HAVE_OPENJPEG=yes,HAVE_OPENJPEG=no,)
++                  if test "$HAVE_OPENJPEG" = "yes"; then
++                      LIBS="-lopenjp2 $LIBS"
++                  fi
++              fi
++          fi
++      fi
+     fi
+   fi
+ else
+@@ -2588,8 +2596,11 @@
+   elif test -r $with_openjpeg/include/openjpeg-2.3/openjpeg.h ; then
+     OPENJPEG_VERSION=20300
+     EXTRA_INCLUDES="-I$with_openjpeg/include $EXTRA_INCLUDES"
++  elif test -r $with_openjpeg/include/openjpeg-2.4/openjpeg.h ; then
++    OPENJPEG_VERSION=20400
++    EXTRA_INCLUDES="-I$with_openjpeg/include $EXTRA_INCLUDES"
+   else
+-    AC_MSG_ERROR([openjpeg.h not found in $with_openjpeg/include/openjpeg-2.0 or $with_openjpeg/include/openjpeg-2.1 or $with_openjpeg/include/openjpeg-2.2 or $with_openjpeg/include/openjpeg-2.3])
++    AC_MSG_ERROR([openjpeg.h not found in $with_openjpeg/include/openjpeg-2.0 or $with_openjpeg/include/openjpeg-2.1 or $with_openjpeg/include/openjpeg-2.2 or $with_openjpeg/include/openjpeg-2.3 or $with_openjpeg/include/openjpeg-2.4])
+   fi
+
+   AC_CHECK_LIB(openjp2,opj_stream_set_user_data_length,HAVE_OPENJPEG=yes,HAVE_OPENJPEG=no,-L$with_openjpeg/lib)
+@@ -3598,16 +3609,21 @@
  
  HAVE_SPATIALITE=no
  SPATIALITE_AMALGAMATION=no
@@ -93,3 +181,20 @@ index 1111111..2222222 100644
  #elif defined(__APPLE__)
  #  define LIBNAME "libproj.dylib"
  #else
+
+
+diff --git a/frmts/openjpeg/openjpegdataset.cpp b/frmts/openjpeg/openjpegdataset.cpp
+index 1111111..2222222 100644
+--- a/frmts/openjpeg/openjpegdataset.cpp
++++ b/frmts/openjpeg/openjpegdataset.cpp
+@@ -34,7 +34,9 @@
+ #pragma clang diagnostic ignored "-Wdocumentation"
+ #endif
+
+-#if defined(OPENJPEG_VERSION) && OPENJPEG_VERSION >= 20300
++#if defined(OPENJPEG_VERSION) && OPENJPEG_VERSION >= 20400
++#include <openjpeg-2.4/openjpeg.h>
++#elif defined(OPENJPEG_VERSION) && OPENJPEG_VERSION >= 20300
+ #include <openjpeg-2.3/openjpeg.h>
+ #elif defined(OPENJPEG_VERSION) && OPENJPEG_VERSION >= 20200
+ #include <openjpeg-2.2/openjpeg.h>

--- a/src/gdal.mk
+++ b/src/gdal.mk
@@ -74,7 +74,7 @@ define $(PKG)_BUILD
         --with-xerces=no \
         --with-xml2='$(PREFIX)/$(TARGET)/bin/xml2-config' \
         --with-pg='$(PREFIX)/$(TARGET)/bin/pg_config' \
-        CXXFLAGS='-D_WIN32_WINNT=0x0600' \
+        CXXFLAGS='-D_WIN32_WINNT=0x0600 -DOPJ_STATIC' \
         LIBS="-ljpeg -lsecur32 -lportablexdr `'$(TARGET)-pkg-config' --libs openssl libtiff-4 spatialite freexl armadillo`" \
         $(PKG_CONFIGURE_OPTS)
 


### PR DESCRIPTION
I also ran into #2691 and #2610. After applying the patch proposed by @HuidaeCho in #2721 I encountered a build failure caused by (also seen in i686-w64-mingw32):

```
/home/vagrant/mxe/usr/bin/x86_64-w64-mingw32.static-ld: /home/vagrant/mxe/tmp-gdal-x86_64-w64-mingw32.static/gdal-2.2.4/.libs/libgdal.a(openjpegdataset.o):openjpegdataset.cpp:(.text+0x10bc): undefined reference to `__imp_opj_stream_create'
```

The [fix to add tests to the openjpeg build](https://github.com/mxe/mxe/blob/master/src/openjpeg-1-fixes.patch#L19) sets the `-DOPJ_STATIC` flag which causes the library to be build without the [`__declspec(dllimport)`]( https://github.com/uclouvain/openjpeg/blob/883c31dbe09771aab043744ac2b490d7386878e3/src/lib/openjp2/openjpeg.h#L85), and thus symbols without the `__imp_`:

```
nm usr/x86_64-w64-mingw32.static/lib/libopenjp2.a | grep opj_stream | head -n3
0000000000000620 T opj_stream_create
0000000000000720 T opj_stream_default_create
0000000000000060 T opj_stream_default_read
```

`gdal` however includes the openjpeg headers, but does not set the flag, which produces the `__imp_` variety in openjpegdataset.o.

This patch fixes the issue by adding `-DOPJ_STATIC` to the MXE gdal configure to match the `openjpg` library produced by the MXE recipe.  I am a novice at cross compilation (and builds in general), so I don't know if this is appropriate, but the build does succeed with the change.  I tested also the x86_64-w64-mingw32.shared build, and that worked, although it seems weird to set that flag for the shared builds.  It might be better to modify the make files in gdal-2.2.4/frmts/openjpg directly via patch instead of the top level change I made here.

Assuming you agree with this analysis of the problem, ideally you would first accept @HuidaeCho's patch (#2721) and then I can produce a new one with the additional change (or of course you can just make that additional change).


