### PR TITLE
add graphviz 5.0.0

### DIFF
--- a/src/graphviz.mk
+++ b/src/graphviz.mk
@@ -53,7 +53,7 @@ $(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.gz
 $(PKG)_URL      := https://gitlab.com/api/v4/projects/4207231/packages/generic/graphviz-releases/5.0.0/graphviz-5.0.0.tar.gz
 $(PKG)_DEPS     := gcc mman-win32 cairo devil expat freetype fontconfig gd ghostscript libwebp pango poppler
 
-define $(PKG)_BUILD
+define $(PKG)_BUILD_SHARED
     cd '$(BUILD_DIR)' && '$(SOURCE_DIR)/configure' \
         $(MXE_CONFIGURE_OPTS) \
 		--disable-swig \


### PR DESCRIPTION
Make graphviz-5.0.0 available. The differences with the patches that are part of pull request #1804 are:

 * the most recent graphviz (5.0.0) is installed
 * no patches are needed: the cross-compilation problems have been fixed upstream
 * compilation is done in a separate build directory (as opposed to in the source directory)
 * the standard MXE configure flags are used

Shared builds have been tried with gcc11 and the gcc12 plugin. The gcc12-shared version of graphviz has been tested in the MXE-based MSW-deployment of our simulation software (admittedly, not all corners of graphviz are exercised by our code). Static libs may need more work.

I believe that this addresses most concerns @tonytheodore had with @hankhank's patch series. If this pull request is accepted, #1804 can obviously be closed. Please see the commit log below for additional details about this submission.