### PR TITLE
cfitsio: include description when generating .pc file

### DIFF
--- a/src/cfitsio.mk
+++ b/src/cfitsio.mk
@@ -26,6 +26,7 @@ define $(PKG)_BUILD
     $(INSTALL) -d '$(PREFIX)/$(TARGET)/lib/pkgconfig'
     (echo 'Name: $(PKG)'; \
      echo 'Version: $($(PKG)_VERSION)'; \
+     echo 'Description: A FITS File Subroutine Library'; \
      echo 'Libs: -l$(PKG)';) \
      > '$(PREFIX)/$(TARGET)/lib/pkgconfig/$(PKG).pc'
 


### PR DESCRIPTION
A description seems to be required when using a newer pkg-config (and does no harm with the one used currently by MXE).

With pkg-config 1.8.0 and without this fix, I get this error during cfitsio build, when it is linking the test:

```
Package cfitsio was not found in the pkg-config search path.
Perhaps you should add the directory containing `cfitsio.pc'
to the PKG_CONFIG_PATH environment variable
```


