### PR TITLE
Qt6: properly include conf Makefile

### DIFF
--- a/src/qt/qt6/qt6-conf.mk
+++ b/src/qt/qt6/qt6-conf.mk
@@ -1,5 +1,7 @@
 # This file is part of MXE. See LICENSE.md for licensing information.
 
+include src/qt/qt6/qt6-qtbase.mk
+
 PKG            := qt6-conf
 $(PKG)_VERSION  = $(qt6-qtbase_VERSION)
 $(PKG)_DEPS    := qt6-qtbase

--- a/src/qt/qt6/qt6-qt5compat.mk
+++ b/src/qt/qt6/qt6-qt5compat.mk
@@ -1,16 +1,12 @@
 # This file is part of MXE. See LICENSE.md for licensing information.
 
+include src/qt/qt6/qt6-conf.mk
+
 PKG := qt6-qt5compat
 $(eval $(QT6_METADATA))
 
-# The following variables don't seem to be set correctly by the $(eval) above,
-# presumably because this file is included before qtbase (qt5compat < qtbase).
-qt6-qt5compat_SUBDIR    = $(subst qtbase,qt5compat,$(qt6-qtbase_SUBDIR))
-qt6-qt5compat_FILE      = $(subst qtbase,qt5compat,$(qt6-qtbase_FILE))
-qt6-qt5compat_URL       = $(subst qtbase,qt5compat,$(qt6-qtbase_URL))
-
 $(PKG)_CHECKSUM := 5de2b9e25bf7de161fbb88ecdd468ed1788bc899392fc05ed80aa590ebb352fa
-$(PKG)_DEPS     := cc qt6-qtbase
+$(PKG)_DEPS     := cc qt6-conf qt6-qtbase
 
 QT6_PREFIX   = '$(PREFIX)/$(TARGET)/$(MXE_QT6_ID)'
 QT6_QT_CMAKE = '$(QT6_PREFIX)/bin/qt-cmake-private' \

--- a/src/qt/qt6/qt6-qtcharts.mk
+++ b/src/qt/qt6/qt6-qtcharts.mk
@@ -1,10 +1,12 @@
 # This file is part of MXE. See LICENSE.md for licensing information.
 
+include src/qt/qt6/qt6-conf.mk
+
 PKG := qt6-qtcharts
 $(eval $(QT6_METADATA))
 
 $(PKG)_CHECKSUM := 3c2e6267ef0fb5345c7737e3a12e09ce9ec09117792e78af9a8617f828b2249a
-$(PKG)_DEPS     := cc qt6-qtbase
+$(PKG)_DEPS     := cc qt6-conf qt6-qtbase
 
 QT6_PREFIX   = '$(PREFIX)/$(TARGET)/$(MXE_QT6_ID)'
 QT6_QT_CMAKE = '$(QT6_PREFIX)/bin/qt-cmake-private' \

--- a/src/qt/qt6/qt6-qtdeclarative.mk
+++ b/src/qt/qt6/qt6-qtdeclarative.mk
@@ -1,11 +1,13 @@
 # This file is part of MXE. See LICENSE.md for licensing information.
 
+include src/qt/qt6/qt6-conf.mk
+
 PKG := qt6-qtdeclarative
 $(eval $(QT6_METADATA))
 
 $(PKG)_CHECKSUM      := fa6a8b5bfe43203daf022b7949c7874240ec28b9c4b7ebc52b2e5ea440e6e94f
 $(PKG)_TARGETS       := $(BUILD) $(MXE_TARGETS)
-$(PKG)_DEPS_$(BUILD) := qt6-qtbase qt6-qtshadertools
+$(PKG)_DEPS_$(BUILD) := qt6-conf qt6-qtbase qt6-qtshadertools
 $(PKG)_DEPS          := cc $($(PKG)_DEPS_$(BUILD)) $(BUILD)~$(PKG)
 
 QT6_PREFIX   = '$(PREFIX)/$(TARGET)/$(MXE_QT6_ID)'

--- a/src/qt/qt6/qt6-qtimageformats.mk
+++ b/src/qt/qt6/qt6-qtimageformats.mk
@@ -1,10 +1,12 @@
 # This file is part of MXE. See LICENSE.md for licensing information.
 
+include src/qt/qt6/qt6-conf.mk
+
 PKG := qt6-qtimageformats
 $(eval $(QT6_METADATA))
 
 $(PKG)_CHECKSUM := ee22e84866ed3fb39bdaf88f533851658919ee92dad56eb6da3d31c311a97e5c
-$(PKG)_DEPS     := cc qt6-qtbase jasper libmng libwebp tiff
+$(PKG)_DEPS     := cc qt6-conf qt6-qtbase jasper libmng libwebp tiff
 
 QT6_PREFIX   = '$(PREFIX)/$(TARGET)/$(MXE_QT6_ID)'
 QT6_QT_CMAKE = '$(QT6_PREFIX)/bin/qt-cmake-private' \

