### PR TITLE
Remove unnecessary dependency from harfbuzz

### DIFF
--- a/src/harfbuzz.mk
+++ b/src/harfbuzz.mk
@@ -7,7 +7,7 @@ $(PKG)_IGNORE   :=
 $(PKG)_VERSION  := 3.4.0
 $(PKG)_CHECKSUM := 810bcd3d22fae3c2c18c3688455abc1cd0d7fb2fae25404890b0d77e6443bd0a
 $(PKG)_GH_CONF  := harfbuzz/harfbuzz/releases
-$(PKG)_DEPS     := cc cairo freetype-bootstrap glib icu4c
+$(PKG)_DEPS     := cc cairo freetype-bootstrap glib
 
 define $(PKG)_BUILD
     # mman-win32 is only a partial implementation


### PR DESCRIPTION
Harfbuzz has built-in Unicode-data functions. Also we do not enabled ICU. So remove extra build dependency. 

Do not waste extra build time.

Build still works fine.