### PR TITLE
qt6-qtmultimedia: Update patch

### DIFF
--- a/src/qt/qt6/qt6-qtmultimedia-1-fixes.patch
+++ b/src/qt/qt6/qt6-qtmultimedia-1-fixes.patch
@@ -59,15 +59,17 @@ diff --git a/src/plugins/multimedia/ffmpeg/qwindowscamera.cpp b/src/plugins/mult
 index 1111111..2222222 100644
 --- a/src/plugins/multimedia/ffmpeg/qwindowscamera.cpp
 +++ b/src/plugins/multimedia/ffmpeg/qwindowscamera.cpp
-@@ -10,7 +10,7 @@
+@@ -10,8 +10,8 @@
  
  #include <mfapi.h>
  #include <mfidl.h>
 -#include <Mferror.h>
+-#include <Mfreadwrite.h>
 +#include <mferror.h>
- #include <Mfreadwrite.h>
++#include <mfreadwrite.h>
  
  #include <system_error>
+ 
 diff --git a/src/plugins/multimedia/windows/common/mfmetadata_p.h b/src/plugins/multimedia/windows/common/mfmetadata_p.h
 index 1111111..2222222 100644
 --- a/src/plugins/multimedia/windows/common/mfmetadata_p.h


### PR DESCRIPTION
Fixes the following build error:
```
/home/jonas/Projects/jonaski-mxe/tmp-qt6-qtmultimedia-x86_64-w64-mingw32.static/qtmultimedia-everywhere-src-6.4.0/src/plugins/multimedia/ffmpeg/qwindowscamera.cpp:14:10: fatal error: Mfreadwrite.h: No such file or directory
   14 | #include <Mfreadwrite.h>
      |          ^~~~~~~~~~~~~~~
compilation terminated.
```