### PR TITLE
qt6-qtbase: Add CMake package configuration for Qt6 host path

### DIFF
--- a/src/qt/qt6/qt6-qtbase.mk
+++ b/src/qt/qt6/qt6-qtbase.mk
@@ -66,6 +66,10 @@ define $(PKG)_BUILD
     $(if $(BUILD_STATIC),$(SED) -i -e 's/^QMAKE_PRL_LIBS .*/& -lodbc32/;' \
 	      -e 's/^QMAKE_PRL_LIBS_FOR_CMAKE .*/&;-lodbc32/;' \
               '$(PREFIX)/$(TARGET)/$(MXE_QT6_ID)/plugins/sqldrivers/qsqlodbc.prl',)
+
+    mkdir -p '$(CMAKE_TOOLCHAIN_DIR)'
+    echo 'set(QT_HOST_PATH "$(PREFIX)/$(BUILD)/$(MXE_QT6_ID)")' \
+        > '$(CMAKE_TOOLCHAIN_DIR)/$(PKG).cmake'
 endef
 
 define $(PKG)_BUILD_$(BUILD)


### PR DESCRIPTION
The Qt6 cross-build uses tools from the host build and thus depends on it. CMake configuration of target projects fails if the path to the Qt host build is missing. This pull requests adds a Qt6 package configuration for the CMake target build.

Refers to #2799.