### PR TITLE
qt6-qttools: Turn off building designer for native build

### DIFF
--- a/src/qt/qt6/qt6-qttools.mk
+++ b/src/qt/qt6/qt6-qttools.mk
@@ -28,7 +28,9 @@ define $(PKG)_BUILD
 endef
 
 define $(PKG)_BUILD_$(BUILD)
-    $(QT6_QT_CMAKE) -S '$(SOURCE_DIR)' -B '$(BUILD_DIR)'
+    $(QT6_QT_CMAKE) -S '$(SOURCE_DIR)' -B '$(BUILD_DIR)' \
+        -DFEATURE_linguist=ON \
+        -DFEATURE_designer=OFF
     cmake --build '$(BUILD_DIR)' -j '$(JOBS)'
     cmake --install '$(BUILD_DIR)'
 endef


### PR DESCRIPTION
Building linguist without designer is now possible in Qt 6.4.
