### PR TITLE
Qt6: add qtmultimedia

### DIFF
--- a/src/qt/qt6/qt6-qtmultimedia-1-fixes.patch
+++ b/src/qt/qt6/qt6-qtmultimedia-1-fixes.patch
@@ -1,0 +1,191 @@
+This file is part of MXE. See LICENSE.md for licensing information.
+
+Contains ad hoc patches for cross building.
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Moritz Bunkus <mo@bunkus.online>
+Date: Fri, 8 Apr 2022 21:22:34 +0200
+Subject: [PATCH 1/1] fix file name wrt. case
+
+
+diff --git a/cmake/FindWMF.cmake b/cmake/FindWMF.cmake
+index 1111111..2222222 100644
+--- a/cmake/FindWMF.cmake
++++ b/cmake/FindWMF.cmake
+@@ -22,11 +22,11 @@ find_library(WMF_UUID_LIBRARY uuid HINTS ${CMAKE_C_IMPLICIT_LINK_DIRECTORIES})
+ find_library(WMF_MSDMO_LIBRARY msdmo HINTS ${CMAKE_C_IMPLICIT_LINK_DIRECTORIES})
+ find_library(WMF_OLE32_LIBRARY ole32 HINTS ${CMAKE_C_IMPLICIT_LINK_DIRECTORIES})
+ find_library(WMF_OLEAUT32_LIBRARY oleaut32 HINTS ${CMAKE_C_IMPLICIT_LINK_DIRECTORIES})
+-find_library(WMF_MF_LIBRARY Mf HINTS ${CMAKE_C_IMPLICIT_LINK_DIRECTORIES})
+-find_library(WMF_MFUUID_LIBRARY Mfuuid HINTS ${CMAKE_C_IMPLICIT_LINK_DIRECTORIES})
+-find_library(WMF_MFPLAT_LIBRARY Mfplat HINTS ${CMAKE_C_IMPLICIT_LINK_DIRECTORIES})
+-find_library(WMF_MFCORE_LIBRARY Mfcore HINTS ${CMAKE_C_IMPLICIT_LINK_DIRECTORIES})
+-find_library(WMF_PROPSYS_LIBRARY Propsys HINTS ${CMAKE_C_IMPLICIT_LINK_DIRECTORIES})
++find_library(WMF_MF_LIBRARY mf HINTS ${CMAKE_C_IMPLICIT_LINK_DIRECTORIES})
++find_library(WMF_MFUUID_LIBRARY mfuuid HINTS ${CMAKE_C_IMPLICIT_LINK_DIRECTORIES})
++find_library(WMF_MFPLAT_LIBRARY mfplat HINTS ${CMAKE_C_IMPLICIT_LINK_DIRECTORIES})
++find_library(WMF_MFCORE_LIBRARY mfcore HINTS ${CMAKE_C_IMPLICIT_LINK_DIRECTORIES})
++find_library(WMF_PROPSYS_LIBRARY propsys HINTS ${CMAKE_C_IMPLICIT_LINK_DIRECTORIES})
+ 
+ 
+ set(WMF_LIBRARIES ${WMF_STRMIIDS_LIBRARY} ${WMF_AMSTRMID_LIBRARY} ${WMF_DMOGUIDS_LIBRARY} ${WMF_UUID_LIBRARY}
+diff --git a/src/multimedia/platform/windows/common/mfmetadata_p.h b/src/multimedia/platform/windows/common/mfmetadata_p.h
+index 1111111..2222222 100644
+--- a/src/multimedia/platform/windows/common/mfmetadata_p.h
++++ b/src/multimedia/platform/windows/common/mfmetadata_p.h
+@@ -52,7 +52,7 @@
+ //
+ 
+ #include <qmediametadata.h>
+-#include "Mfidl.h"
++#include "mfidl.h"
+ 
+ QT_USE_NAMESPACE
+ 
+diff --git a/src/multimedia/platform/windows/common/qwindowsresampler.cpp b/src/multimedia/platform/windows/common/qwindowsresampler.cpp
+index 1111111..2222222 100644
+--- a/src/multimedia/platform/windows/common/qwindowsresampler.cpp
++++ b/src/multimedia/platform/windows/common/qwindowsresampler.cpp
+@@ -41,7 +41,7 @@
+ #include <private/qwindowsaudioutils_p.h>
+ #include <qloggingcategory.h>
+ 
+-#include <Wmcodecdsp.h>
++#include <wmcodecdsp.h>
+ #include <mftransform.h>
+ #include <mfapi.h>
+ #include <mferror.h>
+diff --git a/src/multimedia/platform/windows/decoder/mfaudiodecodercontrol.cpp b/src/multimedia/platform/windows/decoder/mfaudiodecodercontrol.cpp
+index 1111111..2222222 100644
+--- a/src/multimedia/platform/windows/decoder/mfaudiodecodercontrol.cpp
++++ b/src/multimedia/platform/windows/decoder/mfaudiodecodercontrol.cpp
+@@ -40,7 +40,7 @@
+ #include <system_error>
+ #include <mferror.h>
+ #include <qglobal.h>
+-#include "Wmcodecdsp.h"
++#include "wmcodecdsp.h"
+ #include "mfaudiodecodercontrol_p.h"
+ #include <private/qwindowsaudioutils_p.h>
+ 
+diff --git a/src/multimedia/platform/windows/mediacapture/qwindowsmediadevicereader_p.h b/src/multimedia/platform/windows/mediacapture/qwindowsmediadevicereader_p.h
+index 1111111..2222222 100644
+--- a/src/multimedia/platform/windows/mediacapture/qwindowsmediadevicereader_p.h
++++ b/src/multimedia/platform/windows/mediacapture/qwindowsmediadevicereader_p.h
+@@ -53,8 +53,8 @@
+ 
+ #include <mfapi.h>
+ #include <mfidl.h>
+-#include <Mferror.h>
+-#include <Mfreadwrite.h>
++#include <mferror.h>
++#include <mfreadwrite.h>
+ 
+ #include <QtCore/qobject.h>
+ #include <QtCore/qmutex.h>
+diff --git a/src/multimedia/platform/windows/mediacapture/qwindowsmediaencoder.cpp b/src/multimedia/platform/windows/mediacapture/qwindowsmediaencoder.cpp
+index 1111111..2222222 100644
+--- a/src/multimedia/platform/windows/mediacapture/qwindowsmediaencoder.cpp
++++ b/src/multimedia/platform/windows/mediacapture/qwindowsmediaencoder.cpp
+@@ -45,7 +45,7 @@
+ #include "mfmetadata_p.h"
+ #include <QtCore/QUrl>
+ #include <QtCore/QMimeType>
+-#include <Mferror.h>
++#include <mferror.h>
+ #include <shobjidl.h>
+ #include <private/qmediarecorder_p.h>
+ 
+diff --git a/src/multimedia/platform/windows/player/mfplayercontrol_p.h b/src/multimedia/platform/windows/player/mfplayercontrol_p.h
+index 1111111..2222222 100644
+--- a/src/multimedia/platform/windows/player/mfplayercontrol_p.h
++++ b/src/multimedia/platform/windows/player/mfplayercontrol_p.h
+@@ -51,7 +51,7 @@
+ // We mean it.
+ //
+ 
+-#include "QUrl.h"
++#include <QtCore/qurl.h>
+ #include "qplatformmediaplayer_p.h"
+ 
+ #include <QtCore/qcoreevent.h>
+diff --git a/src/multimedia/platform/windows/player/mfplayersession.cpp b/src/multimedia/platform/windows/player/mfplayersession.cpp
+index 1111111..2222222 100644
+--- a/src/multimedia/platform/windows/player/mfplayersession.cpp
++++ b/src/multimedia/platform/windows/player/mfplayersession.cpp
+@@ -66,7 +66,7 @@
+ 
+ #include <mmdeviceapi.h>
+ #include <propvarutil.h>
+-#include <Functiondiscoverykeys_devpkey.h>
++#include <functiondiscoverykeys_devpkey.h>
+ 
+ //#define DEBUG_MEDIAFOUNDATION
+ 
+@@ -2060,4 +2060,3 @@ QMediaMetaData MFPlayerSession::trackMetaData(QPlatformMediaPlayer::TrackType ty
+ 
+     return m_trackInfo[type].metaData.at(trackNumber);
+ }
+-
+diff --git a/src/multimedia/platform/windows/player/mftvideo.cpp b/src/multimedia/platform/windows/player/mftvideo.cpp
+index 1111111..2222222 100644
+--- a/src/multimedia/platform/windows/player/mftvideo.cpp
++++ b/src/multimedia/platform/windows/player/mftvideo.cpp
+@@ -43,7 +43,7 @@
+ #include <mferror.h>
+ #include <strmif.h>
+ #include <uuids.h>
+-#include <InitGuid.h>
++#include <initguid.h>
+ #include <d3d9.h>
+ #include <qdebug.h>
+ 
+diff --git a/src/multimedia/platform/windows/player/mfvideorenderercontrol.cpp b/src/multimedia/platform/windows/player/mfvideorenderercontrol.cpp
+index 1111111..2222222 100644
+--- a/src/multimedia/platform/windows/player/mfvideorenderercontrol.cpp
++++ b/src/multimedia/platform/windows/player/mfvideorenderercontrol.cpp
+@@ -47,13 +47,13 @@
+ #include <private/qwindowsmfdefs_p.h>
+ #include <qvideosink.h>
+ #include <qvideoframeformat.h>
+-#include <qtcore/qtimer.h>
+-#include <qtcore/qmutex.h>
+-#include <qtcore/qcoreevent.h>
+-#include <qtcore/qcoreapplication.h>
+-#include <qtcore/qthread.h>
++#include <QtCore/qtimer.h>
++#include <QtCore/qmutex.h>
++#include <QtCore/qcoreevent.h>
++#include <QtCore/qcoreapplication.h>
++#include <QtCore/qthread.h>
+ #include "guiddef.h"
+-#include <qtcore/qdebug.h>
++#include <QtCore/qdebug.h>
+ 
+ //#define DEBUG_MEDIAFOUNDATION
+ #define PAD_TO_DWORD(x)  (((x) + 3) & ~3)
+diff --git a/src/multimedia/platform/windows/qwindowsmediadevices.cpp b/src/multimedia/platform/windows/qwindowsmediadevices.cpp
+index 1111111..2222222 100644
+--- a/src/multimedia/platform/windows/qwindowsmediadevices.cpp
++++ b/src/multimedia/platform/windows/qwindowsmediadevices.cpp
+@@ -49,7 +49,7 @@
+ 
+ #include <private/mftvideo_p.h>
+ 
+-#include <Dbt.h>
++#include <dbt.h>
+ #include <ks.h>
+ 
+ #include <mmsystem.h>
+@@ -58,9 +58,9 @@
+ #include <mfobjects.h>
+ #include <mfidl.h>
+ #include <mfreadwrite.h>
+-#include <Mferror.h>
++#include <mferror.h>
+ #include <mmdeviceapi.h>
+-#include <Functiondiscoverykeys_devpkey.h>
++#include <functiondiscoverykeys_devpkey.h>
+ #include <private/qwindowsaudioutils_p.h>
+ #include <private/qwindowsmfdefs_p.h>
+ 

--- a/src/qt/qt6/qt6-qtmultimedia.mk
+++ b/src/qt/qt6/qt6-qtmultimedia.mk
@@ -1,0 +1,19 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+include src/qt/qt6/qt6-conf.mk
+
+PKG := qt6-qtmultimedia
+$(eval $(QT6_METADATA))
+
+$(PKG)_CHECKSUM := ea703487c21613fcc55dd0c3fb2dc8e1ae77003ae6212a60c85d5210b64832b6
+$(PKG)_DEPS     := cc qt6-conf qt6-qtbase qt6-qtshadertools
+
+QT6_PREFIX   = '$(PREFIX)/$(TARGET)/$(MXE_QT6_ID)'
+QT6_QT_CMAKE = '$(QT6_PREFIX)/bin/qt-cmake-private' \
+                   -DCMAKE_INSTALL_PREFIX='$(QT6_PREFIX)'
+
+define $(PKG)_BUILD
+    $(QT6_QT_CMAKE) -S '$(SOURCE_DIR)' -B '$(BUILD_DIR)'
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --build . -j '$(JOBS)'
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --install .
+endef


### PR DESCRIPTION
Modeled on qt6-qtimageformats. Patch done via `patch-tool-mxe`. Tested with my own MKVToolNix: successful audio playback on Windows.

The patch is needed as the library & include file names are all over the place:

* libraries are all lowercase in the file system, but the `cmake` snippet tries to find them in mixed case
* several includes that are all lowercase in the file system are spelled in mixed case
* the `QtCore` include sub-directory is misspelled `qtcore`
