### PR TITLE
Qt6 improvements

### DIFF
--- a/src/qt/qt6/qt6-qt5compat.mk
+++ b/src/qt/qt6/qt6-qt5compat.mk
@@ -1,0 +1,23 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+PKG := qt6-qt5compat
+$(eval $(QT6_METADATA))
+
+# The following variables don't seem to be set correctly by the $(eval) above,
+# presumably because this file is included before qtbase (qt5compat < qtbase).
+qt6-qt5compat_SUBDIR    = $(subst qtbase,qt5compat,$(qt6-qtbase_SUBDIR))
+qt6-qt5compat_FILE      = $(subst qtbase,qt5compat,$(qt6-qtbase_FILE))
+qt6-qt5compat_URL       = $(subst qtbase,qt5compat,$(qt6-qtbase_URL))
+
+$(PKG)_CHECKSUM := 1cf89198cf2cf8a5c15336ccd69fa1f39b779feb64117d6bbf5509c21c123f53
+$(PKG)_DEPS     := cc qt6-qtbase
+
+QT6_PREFIX   = '$(PREFIX)/$(TARGET)/$(MXE_QT6_ID)'
+QT6_QT_CMAKE = '$(QT6_PREFIX)/bin/qt-cmake-private' \
+                   -DCMAKE_INSTALL_PREFIX='$(QT6_PREFIX)'
+
+define $(PKG)_BUILD
+    $(QT6_QT_CMAKE) -S '$(SOURCE_DIR)' -B '$(BUILD_DIR)'
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --build . -j '$(JOBS)'
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --install .
+endef

--- a/src/qt/qt6/qt6-qtdeclarative.mk
+++ b/src/qt/qt6/qt6-qtdeclarative.mk
@@ -1,0 +1,19 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+PKG := qt6-qtdeclarative
+$(eval $(QT6_METADATA))
+
+$(PKG)_CHECKSUM      := 2618c31f64820ed426ebfe2c10b6f3a43f08d2c03d6c63f024bc396455c1a86b
+$(PKG)_TARGETS       := $(BUILD) $(MXE_TARGETS)
+$(PKG)_DEPS_$(BUILD) := qt6-qtbase qt6-qtshadertools
+$(PKG)_DEPS          := cc $($(PKG)_DEPS_$(BUILD)) $(BUILD)~$(PKG)
+
+QT6_PREFIX   = '$(PREFIX)/$(TARGET)/$(MXE_QT6_ID)'
+QT6_QT_CMAKE = '$(QT6_PREFIX)/bin/qt-cmake-private' \
+                   -DCMAKE_INSTALL_PREFIX='$(QT6_PREFIX)'
+
+define $(PKG)_BUILD
+    $(QT6_QT_CMAKE) -S '$(SOURCE_DIR)' -B '$(BUILD_DIR)'
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --build . -j '$(JOBS)'
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --install .
+endef

--- a/src/qt/qt6/qt6-qtshadertools.mk
+++ b/src/qt/qt6/qt6-qtshadertools.mk
@@ -1,0 +1,19 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+PKG := qt6-qtshadertools
+$(eval $(QT6_METADATA))
+
+$(PKG)_CHECKSUM      := 8eb506e12e8e7096e02e7d44e53b927151c4f93b9c48e3e758e9702cd77f7ca7
+$(PKG)_TARGETS       := $(BUILD) $(MXE_TARGETS)
+$(PKG)_DEPS_$(BUILD) := qt6-qtbase
+$(PKG)_DEPS          := cc $($(PKG)_DEPS_$(BUILD)) $(BUILD)~$(PKG)
+
+QT6_PREFIX   = '$(PREFIX)/$(TARGET)/$(MXE_QT6_ID)'
+QT6_QT_CMAKE = '$(QT6_PREFIX)/bin/qt-cmake-private' \
+                   -DCMAKE_INSTALL_PREFIX='$(QT6_PREFIX)'
+
+define $(PKG)_BUILD
+    $(QT6_QT_CMAKE) -S '$(SOURCE_DIR)' -B '$(BUILD_DIR)'
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --build . -j '$(JOBS)'
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --install .
+endef

--- a/src/qt/qt6/qt6-qttools.mk
+++ b/src/qt/qt6/qt6-qttools.mk
@@ -5,7 +5,7 @@ $(eval $(QT6_METADATA))
 
 $(PKG)_CHECKSUM := 9aadbd5a14fad8874d2aa76be79652ec5ed81d31d49b3eff245ebeffc7d8ac08
 $(PKG)_TARGETS  := $(BUILD) $(MXE_TARGETS)
-$(PKG)_DEPS     := cc qt6-qtbase qt6-qtdeclarative
+$(PKG)_DEPS     := cc qt6-qtbase qt6-qtdeclarative $(BUILD)~$(PKG)
 $(PKG)_DEPS_$(BUILD) := qt6-qtbase
 
 define $(PKG)_BUILD

--- a/src/qt/qt6/qt6-qttools.mk
+++ b/src/qt/qt6/qt6-qttools.mk
@@ -5,7 +5,7 @@ $(eval $(QT6_METADATA))
 
 $(PKG)_CHECKSUM := 9aadbd5a14fad8874d2aa76be79652ec5ed81d31d49b3eff245ebeffc7d8ac08
 $(PKG)_TARGETS  := $(BUILD) $(MXE_TARGETS)
-$(PKG)_DEPS     := cc qt6-qtbase #qt6-qtdeclarative
+$(PKG)_DEPS     := cc qt6-qtbase qt6-qtdeclarative
 $(PKG)_DEPS_$(BUILD) := qt6-qtbase
 
 define $(PKG)_BUILD


### PR DESCRIPTION
Add several Qt6 modules (required to build [TeXworks](https://github.com/TeXworks/texworks/)). Dependencies (in particular for host-builds) might be reducible further, however host builds are required (where added as dependencies) to build native tools and create `Qt6<module>Tools` CMake targets required by dependent packages.
Tested so far only with the `i686-w64-mingw32.static` target on `x86_64-pc-linux-gnu`.