### PR TITLE
libzmq: disable IPC to allow building.

### DIFF
--- a/src/libzmq.mk
+++ b/src/libzmq.mk
@@ -16,7 +16,8 @@ define $(PKG)_BUILD
         -DCMAKE_CXX_FLAGS='-D_WIN32_WINNT=0x0600' \
         -DWITH_DOC=OFF \
         -DWITH_LIBSODIUM=ON \
-        -DWITH_PERF_TOOL=OFF
+        -DWITH_PERF_TOOL=OFF \
+        -DZMQ_HAVE_IPC=OFF
     $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)'
     $(MAKE) -C '$(BUILD_DIR)' -j 1 install
 


### PR DESCRIPTION
libzmq cannot be built because of errors like this:

```
tmp-libzmq-i686-w64-mingw32.static/zeromq-libzmq-c89390f/src/ipc_address.hpp:40:10: fatal error: sys/socket.h: No such file or directory
   40 | #include <sys/socket.h>
      |          ^~~~~~~~~~~~~~
```
This patch simply disables IPC to make it build, but, there may be a better way (?epoll poller).