### PR TITLE
gcc: enable precise timers (clock_gettime) in the C++ library

### DIFF
--- a/src/gcc.mk
+++ b/src/gcc.mk
@@ -51,6 +51,7 @@ define $(PKG)_CONFIGURE
         --with-as='$(PREFIX)/bin/$(TARGET)-as' \
         --with-ld='$(PREFIX)/bin/$(TARGET)-ld' \
         --with-nm='$(PREFIX)/bin/$(TARGET)-nm' \
+        --enable-libstdcxx-time \
         $(shell [ `uname -s` == Darwin ] && echo "LDFLAGS='-Wl,-no_pie'") \
         $(PKG_CONFIGURE_OPTS)
 endef


### PR DESCRIPTION
This makes the C++ library use clock_gettime and hence more precise timers. Without this setting, system_clock from <chrono> only uses gettimeofday. Msys2 enables the precise timers as well in their builds.
