### PR TITLE
Update default windows API to 0x0601 (Win 7).

### DIFF
--- a/src/gcc.mk
+++ b/src/gcc.mk
@@ -74,7 +74,7 @@ define $(PKG)_BUILD_mingw-w64
         --enable-idl \
         --enable-secure-api \
         --with-default-msvcrt=msvcrt \
-        --with-default-win32-winnt=0x0600 \
+        --with-default-win32-winnt=0x0601 \
         $(mingw-w64-headers_CONFIGURE_OPTS)
     $(MAKE) -C '$(BUILD_DIR).headers' install
 
@@ -89,7 +89,7 @@ define $(PKG)_BUILD_mingw-w64
         --host='$(TARGET)' \
         --prefix='$(PREFIX)/$(TARGET)' \
         --with-default-msvcrt=msvcrt \
-        --with-default-win32-winnt=0x0600 \
+        --with-default-win32-winnt=0x0601 \
         @gcc-crt-config-opts@ \
         $(mingw-w64-crt_CONFIGURE_OPTS)
     $(MAKE) -C '$(BUILD_DIR).crt' -j '$(JOBS)' || $(MAKE) -C '$(BUILD_DIR).crt' -j '$(JOBS)'


### PR DESCRIPTION
The recent update of jasper requires at least 0x0601, and the current
default of 0x0600 breaks linking everything that uses jasper, including
Qt.

Since there is a good chance other packages will require newer Windows
APIs in the forseeable future (or already do) changing the default to
Win 7 seems like a reasonable step.

Fixes #2771, #2777.

---

The mentioned bugs have been fixed in the meantime in bb65d2c7fa4cebb3a4d1f4fa2b310dc0aa1d7d69 by changing the API for jasper only, but it might be worthwhile considering to generally update the default API given the age of Vista / 7.
