### PR TITLE
exiv2: enable wide string methods

### DIFF
--- a/src/exiv2.mk
+++ b/src/exiv2.mk
@@ -11,6 +11,7 @@ $(PKG)_DEPS     := cc expat gettext mman-win32 zlib
 
 define $(PKG)_BUILD
     $(TARGET)-cmake -S '$(SOURCE_DIR)' -B '$(BUILD_DIR)' \
+        -DEXIV2_ENABLE_WIN_UNICODE=ON \
         -DEXIV2_BUILD_SAMPLES=OFF
     $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)'
     $(MAKE) -C '$(BUILD_DIR)' -j 1 install


### PR DESCRIPTION
With this configuration opetion exiv2 provides a couple of more methods to open image files which take a std::wstring as parameter. This allows supporting file paths containing non-ascii characters.
