### PR TITLE
update minizip to 3.0.1

### DIFF
--- a/src/minizip-1-fixes.patch
+++ b/src/minizip-1-fixes.patch
@@ -3,16 +3,19 @@ This file is part of MXE. See LICENSE.md for licensing information.
 Contains ad hoc patches for cross building.
 
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: brodieG <brodieG@users.noreply.github.com>
+Date: Tue, 21 Jun 2022 01:10:20 +0000
+Subject: [PATCH 1/5] fix format string
+
+Originally:
 From: Mark Brand <mabrand@mabrand.nl>
 Date: Thu, 28 May 2020 13:42:05 +0200
-Subject: [PATCH 1/4] fix format string
-
 
 diff --git a/minizip.c b/minizip.c
 index 1111111..2222222 100644
 --- a/minizip.c
 +++ b/minizip.c
-@@ -237,7 +237,7 @@ int32_t minizip_add_progress_cb(void *handle, void *userdata, mz_zip_file *file_
+@@ -202,7 +202,7 @@ int32_t minizip_add_progress_cb(void *handle, void *userdata, mz_zip_file *file_
  
      /* Print the progress of the current compress operation */
      if (options->verbose)
@@ -21,7 +24,7 @@ index 1111111..2222222 100644
              file_info->uncompressed_size, progress);
      return MZ_OK;
  }
