### PR TITLE
libffi: upgrade to version 3.3

### DIFF
--- a/src/libffi.mk
+++ b/src/libffi.mk
@@ -3,8 +3,8 @@
 PKG             := libffi
 $(PKG)_WEBSITE  := https://sourceware.org/libffi/
 $(PKG)_IGNORE   :=
-$(PKG)_VERSION  := 3.2.1
-$(PKG)_CHECKSUM := d06ebb8e1d9a22d19e38d63fdb83954253f39bedc5d46232a05645685722ca37
+$(PKG)_VERSION  := 3.3
+$(PKG)_CHECKSUM := 72fba7922703ddfa7a028d513ac15a85c8d54c8d67f55fa5a4802885dc652056
 $(PKG)_GH_CONF  := atgreen/libffi/tags, v
 $(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
 $(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.gz


### PR DESCRIPTION
This upgrades libffi to version 3.3. This is the most recent version available at https://sourceware.org/pub/libffi/, but there is also version 3.4.2 at https://github.com/libffi/libffi and https://github.com/atgreen/libffi.