--- a/src/qt/qt6/qt6-qtserialport.mk
+++ b/src/qt/qt6/qt6-qtserialport.mk
@@ -1,10 +1,12 @@
 # This file is part of MXE. See LICENSE.md for licensing information.
 
+include src/qt/qt6/qt6-conf.mk
+
 PKG := qt6-qtserialport
 $(eval $(QT6_METADATA))
 
 $(PKG)_CHECKSUM := 8fdbfbb2aeee0e6400c90406927a784d3790bb0dfa7e5d7b9da7b2ded52bb744
-$(PKG)_DEPS     := cc qt6-qtbase
+$(PKG)_DEPS     := cc qt6-conf qt6-qtbase
 
 QT6_PREFIX   = '$(PREFIX)/$(TARGET)/$(MXE_QT6_ID)'
 QT6_QT_CMAKE = '$(QT6_PREFIX)/bin/qt-cmake-private' \

--- a/src/qt/qt6/qt6-qtshadertools.mk
+++ b/src/qt/qt6/qt6-qtshadertools.mk
@@ -1,11 +1,13 @@
 # This file is part of MXE. See LICENSE.md for licensing information.
 
+include src/qt/qt6/qt6-conf.mk
+
 PKG := qt6-qtshadertools
 $(eval $(QT6_METADATA))
 
 $(PKG)_CHECKSUM      := 20881824cba0c1396c0fe6b27d0f995a261070b68fa3629b1a188147d58933cc
 $(PKG)_TARGETS       := $(BUILD) $(MXE_TARGETS)
-$(PKG)_DEPS_$(BUILD) := qt6-qtbase
+$(PKG)_DEPS_$(BUILD) := qt6-conf qt6-qtbase
 $(PKG)_DEPS          := cc $($(PKG)_DEPS_$(BUILD)) $(BUILD)~$(PKG)
 
 QT6_PREFIX   = '$(PREFIX)/$(TARGET)/$(MXE_QT6_ID)'

--- a/src/qt/qt6/qt6-qtsvg.mk
+++ b/src/qt/qt6/qt6-qtsvg.mk
@@ -1,10 +1,12 @@
 # This file is part of MXE. See LICENSE.md for licensing information.
 
+include src/qt/qt6/qt6-conf.mk
+
 PKG := qt6-qtsvg
 $(eval $(QT6_METADATA))
 
 $(PKG)_CHECKSUM := 23ec4c14259d799bb6aaf1a07559d6b1bd2cf6d0da3ac439221ebf9e46ff3fd2
-$(PKG)_DEPS     := cc qt6-qtbase
+$(PKG)_DEPS     := cc qt6-conf qt6-qtbase
 
 QT6_PREFIX   = '$(PREFIX)/$(TARGET)/$(MXE_QT6_ID)'
 QT6_QT_CMAKE = '$(QT6_PREFIX)/bin/qt-cmake-private' \

--- a/src/qt/qt6/qt6-qttools.mk
+++ b/src/qt/qt6/qt6-qttools.mk
@@ -1,12 +1,14 @@
 # This file is part of MXE. See LICENSE.md for licensing information.
 
+include src/qt/qt6/qt6-conf.mk
+
 PKG := qt6-qttools
 $(eval $(QT6_METADATA))
 
 $(PKG)_CHECKSUM := 17f40689c4a1706a1b7db22fa92f6ab79f7b698a89e100cab4d10e19335f8267
 $(PKG)_TARGETS  := $(BUILD) $(MXE_TARGETS)
-$(PKG)_DEPS     := cc qt6-qtbase qt6-qtdeclarative $(BUILD)~$(PKG)
-$(PKG)_DEPS_$(BUILD) := qt6-qtbase
+$(PKG)_DEPS_$(BUILD) := qt6-conf qt6-qtbase
+$(PKG)_DEPS     := cc $($(PKG)_DEPS_$(BUILD)) qt6-qtdeclarative $(BUILD)~$(PKG)
 
 define $(PKG)_BUILD
     $(QT6_QT_CMAKE) -S '$(SOURCE_DIR)' -B '$(BUILD_DIR)' \


### PR DESCRIPTION
All Qt6 Makefiles that depend on `QT6_METADATA` need to include `qt6-conf.mk` (instead of relying on `make` to automatically parse it first). In turn, `qt6-conf.mk` depends on `qt6-qtbase.mk` for some of its variable assignments.

For make < 4.3, this is essential as those versions don't sort globbing results alphabetically (see #2796 and [make bug 52076](https://savannah.gnu.org/bugs/?52076)). For later versions of make, globbing results are sorted, but still some package names (e.g., `qt6-qt5compat`) would require special treatment as they are sorted before `qt6-qtbase` (which includes some required variables).

Caveats of this patch: it results in `qt6-conf.mk` (and in turn `qt6-qtbase.mk`) being parsed multiple times when running make. However, IMO, this is still the most reliable way (especially in case files are added/removed in the future).

Fixes #2796 