### PR TITLE
mesa: declare dependency on llvm, disable rtti, do not install DLLs in static build

### DIFF
--- a/src/mesa.mk
+++ b/src/mesa.mk
@@ -8,7 +8,7 @@ $(PKG)_CHECKSUM := df4fa560dcce6680133067cd15b0505fc424ca703244ce9ab247c74d2fab6
 $(PKG)_SUBDIR   := mesa-$($(PKG)_VERSION)
 $(PKG)_FILE     := mesa-$($(PKG)_VERSION).tar.xz
 $(PKG)_URL      := https://archive.mesa3d.org/$($(PKG)_FILE)
-$(PKG)_DEPS     := cc meson-wrapper zlib zstd
+$(PKG)_DEPS     := cc meson-wrapper zlib zstd llvm
 
 define $(PKG)_UPDATE
     $(call GET_LATEST_VERSION, https://archive.mesa3d.org, mesa-)
@@ -17,6 +17,7 @@ endef
 define $(PKG)_BUILD
     '$(MXE_MESON_WRAPPER)' $(MXE_MESON_OPTS) \
         -Dbuild-tests=false \
+        -Dcpp_rtti=false \
         $(PKG_MESON_OPTS) \
         '$(BUILD_DIR)' '$(SOURCE_DIR)'
     '$(MXE_NINJA)' -C '$(BUILD_DIR)' -j '$(JOBS)'
@@ -26,6 +27,11 @@ define $(PKG)_BUILD
         $(INSTALL) -d "$(PREFIX)/$(TARGET)/include/$$i"; \
         $(INSTALL) -m 644 "$(1)/include/$$i/"* "$(PREFIX)/$(TARGET)/include/$$i/"; \
     done
-    $(INSTALL) -m 755 '$(BUILD_DIR)/src/gallium/targets/wgl/libgallium_wgl.dll' '$(PREFIX)/$(TARGET)/bin/'
-    $(INSTALL) -m 755 '$(BUILD_DIR)/src/gallium/targets/libgl-gdi/opengl32.dll' '$(PREFIX)/$(TARGET)/bin/'
+
+    $(if $(BUILD_SHARED), \
+        $(INSTALL) -m 755 '$(BUILD_DIR)/src/gallium/targets/wgl/libgallium_wgl.dll' \
+                          '$(PREFIX)/$(TARGET)/bin/'
+        $(INSTALL) -m 755 '$(BUILD_DIR)/src/gallium/targets/libgl-gdi/opengl32.dll' \
+                          '$(PREFIX)/$(TARGET)/bin/'
+    )
 endef


### PR DESCRIPTION
This declares a dependency of mesa on llvm. Without that, on my system llvm was not built and mesa started picking up the host system llvm, resulting in error messages like

```
In file included from /usr/include/llvm-10/llvm/Support/MemoryBuffer.h:22,
                 from /usr/include/llvm-10/llvm/Object/Binary.h:20,
                 from /usr/include/llvm-10/llvm/ExecutionEngine/ExecutionEngine.h:27,
                 from ../mesa-22.0.2/src/gallium/auxiliary/gallivm/lp_bld_misc.cpp:58:
/usr/include/llvm-10/llvm/Support/FileSystem.h:164:3: error: 'uid_t' does not name a type; did you me
an 'pid_t'?
```
It is necessary to disable rtti as llvm is built without it:

```
tmp-mesa-x86_64-w64-mingw32.static.posix/mesa-22.0.2/meson.build:1736:8: ERROR: Problem encountered: 
LLVM was built without RTTI, so Mesa must also disable RTTI. Use an LLVM built with LLVM_ENABLE_RTTI 
or add cpp_rtti=false.
```

Also this conditionalizes installation of DLLs on static build. 
I've not tested the built library, only the building of it.