-@@ -363,7 +363,7 @@ int32_t minizip_extract_progress_cb(void *handle, void *userdata, mz_zip_file *f
+@@ -314,7 +314,7 @@ int32_t minizip_extract_progress_cb(void *handle, void *userdata, mz_zip_file *f
  
      /* Print the progress of the current extraction */
      if (options->verbose)
@@ -32,38 +35,53 @@ index 1111111..2222222 100644
      return MZ_OK;
 
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: brodieG <brodieG@users.noreply.github.com>
+Date: Tue, 21 Jun 2022 01:14:03 +0000
+Subject: [PATCH 2/5] fix library names
+
+adding lzma in addition to origina fix for lbz2 by
 From: Mark Brand <mabrand@mabrand.nl>
 Date: Thu, 28 May 2020 14:33:19 +0200
-Subject: [PATCH 2/4] fix bzip2 library name
-
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
 index 1111111..2222222 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -134,7 +134,7 @@ if(MZ_BZIP2)
-         message(STATUS "Using BZIP2 ${BZIP2_VERSION_STRING}")
-         list(APPEND MINIZIP_INC ${BZIP2_INCLUDE_DIRS})
-         list(APPEND MINIZIP_DEF -DHAVE_BZIP2)
+@@ -255,7 +255,7 @@ if(MZ_BZIP2)
+         list(APPEND MINIZIP_LIB ${BZIP2_LIBRARIES})
+         list(APPEND MINIZIP_LBD ${BZIP2_LIBRARY_DIRS})
+ 
 -        set(PC_PRIVATE_LIBS "${PC_PRIVATE_LIBS} -lbzip2")
 +        set(PC_PRIVATE_LIBS "${PC_PRIVATE_LIBS} -lbz2")
-     endif()
- endif()
+     elseif(MZ_FETCH_LIBS)
+         clone_repo(bzip2 https://sourceware.org/git/bzip2.git)
+ 
+@@ -313,7 +313,7 @@ if(MZ_LZMA)
+         list(APPEND MINIZIP_INC ${LIBLZMA_INCLUDE_DIRS})
+         list(APPEND MINIZIP_LIB ${LIBLZMA_LIBRARIES})
+ 
+-        set(PC_PRIVATE_LIBS "${PC_PRIVATE_LIBS} -lliblzma")
++        set(PC_PRIVATE_LIBS "${PC_PRIVATE_LIBS} -llzma")
+     elseif(MZ_FETCH_LIBS)
+         clone_repo(liblzma https://git.tukaani.org/xz.git)
  
 
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: brodieG <brodieG@users.noreply.github.com>
+Date: Tue, 21 Jun 2022 01:14:54 +0000
+Subject: [PATCH 3/5] fix output library name
+
+Originally:
 From: Mark Brand <mabrand@mabrand.nl>
 Date: Thu, 28 May 2020 14:52:00 +0200
-Subject: [PATCH 3/4] fix output library name
-
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
 index 1111111..2222222 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -652,7 +652,7 @@ set_target_properties(${PROJECT_NAME} PROPERTIES
- 
- if(WIN32)
+@@ -708,7 +708,7 @@ if(MINIZIP_LFG)
+ endif()
+ if(MSVC)
      # VS debugger has problems when executable and static library are named the same
 -    set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME lib${PROJECT_NAME})
 +    set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME ${PROJECT_NAME})
@@ -72,20 +90,42 @@ index 1111111..2222222 100644
      set_target_properties(${PROJECT_NAME} PROPERTIES POSITION_INDEPENDENT_CODE 1)
 
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Mark Brand <mabrand@mabrand.nl>
-Date: Thu, 28 May 2020 15:04:20 +0200
-Subject: [PATCH 4/4] add missing private libcrypt32
+From: brodieG <brodieG@users.noreply.github.com>
+Date: Tue, 21 Jun 2022 01:16:56 +0000
+Subject: [PATCH 4/5] fix lcrypt library name
 
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
 index 1111111..2222222 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -257,6 +257,7 @@ if(WIN32)
-     if (MZ_PKCRYPT OR MZ_WZAES)
-         if (NOT MZ_OPENSSL AND NOT OPENSSL_FOUND AND NOT MZ_BRG)
-             list(APPEND MINIZIP_SRC "mz_crypt_win32.c")
-+            set(PC_PRIVATE_LIBS "${PC_PRIVATE_LIBS} -lcrypt32")
+@@ -437,7 +437,7 @@ if(WIN32)
+             message(STATUS "Using CryptoAPI")
+ 
+             list(APPEND MINIZIP_SRC mz_crypt_win32.c)
+-            list(APPEND MINIZIP_LIB crypt32.lib)
++            list(APPEND MINIZIP_LIB -lcrypt32)
          endif()
-     endif()
- endif()
+     else()
+         list(APPEND MINIZIP_DEF -DMZ_ZIP_NO_CRYPTO)
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: brodieG <brodieG@users.noreply.github.com>
+Date: Tue, 21 Jun 2022 01:17:43 +0000
+Subject: [PATCH 5/5] add lbz2 to pkgconfig
+
+
+diff --git a/minizip.pc.cmakein b/minizip.pc.cmakein
+index 1111111..2222222 100644
+--- a/minizip.pc.cmakein
++++ b/minizip.pc.cmakein
+@@ -8,7 +8,7 @@ Name: @PROJECT_NAME@
+ Description: Minizip zip file manipulation library
+ Version: @VERSION@
+ 
+-Requires: zlib
+-Libs: -L${libdir} -L${sharedlibdir} -l@PROJECT_NAME@
++Requires: zlib openssl
++Libs: -L${libdir} -L${sharedlibdir} -l@PROJECT_NAME@ -lbz2
+ Libs.private:@PC_PRIVATE_LIBS@
+ Cflags: -I${includedir}

--- a/src/minizip.mk
+++ b/src/minizip.mk
@@ -3,9 +3,9 @@
 PKG             := minizip
 $(PKG)_WEBSITE  := https://www.winimage.com/zLibDll/minizip.html
 $(PKG)_IGNORE   :=
-$(PKG)_VERSION  := 2aa369c
-$(PKG)_CHECKSUM := 165afc71c29863f41c4d1cf9d3a2b1333b863e3d66e5e05b9e1e41c5af8b8a44
-$(PKG)_GH_CONF  := nmoinvaz/minizip/branches/master
+$(PKG)_VERSION  := 3.0.1
+$(PKG)_CHECKSUM := 96c95b274dd535984ce0e87691691388f2b976106e8cf8d527b15da552ac94e4
+$(PKG)_GH_CONF  := zlib-ng/minizip-ng/releases
 $(PKG)_DEPS     := cc bzip2 zlib openssl
 
 define $(PKG)_BUILD
@@ -13,12 +13,13 @@ define $(PKG)_BUILD
     cd '$(BUILD_DIR)' && $(TARGET)-cmake '$(SOURCE_DIR)' \
         -DBUILD_TEST=OFF \
         -DUSE_ZLIB=ON
+
     $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)'
     $(MAKE) -C '$(BUILD_DIR)' -j 1 install
 
     # compile test
     '$(TARGET)-gcc' \
-        -W -Wall -Werror \
+        -W -Wall -Werror -Wno-format \
         -DHAVE_STDINT_H -DHAVE_INTTYPES_H \
         '$(SOURCE_DIR)/minizip.c' -o '$(PREFIX)/$(TARGET)/bin/test-$(PKG).exe' \
         `'$(TARGET)-pkg-config' $(PKG) --libs-only-l`


### PR DESCRIPTION
This is a small part of the GDAL 3.6 upgrade (#2918) (@mabrand).

Updating `PROJ` (which is still a todo) causes the `spatialite` build to start failing with the current `minizip`, and upgraded `minizip` to 3.0.1 resolves that.

I am not upgrading further because when I tested 3.0.3 that caused further issues downstream (3.0.2. is where the problem started, I have not looked at later versions yet as they were unreleased when I did this originally).  This will be something to look into once GDAL is upgraded.

I checked all the direct downstream dependencies.  Currently the following fail, but **they also fail on the master branch**, so it is not a change for the worse:

* `cegui` because it's dependency `freeimage` is failing (unrelated to this patch).
* `openscenegraph` shared builds, not linked properly, separate patch to follow (problem unrelated to this patch)
* `osgearth`

`osgearth` is broken in the master MXE branch because the current version is not compatible with the new [GEOS][14].  I upgraded `GEOS` for the new [`spatialite`][2], but because "osgearth.mk" didn't declare a dependency on GEOS I didn't notice this issue at the time.

I started trying to fix it but ran into some issues that I don't quite know how to resolve simply.  The problem is that the current version uses git submodules for some of the third party libraries, and those are not included as part of the build tarball on github, so the build fails.  I _think_ fixing this will require changes on the MXE build scripts to clone the repository with `--recurse-submodules` instead of using the Github pre-built tarball.

I have not looked into the `freeimage` problem.

[2]: https://github.com/mxe/mxe/pull/2873
[14]: https://github.com/gwaldron/osgearth/issues/1455
