### PR TITLE
Document that MXE is used by R.

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -3260,6 +3260,9 @@ endef</pre>
         <a href="https://qtads.sourceforge.io/">QTads</a>
     </li>
     <li>
+        <a href="https://www.r-project.org/">R</a>
+    </li>
+    <li>
         <a href="https://github.com/scummvm/scummvm">ScummVM</a>
     </li>
     <li>


### PR DESCRIPTION
The "R Project for Statistical Computing" (www.r-project.org) uses MXE to build the cross and native GCC toolchains and a number of external libraries for building R itself and contributed R packages. This patch adds a link to the documentation to acknowledge/thank MXE.

R uses UCRT, so some modifications had to be done to support that. Additional local modifications were required to upgrade some MXE packages (as needed by CRAN packages) and to add several new MXE packages. Several bug fixes and improvements have already been contributed upstream back to MXE and the goal is to reduce the amount of downstream modifications as much as possible.
 
For more information, see Rtools42 (https://cran.r-project.org/bin/windows/Rtools/rtools42/rtools.html), with more details at https://cran.r-project.org/bin/windows/base/howto-R-devel.html and the source code living at
https://svn.r-project.org/R-dev-web/trunk/WindowsBuilds/winutf8/ucrt3/toolchain_libs/mxe.

This also means that the subset of MXE used by R/CRAN packages is regularly tested using checks of the R packages.