### PR TITLE
chafa: Add LDFLAGS='-no-undefined'

### DIFF
--- a/src/chafa.mk
+++ b/src/chafa.mk
@@ -26,7 +26,7 @@ define $(PKG)_BUILD
         --disable-man \
         --without-tools \
         --without-imagemagick
-    $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)'
+    $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)' LDFLAGS='-no-undefined'
     $(MAKE) -C '$(BUILD_DIR)' -j 1 install
 endef
 


### PR DESCRIPTION
Fixes: libtool:   error: can't build i686-w64-mingw32.shared shared library unless -no-undefined is specified
