### PR TITLE
Fix boost and gcc11 header issues

### DIFF
--- a/src/wt-1-fixes.patch
+++ b/src/wt-1-fixes.patch
@@ -5,7 +5,7 @@ Contains ad hoc patches for cross building.
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Boris Nagaev <bnagaev@gmail.com>
 Date: Sat, 1 Apr 2017 15:17:43 +0200
-Subject: [PATCH 1/3] Wt fixes
+Subject: [PATCH 1/5] Wt fixes
 
 
 diff --git a/cmake/WtFindGm.txt b/cmake/WtFindGm.txt
@@ -58,7 +58,7 @@ index 1111111..2222222 100644
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mark Brand <mabrand@mabrand.nl>
 Date: Mon, 17 Sep 2018 23:31:42 +0200
-Subject: [PATCH 2/3] fix missing gmtime_r definition
+Subject: [PATCH 2/5] fix missing gmtime_r definition
 
 
 diff --git a/src/http/Reply.C b/src/http/Reply.C
@@ -77,7 +77,7 @@ index 1111111..2222222 100644
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mark Brand <mabrand@mabrand.nl>
 Date: Sat, 6 Jul 2019 17:25:06 +0200
-Subject: [PATCH 3/3] fix build on case senstive filesystem
+Subject: [PATCH 3/5] fix build on case senstive filesystem
 
 
 diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
@@ -123,3 +123,43 @@ index 1111111..2222222 100644
  #endif // WT_WIN32
  
  #include "Wt/Dbo/backend/Postgres.h"
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Brodie Gaslam <brodie.gaslam@yahoo.com>
+Date: Mon, 21 Feb 2022 12:50:37 +0000
+Subject: [PATCH 4/5] add include for BOOST_FOREACH
+
+
+diff --git a/src/Wt/Render/CssParser.C b/src/Wt/Render/CssParser.C
+index 1111111..2222222 100644
+--- a/src/Wt/Render/CssParser.C
++++ b/src/Wt/Render/CssParser.C
+@@ -40,6 +40,7 @@ using namespace Wt::Render;
+ #include <boost/phoenix.hpp>
+ #endif
+ #include <boost/spirit/include/classic_file_iterator.hpp>
++#include <boost/foreach.hpp>
+ 
+ #include <map>
+ 
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: brodieG <brodieG@users.noreply.github.com>
+Date: Mon, 21 Feb 2022 13:39:57 +0000
+Subject: [PATCH 5/5] add <limits> explicitly for GCC 11 changes
+
+Header was previously included implicitly via other
+headers
+
+diff --git a/src/Wt/Render/WTextRenderer.C b/src/Wt/Render/WTextRenderer.C
+index 1111111..2222222 100644
+--- a/src/Wt/Render/WTextRenderer.C
++++ b/src/Wt/Render/WTextRenderer.C
+@@ -15,6 +15,7 @@
+ 
+ #include <fstream>
+ #include <string>
++#include <limits>
+ 
+ namespace {
+   const double EPSILON = 1e-4;


### PR DESCRIPTION
* boost problems possibly caused by upgrade to boost 1.78
* need for explicit <limits> likely caused by GCC 11
