### PR TITLE
gdk-pixbuf: include all loaders when building statically (rather than creating DLLs)

### DIFF
--- a/src/gdk-pixbuf.mk
+++ b/src/gdk-pixbuf.mk
@@ -23,6 +23,7 @@ define $(PKG)_BUILD
       -Dinstalled_tests=false \
       -Dintrospection=disabled \
       -Dman=false \
+      $(if $(BUILD_STATIC),-Dbuiltin_loaders=all) \
     '$(BUILD_DIR)' '$(SOURCE_DIR)'
     '$(MXE_NINJA)' -C '$(BUILD_DIR)' -j '$(JOBS)'
     '$(MXE_NINJA)' -C '$(BUILD_DIR)' -j '$(JOBS)' install


### PR DESCRIPTION
This ensures that in a static build, all loaders are built in. 

Without this patch, these DLLs for most loaders are created (in a static build):

```
./usr/i686-w64-mingw32.static/lib/gdk-pixbuf-2.0/2.10.0/loaders/libpixbufloader-xpm.dll
./usr/i686-w64-mingw32.static/lib/gdk-pixbuf-2.0/2.10.0/loaders/libpixbufloader-pnm.dll
./usr/i686-w64-mingw32.static/lib/gdk-pixbuf-2.0/2.10.0/loaders/libpixbufloader-bmp.dll
./usr/i686-w64-mingw32.static/lib/gdk-pixbuf-2.0/2.10.0/loaders/libpixbufloader-ico.dll
./usr/i686-w64-mingw32.static/lib/gdk-pixbuf-2.0/2.10.0/loaders/libpixbufloader-gif.dll
./usr/i686-w64-mingw32.static/lib/gdk-pixbuf-2.0/2.10.0/loaders/libpixbufloader-tiff.dll
./usr/i686-w64-mingw32.static/lib/gdk-pixbuf-2.0/2.10.0/loaders/libpixbufloader-tga.dll
./usr/i686-w64-mingw32.static/lib/gdk-pixbuf-2.0/2.10.0/loaders/libpixbufloader-icns.dll
./usr/i686-w64-mingw32.static/lib/gdk-pixbuf-2.0/2.10.0/loaders/libpixbufloader-qtif.dll
./usr/i686-w64-mingw32.static/lib/gdk-pixbuf-2.0/2.10.0/loaders/libpixbufloader-xbm.dll
./usr/i686-w64-mingw32.static/lib/gdk-pixbuf-2.0/2.10.0/loaders/libpixbufloader-ani.dll
```
