### PR TITLE
Fix poppler static linking with pkgconfig

### DIFF
--- a/src/poppler-1-win32.patch
+++ b/src/poppler-1-win32.patch
@@ -5,7 +5,7 @@ Contains ad hoc patches for cross building.
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Stefan=20L=C3=B6ffler?= <st.loeffler@gmail.com>
 Date: Sat, 26 Jun 2021 19:49:25 +0200
-Subject: [PATCH 1/2] Fix static builds
+Subject: [PATCH 1/3] Fix static builds
 
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
@@ -25,7 +25,7 @@ index 1111111..2222222 100644
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Stefan=20L=C3=B6ffler?= <st.loeffler@gmail.com>
 Date: Thu, 4 Feb 2021 20:44:30 +0100
-Subject: [PATCH 2/2] Fix static linking for libopenjpeg >= 2.4
+Subject: [PATCH 2/3] Fix static linking for libopenjpeg >= 2.4
 
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
@@ -42,3 +42,24 @@ index 1111111..2222222 100644
  if(ENABLE_CMS STREQUAL "lcms2")
    find_package(LCMS2)
    set(USE_CMS ${LCMS2_FOUND})
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: brodieG <brodieG@users.noreply.github.com>
+Date: Sat, 5 Nov 2022 14:08:43 +0000
+Subject: [PATCH 3/3] Allow setting PC requires for C Lib
+
+POPPLER_REQUIRES should be set through the .mk file, although
+ideally this would all be done through the cmake files (and
+even better POPPLER would be configured for EXPORT).
+
+diff --git a/poppler.pc.cmake b/poppler.pc.cmake
+index 1111111..2222222 100644
+--- a/poppler.pc.cmake
++++ b/poppler.pc.cmake
+@@ -6,5 +6,6 @@ Name: poppler
+ Description: PDF rendering library
+ Version: @POPPLER_VERSION@
+ 
++Requires.private: @POPPLER_REQUIRES@
+ Libs: -L${libdir} -lpoppler
+ Cflags: -I${includedir}/poppler

--- a/src/poppler.mk
+++ b/src/poppler.mk
@@ -17,6 +17,7 @@ endef
 define $(PKG)_BUILD
     # build and install the library
     cd '$(BUILD_DIR)' && $(TARGET)-cmake \
+        -DPOPPLER_REQUIRES="lcms2 freetype2 libjpeg libpng libopenjp2 libtiff-4" \
         -DENABLE_UNSTABLE_API_ABI_HEADERS=ON \
         -DBUILD_GTK_TESTS=OFF \
         -DBUILD_QT5_TESTS=OFF \


### PR DESCRIPTION
Yet another small change chipped off of #2918.  Declares pkgconfig requires so that static builds relying on pkgconfig work correctly.