### PR TITLE
openssl: fix static build to include legacy driver

### DIFF
--- a/src/openssl.mk
+++ b/src/openssl.mk
@@ -36,7 +36,7 @@ define $(PKG)_BUILD
     cd '$(1)' && CC='$(TARGET)-gcc' RC='$(TARGET)-windres' ./Configure \
         @openssl-target@ \
         zlib \
-        $(if $(BUILD_STATIC),no-,)shared \
+        $(if $(BUILD_STATIC),no-module no-,)shared \
         no-capieng \
         --prefix='$(PREFIX)/$(TARGET)' \
         --libdir='$(PREFIX)/$(TARGET)/lib'


### PR DESCRIPTION
Openssl while building static libraries still builds legacy.dll, a loadable module for the legacy driver. This patch ensures that the legacy driver is, instead, compiled into the main static library, following this recommendation:

https://github.com/openssl/openssl/issues/17679#issuecomment-1034949099