### PR TITLE
Debian required packages: Add python-is-python3

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -828,6 +828,7 @@ USE_OSGPLUGIN(&lt;plugin2&gt;)
     python3 \
     python3-mako \
     python3-pkg-resources \
+    python-is-python3 \
     ruby \
     sed \
     unzip \


### PR DESCRIPTION
Fix #2860

It seems there are packages that require a `python` binary. However, Debian Bullseye no longer packages `python`, only `python2` and `python3`.  By adding `python-is-python3`, we can fix build issues.
