### PR TITLE
Improve host build of cmake (fix install locations, default to Unix Makefiles)

### DIFF
--- a/plugins/examples/host-toolchain/README.md
+++ b/plugins/examples/host-toolchain/README.md
@@ -31,7 +31,7 @@ FC: no differences encountered
 make cmake-host MXE_PLUGIN_DIRS=plugins/examples/host-toolchain/
 ```
 
-CMake defaults to Visual Studio generators and additional configuration is
+CMake is made to default to Unix Makefiles generator and additional configuration is
 required for [MinGW or MSYS Makefiles][cmake-generators]. MinGW uses `cmd.exe`
 and requires `mingw32-make`, MSYS uses `make` and requires `/bin/sh`. The
 latter is recommended for further investigation since it's closest to the

--- a/plugins/examples/host-toolchain/cmake-host.mk
+++ b/plugins/examples/host-toolchain/cmake-host.mk
@@ -6,6 +6,7 @@ $(PKG)_VERSION   = $(cmake_VERSION)
 $(PKG)_CHECKSUM  = $(cmake_CHECKSUM)
 $(PKG)_SUBDIR    = $(cmake_SUBDIR)
 $(PKG)_FILE      = $(cmake_FILE)
+$(PKG)_PATCHES   = $(cmake_PATCHES)
 $(PKG)_URL       = $(cmake_URL)
 $(PKG)_URL_2     = $(cmake_URL_2)
 $(PKG)_DEPS     := cc

--- a/src/cmake-2-install-locations.patch
+++ b/src/cmake-2-install-locations.patch
@@ -1,0 +1,17 @@
+Without this, data get installed into share/cmake-3.22, while the host cmake
+(built by cmake-host) at startup expects them to be in share/cmake-3.22.1
+and hence fails to detect the cmake root.  From Msys2, mingw-w64-cmake,
+0003-Fix-install-destinations.patch.
+
+diff -Nru cmake-3.22.1-orig/Source/CMakeInstallDestinations.cmake cmake-3.22.1-patched/Source/CMakeInstallDestinations.cmake
+--- cmake-3.22.1-orig/Source/CMakeInstallDestinations.cmake	2021-12-07 10:44:21.000000000 -0500
++++ cmake-3.22.1-patched/Source/CMakeInstallDestinations.cmake	2022-03-23 15:32:47.110924489 -0400
+@@ -6,7 +6,7 @@
+   set(CMAKE_INFO_DIR_DEFAULT "documentation/info") # HAIKU
+   set(CMAKE_MAN_DIR_DEFAULT "documentation/man") # HAIKU
+   set(CMAKE_XDGDATA_DIR_DEFAULT "share") # HAIKU
+-elseif(CYGWIN)
++elseif(CYGWIN OR MINGW)
+   set(CMAKE_BIN_DIR_DEFAULT "bin") # CYGWIN
+   set(CMAKE_DATA_DIR_DEFAULT "share/cmake-${CMake_VERSION}") # CYGWIN
+   set(CMAKE_DOC_DIR_DEFAULT "share/doc/cmake-${CMake_VERSION}") # CYGWIN

--- a/src/cmake-3-default-generator.patch
+++ b/src/cmake-3-default-generator.patch
@@ -1,0 +1,20 @@
+Use "Unix Makefiles" as the default generator.  Without this patch, the
+default generator is "NMake Makefiles", hence requires Microsoft Visual
+Studio.  Analogous to Msys2, mingw-w64-cmake,
+0005-Default-to-ninja-generator.patch.
+
+diff -Nru cmake-3.22.1-orig/Source/cmake.cxx cmake-3.22.1-patched/Source/cmake.cxx
+--- cmake-3.22.1-orig/Source/cmake.cxx	2021-12-07 10:44:21.000000000 -0500
++++ cmake-3.22.1-patched/Source/cmake.cxx	2022-03-23 15:35:25.386828127 -0400
+@@ -2174,7 +2174,10 @@
+       return gen;
+     }
+   }
+-#if defined(_WIN32) && !defined(__CYGWIN__) && !defined(CMAKE_BOOT_MINGW)
++#if defined(_WIN32) && defined(__MINGW32__) && !defined(CMAKE_BOOT_MINGW)
++  return std::unique_ptr<cmGlobalGenerator>(
++    cm::make_unique<cmGlobalUnixMakefileGenerator3>(this));
++#elif defined(_WIN32) && !defined(__CYGWIN__) && !defined(CMAKE_BOOT_MINGW)
+   std::string found;
+   // Try to find the newest VS installed on the computer and
+   // use that as a default if -G is not specified


### PR DESCRIPTION
This pull request includes small fixes needed to make the host "cmake" work without a wrapper or overrides. It fixes cmake-host to take into account cmake patches and adds two. One patch changes the default generator to "Unix Makefiles", so that it can be used with the host toolchain built by MXE by default. The other patch fixes host cmake installation location so that cmake finds its own files. Without that patch, one gets

```
$ cmake --version
CMake Error: Could not find CMAKE_ROOT !!!
CMake has most likely not been installed correctly.
```
The two patches are based on Msys2 (0003-Fix-install-destinations.patch is re-used, 0005-Default-to-ninja-generator.patch was updated for a different default).