### PR TITLE
Add openjpeg 2.4 capability to gdal

### DIFF
--- a/src/gdal-1-fixes.patch
+++ b/src/gdal-1-fixes.patch
@@ -5,7 +5,7 @@ Contains ad hoc patches for cross building.
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Luke Potgieter <fried.roadkill+ght@gmail.com>
 Date: Tue, 29 Aug 2017 16:31:09 +0200
-Subject: [PATCH 1/2] Detect spatialite more effectively than just checking for
+Subject: [PATCH 1/4] Detect spatialite more effectively than just checking for
  headers in the system paths. PostgreSQL detection requires -lpthread when
  building statically.
 
@@ -23,7 +23,7 @@ index 1111111..2222222 100644
  
    if test "${HAVE_PG}" = "yes" ; then
      LIBS=-L`$PG_CONFIG --libdir`" -lpq $LIBS"
-@@ -3557,16 +3557,21 @@ AC_ARG_WITH(spatialite-soname,
+@@ -3598,16 +3598,21 @@ AC_ARG_WITH(spatialite-soname,
  
  HAVE_SPATIALITE=no
  SPATIALITE_AMALGAMATION=no
@@ -74,7 +74,7 @@ index 1111111..2222222 100644
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Luke Potgieter <fried.roadkill+ght@gmail.com>
 Date: Tue, 26 Sep 2017 14:56:19 +0200
-Subject: [PATCH 2/2] Use the new proj dll version number for the latest proj.
+Subject: [PATCH 2/4] Use the new proj dll version number for the latest proj.
 
 
 diff --git a/ogr/ogrct.cpp b/ogr/ogrct.cpp
@@ -93,3 +93,138 @@ index 1111111..2222222 100644
  #elif defined(__APPLE__)
  #  define LIBNAME "libproj.dylib"
  #else
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: brodieG <brodieG@users.noreply.github.com>
+Date: Mon, 21 Feb 2022 21:48:09 +0000
+Subject: [PATCH 3/4] add openjpeg 2.4, based on @HuidaeCho PR
+
+See https://github.com/mxe/mxe/pull/2721
+
+diff --git a/configure.ac b/configure.ac
+index 1111111..2222222 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -2539,39 +2539,47 @@ if test "$with_openjpeg" = "no" ; then
+ 
+ elif test "$with_openjpeg" = "yes" -o "$with_openjpeg" = "" ; then
+ 
+-
+-  AC_CHECK_HEADERS([openjpeg-2.3/openjpeg.h])
+-  if test "$ac_cv_header_openjpeg_2_3_openjpeg_h" = "yes"; then
++  AC_CHECK_HEADERS([openjpeg-2.4/openjpeg.h])
++  if test "$ac_cv_header_openjpeg_2_4_openjpeg_h" = "yes"; then
+     AC_CHECK_LIB(openjp2,opj_stream_set_user_data_length,HAVE_OPENJPEG=yes,HAVE_OPENJPEG=no,)
+     if test "$HAVE_OPENJPEG" = "yes"; then
+-        OPENJPEG_VERSION=20300
++        OPENJPEG_VERSION=20400
+         LIBS="-lopenjp2 $LIBS"
+     fi
+   else
+-    AC_CHECK_HEADERS([openjpeg-2.2/openjpeg.h])
+-    if test "$ac_cv_header_openjpeg_2_2_openjpeg_h" = "yes"; then
+-        AC_CHECK_LIB(openjp2,opj_stream_set_user_data_length,HAVE_OPENJPEG=yes,HAVE_OPENJPEG=no,)
+-        if test "$HAVE_OPENJPEG" = "yes"; then
+-            OPENJPEG_VERSION=20200
+-            LIBS="-lopenjp2 $LIBS"
+-        fi
++    AC_CHECK_HEADERS([openjpeg-2.3/openjpeg.h])
++    if test "$ac_cv_header_openjpeg_2_3_openjpeg_h" = "yes"; then
++      AC_CHECK_LIB(openjp2,opj_stream_set_user_data_length,HAVE_OPENJPEG=yes,HAVE_OPENJPEG=no,)
++      if test "$HAVE_OPENJPEG" = "yes"; then
++          OPENJPEG_VERSION=20300
++          LIBS="-lopenjp2 $LIBS"
++      fi
+     else
+-        AC_CHECK_HEADERS([openjpeg-2.1/openjpeg.h])
+-        if test "$ac_cv_header_openjpeg_2_1_openjpeg_h" = "yes"; then
+-            AC_CHECK_LIB(openjp2,opj_stream_set_user_data_length,HAVE_OPENJPEG=yes,HAVE_OPENJPEG=no,)
+-            if test "$HAVE_OPENJPEG" = "yes"; then
+-                OPENJPEG_VERSION=20100
+-                LIBS="-lopenjp2 $LIBS"
+-            fi
+-        else
+-            AC_CHECK_HEADERS([openjpeg-2.0/openjpeg.h])
+-            if test "$ac_cv_header_openjpeg_2_0_openjpeg_h" = "yes"; then
+-                AC_CHECK_LIB(openjp2,opj_stream_set_user_data_length,HAVE_OPENJPEG=yes,HAVE_OPENJPEG=no,)
+-                if test "$HAVE_OPENJPEG" = "yes"; then
+-                    LIBS="-lopenjp2 $LIBS"
+-                fi
+-            fi
+-        fi
++      AC_CHECK_HEADERS([openjpeg-2.2/openjpeg.h])
++      if test "$ac_cv_header_openjpeg_2_2_openjpeg_h" = "yes"; then
++          AC_CHECK_LIB(openjp2,opj_stream_set_user_data_length,HAVE_OPENJPEG=yes,HAVE_OPENJPEG=no,)
++          if test "$HAVE_OPENJPEG" = "yes"; then
++              OPENJPEG_VERSION=20200
++              LIBS="-lopenjp2 $LIBS"
++          fi
++      else
++          AC_CHECK_HEADERS([openjpeg-2.1/openjpeg.h])
++          if test "$ac_cv_header_openjpeg_2_1_openjpeg_h" = "yes"; then
++              AC_CHECK_LIB(openjp2,opj_stream_set_user_data_length,HAVE_OPENJPEG=yes,HAVE_OPENJPEG=no,)
++              if test "$HAVE_OPENJPEG" = "yes"; then
++                  OPENJPEG_VERSION=20100
++                  LIBS="-lopenjp2 $LIBS"
++              fi
++          else
++              AC_CHECK_HEADERS([openjpeg-2.0/openjpeg.h])
++              if test "$ac_cv_header_openjpeg_2_0_openjpeg_h" = "yes"; then
++                  AC_CHECK_LIB(openjp2,opj_stream_set_user_data_length,HAVE_OPENJPEG=yes,HAVE_OPENJPEG=no,)
++                  if test "$HAVE_OPENJPEG" = "yes"; then
++                      LIBS="-lopenjp2 $LIBS"
++                  fi
++              fi
++          fi
++      fi
+     fi
+   fi
+ else
+@@ -2588,8 +2596,11 @@ else
+   elif test -r $with_openjpeg/include/openjpeg-2.3/openjpeg.h ; then
+     OPENJPEG_VERSION=20300
+     EXTRA_INCLUDES="-I$with_openjpeg/include $EXTRA_INCLUDES"
++  elif test -r $with_openjpeg/include/openjpeg-2.4/openjpeg.h ; then
++    OPENJPEG_VERSION=20400
++    EXTRA_INCLUDES="-I$with_openjpeg/include $EXTRA_INCLUDES"
+   else
+-    AC_MSG_ERROR([openjpeg.h not found in $with_openjpeg/include/openjpeg-2.0 or $with_openjpeg/include/openjpeg-2.1 or $with_openjpeg/include/openjpeg-2.2 or $with_openjpeg/include/openjpeg-2.3])
++    AC_MSG_ERROR([openjpeg.h not found in $with_openjpeg/include/openjpeg-2.0 or $with_openjpeg/include/openjpeg-2.1 or $with_openjpeg/include/openjpeg-2.2 or $with_openjpeg/include/openjpeg-2.3 or $with_openjpeg/include/openjpeg-2.4])
+   fi
+ 
+   AC_CHECK_LIB(openjp2,opj_stream_set_user_data_length,HAVE_OPENJPEG=yes,HAVE_OPENJPEG=no,-L$with_openjpeg/lib)
+diff --git a/frmts/openjpeg/openjpegdataset.cpp b/frmts/openjpeg/openjpegdataset.cpp
+index 1111111..2222222 100644
+--- a/frmts/openjpeg/openjpegdataset.cpp
++++ b/frmts/openjpeg/openjpegdataset.cpp
+@@ -34,7 +34,9 @@
+ #pragma clang diagnostic ignored "-Wdocumentation"
+ #endif
+ 
+-#if defined(OPENJPEG_VERSION) && OPENJPEG_VERSION >= 20300
++#if defined(OPENJPEG_VERSION) && OPENJPEG_VERSION >= 20400
++#include <openjpeg-2.4/openjpeg.h>
++#elif defined(OPENJPEG_VERSION) && OPENJPEG_VERSION >= 20300
+ #include <openjpeg-2.3/openjpeg.h>
+ #elif defined(OPENJPEG_VERSION) && OPENJPEG_VERSION >= 20200
+ #include <openjpeg-2.2/openjpeg.h>
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: brodieG <brodieG@users.noreply.github.com>
+Date: Mon, 21 Feb 2022 21:48:54 +0000
+Subject: [PATCH 4/4] Use CPPFLAGS consistent with MXE openjpg lib
+
+
+diff --git a/frmts/openjpeg/GNUmakefile b/frmts/openjpeg/GNUmakefile
+index 1111111..2222222 100644
+--- a/frmts/openjpeg/GNUmakefile
++++ b/frmts/openjpeg/GNUmakefile
+@@ -4,7 +4,7 @@ include ../../GDALmake.opt
+ OBJ	=	openjpegdataset.o
+ 
+ ifneq ($(OPENJPEG_VERSION),)
+-CPPFLAGS 	:=	$(CPPFLAGS) -DOPENJPEG_VERSION=$(OPENJPEG_VERSION)
++CPPFLAGS 	:=	$(CPPFLAGS) -DOPENJPEG_VERSION=$(OPENJPEG_VERSION) -DOPJ_STATIC
+ endif
+ 
+ CPPFLAGS        :=       -I.. $(CPPFLAGS)


### PR DESCRIPTION
>  Note, this supercedes #2772.  It is not submitted upstream because the current versions of GDAL already fix this issue.  My objective is to eventually update GDAL to the current version, but I'm a long ways from that.

Currently the gdal build is broken as it does not support openjpeg 2.4 and MXE recently updated to that version.  See #2691 and #2610 for reports. @HuidaeCho in #2721 adds support for openjpeg 2.4.  I manually applied the changes in the patch to the sources (so that I can then use `tools/patch-tool/mxe`), but after the version fix I hit:

```
/home/vagrant/mxe/usr/bin/x86_64-w64-mingw32.static-ld: /home/vagrant/mxe/tmp-gdal-x86_64-w64-mingw32.static/gdal-2.2.4/.libs/libgdal.a(openjpegdataset.o):openjpegdataset.cpp:(.text+0x10bc): undefined reference to `__imp_opj_stream_create'
```

This is a mismatch between the MXE openjpeg configuration and MXE gdal likely introduced by the [fix to add tests to the openjpeg build](https://github.com/mxe/mxe/blob/master/src/openjpeg-1-fixes.patch#L19).  That change sets the `-DOPJ_STATIC` flag for MXE openjpeg, so the library builds without [`__declspec(dllimport)`]( https://github.com/uclouvain/openjpeg/blob/883c31dbe09771aab043744ac2b490d7386878e3/src/lib/openjp2/openjpeg.h#L85), and thus symbols without the `__imp_`:

```
nm usr/x86_64-w64-mingw32.static/lib/libopenjp2.a | grep opj_stream | head -n3
0000000000000620 T opj_stream_create
0000000000000720 T opj_stream_default_create
0000000000000060 T opj_stream_default_read
```

This patch adds `-DOPJ_STATIC` to the gdal sub configure file to make it consistent with the openjpeg MXE built library.  I only modified the GNU make file as it seems the  corresponding `nmake` "makefile.vc" is likely irrelavant for MXE builds.  I am a novice at cross compilation (and builds in general), so I don't know if this is appropriate, but the build does succeed with the change including on x86_64-w64-mingw32.shared, although it does seem a bit odd to set that flag for the shared builds.

Most of the credit for this should go to @HuidaeCho and the work he did for #2721.

