### PR TITLE
libgpg_error: create gpg-error-config

### DIFF
--- a/src/libgpg_error.mk
+++ b/src/libgpg_error.mk
@@ -24,7 +24,8 @@ define $(PKG)_BUILD
     cd '$(BUILD_DIR)' && '$(SOURCE_DIR)/configure' \
         $(MXE_CONFIGURE_OPTS) \
         --disable-nls \
-        --disable-languages
+        --disable-languages \
+        --enable-install-gpg-error-config
     $(SED) -i 's/host_os = mingw32.*/host_os = mingw32/' '$(BUILD_DIR)/src/Makefile'
     $(MAKE) -C '$(BUILD_DIR)/src' -j '$(JOBS)' bin_PROGRAMS= sbin_PROGRAMS= noinst_PROGRAMS=
     $(SED) -i 's/-lgpg-error/-lgpg-error -lintl -liconv -lws2_32/;' '$(BUILD_DIR)/src/gpg-error-config'


### PR DESCRIPTION
This ensures that gpg-error-config still gets created while building libgpg_error.

Without it, building libassuan fails with 

```
./configure: line 14370: test: : integer expression expected
./configure: line 14377: test: : integer expression expected
checking for GPG Error - version >= 1.17... no
configure: error: libgpg-error was not found
```