### PR TITLE
Build Tk statically

### DIFF
--- a/plugins/tcl.tk/tk.mk
+++ b/plugins/tcl.tk/tk.mk
@@ -22,10 +22,10 @@ define $(PKG)_BUILD
     cd '$(SOURCE_DIR)/win' && autoreconf -fi
     cd '$(BUILD_DIR)' && '$(SOURCE_DIR)/win/configure' \
         $(MXE_CONFIGURE_OPTS) \
-        --enable-threads \
+        --enable-threads --disable-shared \
         --with-tcl='$(PREFIX)/$(TARGET)/lib' \
         $(if $(findstring x86_64,$(TARGET)), --enable-64bit) \
-        CFLAGS='-D__MINGW_EXCPT_DEFINE_PSDK'
+        CFLAGS='-D__MINGW_EXCPT_DEFINE_PSDK -DSTATIC_BUILD=1'
     $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)' LIBS='-lmincore -lnetapi32 -lz -ltclstub86 -limm32 -lcomctl32 -luuid -lole32 -lgdi32 -lcomdlg32'
     $(MAKE) -C '$(BUILD_DIR)' -j 1 install
 endef


### PR DESCRIPTION
When built dynamically, we get the following error message:
`tkWin32Dll.o:tkWin32Dll.c:(.text+0x4d): relocation truncated to fit: R_X86_64_32S against '.text' `

Building this lib statically at least works.