### PR TITLE
docs: add openssl and which Fedora packages requirements

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -879,6 +879,7 @@ USE_OSGPLUGIN(&lt;plugin2&gt;)
     libtool \
     lzip \
     make \
+    openssl \
     openssl-devel \
     p7zip \
     patch \
@@ -889,6 +890,7 @@ USE_OSGPLUGIN(&lt;plugin2&gt;)
     sed \
     unzip \
     wget \
+    which \
     xz</pre>
 
     <p>


### PR DESCRIPTION
The 'openssl' and 'which' required packages may require installation on
Fedora.

Most systems will have these packages installed already, but they are
not installed by default on the
registry.fedoraproject.org/fedora-minimal container image.