### PR TITLE
Fix gtk2 build

### DIFF
--- a/src/glib.mk
+++ b/src/glib.mk
@@ -48,5 +48,7 @@ define $(PKG)_BUILD
         -Druntime_bindir='../$(BUILD)/bin' \
         '$(BUILD_DIR)' '$(SOURCE_DIR)'
     '$(MXE_NINJA)' -C '$(BUILD_DIR)' -j '$(JOBS)'
+    # add -luuid
+    $(SED) -i 's/-lglib-2.0/-lglib-2.0 -luuid/' '$(BUILD_DIR)/meson-private/glib-2.0.pc'
     '$(MXE_NINJA)' -C '$(BUILD_DIR)' -j '$(JOBS)' install
 endef

--- a/src/gtk2.mk
+++ b/src/gtk2.mk
@@ -39,7 +39,7 @@ define $(PKG)_BUILD
     rm -f '$(PREFIX)/$(TARGET)/lib/gailutil.def'
 
     '$(TARGET)-gcc' \
-        -W -Wall -Werror -ansi \
+        -W -Wall -Werror -Wno-error=deprecated-declarations -ansi \
         '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-gtk2.exe' \
         `'$(TARGET)-pkg-config' gtk+-2.0 gmodule-2.0 --cflags --libs`
 endef


### PR DESCRIPTION
This fixes the build of gtk2 (missing -luuid in glib pkg-config file caused linking errors, use of deprecated declarations caused compile error of the gtk2 test).
