### PR TITLE
boost: remove file accidentally included in boost release (with space in its name)

### DIFF
--- a/src/boost.mk
+++ b/src/boost.mk
@@ -28,6 +28,9 @@ define $(PKG)_BUILD
     rm -rf '$(PREFIX)/$(TARGET)/include/boost/'
     rm -f "$(PREFIX)/$(TARGET)/lib/libboost"*
 
+    # remove file accidentally added to 1.78.0 (with space in its name)
+    rm -f "$(1)/boost/serialization/collection_size_type copy.hpp"
+
     # create user-config
     echo 'using gcc : mxe : $(TARGET)-g++ : <rc>$(TARGET)-windres <archiver>$(TARGET)-ar <ranlib>$(TARGET)-ranlib ;' > '$(1)/user-config.jam'
 


### PR DESCRIPTION
Boost 1.78.0 includes accidentally file "collection_size_type copy.hpp", which is not needed but has a space in its name, which may cause trouble for further processing. This patch deletes it.

https://github.com/boostorg/serialization/commit/07c99b8649d7bb900271ca93ba3eea9dcb478f42#diff-c7259865ae65dd94c715482e2abf4fbb3ee9f77e63eb1b6677eada21bd239b08