### PR TITLE
Qt6 qtmultimedia: fix compilation if gstreamer is installed

### DIFF
--- a/src/qt/qt6/qt6-qtmultimedia.mk
+++ b/src/qt/qt6/qt6-qtmultimedia.mk
@@ -13,7 +13,8 @@ QT6_QT_CMAKE = '$(QT6_PREFIX)/bin/qt-cmake-private' \
                    -DCMAKE_INSTALL_PREFIX='$(QT6_PREFIX)'
 
 define $(PKG)_BUILD
-    $(QT6_QT_CMAKE) -S '$(SOURCE_DIR)' -B '$(BUILD_DIR)'
+    $(QT6_QT_CMAKE) -S '$(SOURCE_DIR)' -B '$(BUILD_DIR)' \
+	 -DFEATURE_gstreamer=OFF
     cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --build . -j '$(JOBS)'
     cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --install .
 endef


### PR DESCRIPTION
This forces gstreamer detection off. Otherwise cmake will complain
that EGL isn't found.