### PR TITLE
Introduce MXE_PREFIX for use on make command line (PREFIX does not work)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,8 @@ REQUIREMENTS := \
     wget \
     xz
 
-PREFIX     := $(PWD)/usr
+MXE_PREFIX := $(PWD)/usr
+PREFIX     := $(MXE_PREFIX)
 LOG_DIR    := $(PWD)/log
 GITS_DIR   := $(PWD)/gits
 GIT_HEAD   := $(shell git rev-parse HEAD)

--- a/tools/build-pkg.lua
+++ b/tools/build-pkg.lua
@@ -69,7 +69,7 @@ rm -rf $MXE_DIR/usr $MXE_DIR/log $MXE_DIR/mxe-* && \
 make -C $MXE_DIR lua \
     MXE_TARGETS=$BUILD \
     lua_TARGETS=$BUILD \
-    PREFIX=$MXE_DIR/usr.lua && \
+    MXE_PREFIX=$MXE_DIR/usr.lua && \
 MXE_BUILD_PKG_CODENAME=focal \
 MXE_BUILD_PKG_TARGETS="i686-w64-mingw32.static" \
 MXE_BUILD_PKG_PKGS=qt5 \


### PR DESCRIPTION
This patch introduces MXE_PREFIX variable for use at the make command line. PREFIX variable may clash with external software, such as zstd.

To demonstrate the problem, run
```
make -j MXE_PLUGIN_DIRS=plugins/gcc10 MXE_TARGETS=x86_64-w64-mingw32.static.posix PREFIX=`pwd`/usr4 gcc
```
which fails with

```
Failed to build package gcc for target x86_64-w64-mingw32.static.posix!
------------------------------------------------------------
checking for zstd.h... no
configure: error: Unable to find zstd.h.  See config.log for details.
```
because `PREFIX` passed to make on command line gets inherited also in make files of zstd, and consequently `zstd.h` will be installed to wrong directory.

With the patch applied, this works:

```
make -j MXE_PLUGIN_DIRS=plugins/gcc10 MXE_TARGETS=x86_64-w64-mingw32.static.posix MXE_PREFIX=`pwd`/usr6 gcc 
```