### PR TITLE
Fix openscenegraph shared builds

### DIFF
--- a/src/openscenegraph-1-fixes.patch
+++ b/src/openscenegraph-1-fixes.patch
@@ -5,7 +5,7 @@ Contains ad hoc patches for cross building.
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Rashad Kanavath <rashad.kanavath@c-s.fr>
 Date: Sun, 10 Jan 2016 14:04:18 +1100
-Subject: [PATCH 2/6] openscenegraph: use previously built openthreads
+Subject: [PATCH 1/5] openscenegraph: use previously built openthreads
 
 
 diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
@@ -14,7 +14,7 @@ index 1111111..2222222 100644
 +++ b/src/CMakeLists.txt
 @@ -8,7 +8,6 @@ ENDIF()
  
- #the old construct SUBDIRS( was substituded by ADD_SUBDIRECTORY that is to be preferred according on CMake docs.
+ #the old construct SUBDIRS( was substituted by ADD_SUBDIRECTORY that is to be preferred according on CMake docs.
  FOREACH( mylibfolder
 -        OpenThreads
          osg
@@ -24,7 +24,7 @@ index 1111111..2222222 100644
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Boris Nagaev <bnagaev@gmail.com>
 Date: Mon, 22 Feb 2016 03:35:28 +0300
-Subject: [PATCH 3/6] disable ffmpeg
+Subject: [PATCH 2/5] disable ffmpeg
 
 OpenSceneGraph is using removed features of ffmpeg, which have
 been deprecated for 3+ years.
@@ -33,10 +33,10 @@ See https://github.com/mxe/mxe/issues/1230#issuecomment-186936198
 Source of patch: http://forum.openscenegraph.org/viewtopic.php?t=10485
 
 diff --git a/src/osgPlugins/CMakeLists.txt b/src/osgPlugins/CMakeLists.txt
-index 77d66f8..1c8398e 100644
+index 1111111..2222222 100644
 --- a/src/osgPlugins/CMakeLists.txt
 +++ b/src/osgPlugins/CMakeLists.txt
-@@ -213,10 +213,6 @@ IF(OSG_CPP_EXCEPTIONS_AVAILABLE)
+@@ -209,10 +209,6 @@ IF(OSG_CPP_EXCEPTIONS_AVAILABLE)
      ADD_PLUGIN_DIRECTORY(txp)
  ENDIF()
  
@@ -51,14 +51,14 @@ index 77d66f8..1c8398e 100644
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Boris Pek <tehnick-8@yandex.ru>
 Date: Wed, 10 Oct 2018 00:56:37 +0300
-Subject: [PATCH 5/6] fix build with GCC < 6.x
+Subject: [PATCH 3/5] fix build with GCC < 6.x
 
 
 diff --git a/src/osgViewer/GraphicsWindowWin32.cpp b/src/osgViewer/GraphicsWindowWin32.cpp
-index 91e6c8f..d11347e 100644
+index 1111111..2222222 100644
 --- a/src/osgViewer/GraphicsWindowWin32.cpp
 +++ b/src/osgViewer/GraphicsWindowWin32.cpp
-@@ -799,7 +799,7 @@ Win32WindowingSystem::Win32WindowingSystem()
+@@ -809,7 +809,7 @@ Win32WindowingSystem::Win32WindowingSystem()
  	if (hModuleShore) {
  		setProcessDpiAwareness = (SetProcessDpiAwarenessFunc *) GetProcAddress(hModuleShore, "SetProcessDpiAwareness");
  		if (setProcessDpiAwareness) {
@@ -71,12 +71,12 @@ index 91e6c8f..d11347e 100644
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Boris Pek <tehnick-8@yandex.ru>
 Date: Wed, 10 Oct 2018 01:48:22 +0300
-Subject: [PATCH 6/6] fix build of gta plugin when pkg-config is used
- + update related variable for build without pkg-config.
+Subject: [PATCH 4/5] fix build of gta plugin when pkg-config is used + update
+ related variable for build without pkg-config.
 
 
 diff --git a/CMakeModules/FindGTA.cmake b/CMakeModules/FindGTA.cmake
-index 086069c..e483ad3 100644
+index 1111111..2222222 100644
 --- a/CMakeModules/FindGTA.cmake
 +++ b/CMakeModules/FindGTA.cmake
 @@ -33,7 +33,7 @@ IF(NOT GTA_FOUND)
@@ -100,36 +100,8 @@ index 086069c..e483ad3 100644
  
  ENDIF(NOT GTA_FOUND)
 \ No newline at end of file
-diff --git a/src/osgPlugins/gta/CMakeLists.txt b/src/osgPlugins/gta/CMakeLists.txt
-index 2b910a6..16466fe 100644
---- a/src/osgPlugins/gta/CMakeLists.txt
-+++ b/src/osgPlugins/gta/CMakeLists.txt
-@@ -2,7 +2,7 @@ INCLUDE_DIRECTORIES( ${GTA_INCLUDE_DIRS} )
- 
- SET(TARGET_SRC ReaderWriterGTA.cpp )
- 
--SET(TARGET_LIBRARIES_VARS GTA_LIBRARY)
-+SET(TARGET_LIBRARIES_VARS GTA_LIBRARIES)
- 
- #### end var setup  ###
- SETUP_PLUGIN(gta)
- commit a2927adc037d2791483ef7fab2261e665ae14557
-Author: Gleb Mazovetskiy <glex.spb@gmail.com>
-Date:   Tue Mar 16 21:46:50 2021 +0000
-
-    Fix C++17 MSVC compilation error
-
-    With C++17, Windows headers must not be included after `using namespace std;`.
-
-    Windows headers define a `byte` type internally and `using namespace std`
-    causes it to conflict with `std::byte`:
-
-        error C2872: 'byte': ambiguous symbol
-
-    MSVC thread: https://developercommunity.visualstudio.com/t/error-c2872-byte-ambiguous-symbol/93889
-
 diff --git a/src/osg/DisplaySettings.cpp b/src/osg/DisplaySettings.cpp
-index 43156bd26..ef2f0e93a 100644
+index 1111111..2222222 100644
 --- a/src/osg/DisplaySettings.cpp
 +++ b/src/osg/DisplaySettings.cpp
 @@ -22,9 +22,6 @@
@@ -152,3 +124,35 @@ index 43156bd26..ef2f0e93a 100644
  void DisplaySettings::setNvOptimusEnablement(int value)
  {
      NvOptimusEnablement = value;
+diff --git a/src/osgPlugins/gta/CMakeLists.txt b/src/osgPlugins/gta/CMakeLists.txt
+index 1111111..2222222 100644
+--- a/src/osgPlugins/gta/CMakeLists.txt
++++ b/src/osgPlugins/gta/CMakeLists.txt
+@@ -2,7 +2,7 @@ INCLUDE_DIRECTORIES( ${GTA_INCLUDE_DIRS} )
+ 
+ SET(TARGET_SRC ReaderWriterGTA.cpp )
+ 
+-SET(TARGET_LIBRARIES_VARS GTA_LIBRARY)
++SET(TARGET_LIBRARIES_VARS GTA_LIBRARIES)
+ 
+ #### end var setup  ###
+ SETUP_PLUGIN(gta)
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: brodieG <brodieG@users.noreply.github.com>
+Date: Thu, 10 Nov 2022 01:29:08 +0000
+Subject: [PATCH 5/5] add tiff lib dependency
+
+
+diff --git a/src/osgPlugins/tiff/CMakeLists.txt b/src/osgPlugins/tiff/CMakeLists.txt
+index 1111111..2222222 100644
+--- a/src/osgPlugins/tiff/CMakeLists.txt
++++ b/src/osgPlugins/tiff/CMakeLists.txt
+@@ -4,5 +4,7 @@ SET(TARGET_SRC ReaderWriterTIFF.cpp )
+ 
+ SET(TARGET_LIBRARIES_VARS TIFF_LIBRARY)
+ 
++SET(TARGET_EXTERNAL_LIBRARIES tiff)
++
+ #### end var setup  ###
+ SETUP_PLUGIN(tiff)


### PR DESCRIPTION
This is one of the failing revdeps mentioned in #2933.  This was an existing failure where the `tiff` library was not getting properly linked for the shared builds.