### PR TITLE
Allow separating ccache's cache dir to a different

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,7 @@ STRIP_EXE       := $(true)
 MXE_USE_CCACHE      := mxe
 MXE_CCACHE_DIR      := $(PWD)/.ccache
 MXE_CCACHE_BASE_DIR := $(PWD)
+MXE_CCACHE_CACHE_DIR := $(MXE_CCACHE_DIR)/ccache
 
 # set to major.minor for LTS
 # MXE_QT6_ID := qt6.2

--- a/src/ccache.mk
+++ b/src/ccache.mk
@@ -50,7 +50,7 @@ define $(PKG)_BUILD_$(BUILD)
      echo '# $($(PKG)_USR_CONF)'; \
      echo; \
      echo 'base_dir = $(MXE_CCACHE_BASE_DIR)'; \
-     echo 'cache_dir = $(MXE_CCACHE_DIR)'; \
+     echo 'cache_dir = $(MXE_CCACHE_CACHE_DIR)'; \
      echo 'compiler_check = %compiler% -v'; \
      ) > '$($(PKG)_SYS_CONF)'
 


### PR DESCRIPTION
In light of what is discussed in #2462, it seems reasonable to allow
having `ccache` put its cache to a persistent storage that is shared
through pipeline runs.  The current setup doesn't do that since it puts
the cache in `MXE_CCACHE_DIR`, a directory in which also binaries and
other files reside that should not be shared as such.