### PR TITLE
Remove unnecessary pe-util dependency

### DIFF
--- a/src/icu4c.mk
+++ b/src/icu4c.mk
@@ -10,7 +10,7 @@ $(PKG)_CHECKSUM := 52a3f2209ab95559c1cf0a14f24338001f389615bf00e2585ef3dbc43ecf0
 $(PKG)_GH_CONF  := unicode-org/icu/releases/latest,release-,,,-
 $(PKG)_SUBDIR   := icu
 $(PKG)_URL      := $($(PKG)_WEBSITE)/releases/download/release-$(subst .,-,$($(PKG)_VERSION))/icu4c-$(subst .,_,$($(PKG)_VERSION))-src.tgz
-$(PKG)_DEPS     := cc $(BUILD)~$(PKG) pe-util
+$(PKG)_DEPS     := cc $(BUILD)~$(PKG)
 
 $(PKG)_TARGETS       := $(BUILD) $(MXE_TARGETS)
 $(PKG)_DEPS_$(BUILD) :=


### PR DESCRIPTION
Remove unnecessary `pe-util` dependency in icu4c package, only causing issues and additional compile time.

Compiled and tested, also works without pe-util dep.