### PR TITLE
qt6-qtbase: Disable zstd for native build

### DIFF
--- a/src/qt/qt6/qt6-qtbase.mk
+++ b/src/qt/qt6/qt6-qtbase.mk
@@ -77,7 +77,7 @@ define $(PKG)_BUILD_$(BUILD)
         -DCMAKE_INSTALL_PREFIX='$(PREFIX)/$(TARGET)/$(MXE_QT6_ID)' \
         -DQT_BUILD_{TESTS,EXAMPLES}=OFF \
         -DBUILD_WITH_PCH=OFF \
-        -DFEATURE_{eventfd,glib,harfbuzz,icu,opengl,openssl}=OFF \
+        -DFEATURE_{eventfd,glib,harfbuzz,icu,opengl,openssl,zstd}=OFF \
         -DFEATURE_sql_{db2,ibase,mysql,oci,odbc,psql,sqlite}=OFF
     '$(TARGET)-cmake' --build '$(BUILD_DIR)' -j '$(JOBS)'
     '$(TARGET)-cmake' --install '$(BUILD_DIR)'


### PR DESCRIPTION
Fixes the following build error on openSUSE:

```
/usr/lib64/gcc/x86_64-suse-linux/12/../../../../x86_64-suse-linux/bin/ld: /__w/jonaski-mxe/jonaski-mxe/usr/x86_64-pc-linux-gnu/lib/libzstd.a(zstd_common.o): relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a shared object; recompile with -fPIC
/usr/lib64/gcc/x86_64-suse-linux/12/../../../../x86_64-suse-linux/bin/ld: failed to set dynamic section sizes: bad value
collect2: error: ld returned 1 exit status
[348/1264] Building C object src/3rdparty/freetype/CMakeFiles/BundledFreetype.dir/src/bdf/bdf.c.o
ninja: build stopped: subcommand failed.
```
