### PR TITLE
glib: Move -luuid dependency to Libs.private

### DIFF
--- a/src/glib-2-link-with-libuuid.patch
+++ b/src/glib-2-link-with-libuuid.patch
@@ -1,0 +1,29 @@
+From 561f4206d4209f57123a63e033519e5a55576699 Mon Sep 17 00:00:00 2001
+From: Hans Petter Jansson <hpj@hpjansson.org>
+Date: Fri, 8 Jul 2022 22:48:57 +0200
+Subject: [PATCH] Add -luuid to win32 dependencies
+
+Needed to prevent certain linking issues on Windows.
+
+This will also have the effect of adding it to the Libs.private line
+in the installed pkgconfig.
+---
+ meson.build | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/meson.build b/meson.build
+index 05b9aca..4e45730 100644
+--- a/meson.build
++++ b/meson.build
+@@ -2282,7 +2282,7 @@ if host_system == 'windows' and cc.get_id() != 'msvc' and cc.get_id() != 'clang-
+   add_project_arguments(win32_cflags, language : 'c')
+ 
+   # Win32 API libs, used only by libglib and exposed in glib-2.0.pc
+-  win32_ldflags = ['-lws2_32', '-lole32', '-lwinmm', '-lshlwapi']
++  win32_ldflags = ['-lws2_32', '-lole32', '-lwinmm', '-lshlwapi', '-luuid']
+ elif host_system == 'cygwin'
+   win32_ldflags = ['-luser32', '-lkernel32']
+ endif
+-- 
+2.33.0
+

--- a/src/glib.mk
+++ b/src/glib.mk
@@ -48,7 +48,5 @@ define $(PKG)_BUILD
         -Druntime_bindir='../$(BUILD)/bin' \
         '$(BUILD_DIR)' '$(SOURCE_DIR)'
     '$(MXE_NINJA)' -C '$(BUILD_DIR)' -j '$(JOBS)'
-    # add -luuid
-    $(SED) -i 's/-lglib-2.0/-lglib-2.0 -luuid/' '$(BUILD_DIR)/meson-private/glib-2.0.pc'
     '$(MXE_NINJA)' -C '$(BUILD_DIR)' -j '$(JOBS)' install
 endef


### PR DESCRIPTION
The hack to add `-luuid` to the pkgconfig file's `Libs:` field was preventing GLib dependents from building shared libraries with `-no-undefined`, since during the build, libuuid is only available as a static library.

I'm not 100% certain about the fix, since I don't know what the original .pc hack was fixing (commit ee08db3111d1a3388b996991d345926944985856), but a GLib-dependent package I tested with builds fine now with both `x86_64-w64.mingw32.static` and `x86_64-w64.mingw32.shared` targets.

Attn: @kalibera @mabrand
