### PR TITLE
Add Chafa package

### DIFF
--- a/src/chafa.mk
+++ b/src/chafa.mk
@@ -1,0 +1,32 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+PKG             := chafa
+$(PKG)_WEBSITE  := https://hpjansson.org/chafa/
+$(PKG)_DESCR    := The Chafa terminal graphics package
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 1.12.3
+$(PKG)_CHECKSUM := 2456a0b6c1150e25b64cd6a92810d59bed3f061f8b86f91aba5a77bc7cc76cfa
+$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.xz
+$(PKG)_URL      := https://hpjansson.org/chafa/releases/$($(PKG)_FILE)
+$(PKG)_DEPS     := cc glib
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- 'https://hpjansson.org/chafa/releases/' | \
+    $(SED) -n 's,.*chafa-\([0-9][^"]*\)\.tar.*,\1,p' | \
+    $(SORT) -rV | \
+    head -1
+endef
+
+define $(PKG)_BUILD
+    cd '$(SOURCE_DIR)' && autoreconf -fi
+    cd '$(BUILD_DIR)' && '$(SOURCE_DIR)/configure' \
+        $(MXE_CONFIGURE_OPTS) \
+        --disable-gtk-doc \
+        --disable-man \
+        --without-tools \
+        --without-imagemagick
+    $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)'
+    $(MAKE) -C '$(BUILD_DIR)' -j 1 install
+endef
+


### PR DESCRIPTION
Hi, I've been a happy user of MXE for many years, and today I'm submitting the Chafa library for consideration.

* It's a terminal graphics package not unlike libcaca, but modern and wider in scope (i.e. supports a large number of Unicode symbols and ANSI escape sequence capabilities, sixels, Kitty and iTerm2 graphics extensions).
* It has API to convert pixel buffers into the above formats, generating a stream of terminal sequences and allowing direct manipulation of a character cell-based canvas.
* Platform-wise it depends on GLib and uses many of the same conventions.
* Harfbuzz has an optional dependency on Chafa for the `hb-view` executable.

I've disabled installation of documentation and the command-line executable as per the instructions. Please let me know what you think or if I need to make changes to the PR.

For convenience: Links to [main website](https://hpjansson.org/chafa/), [GitHub repository](https://github.com/hpjansson/chafa/), [API documentation](https://hpjansson.org/chafa/ref/).