### PR TITLE
add pkgconfig files to HDF4

### DIFF
--- a/src/hdf4.mk
+++ b/src/hdf4.mk
@@ -40,4 +40,22 @@ define $(PKG)_BUILD
     $(MAKE) -C '$(1)'/mfhdf/libsrc -j '$(JOBS)' \
         LDFLAGS="-no-undefined -ldf"
     $(MAKE) -C '$(1)'/mfhdf/libsrc -j 1 install
+
+    # create pkg-config file
+    $(INSTALL) -d '$(PREFIX)/$(TARGET)/lib/pkgconfig'
+    (echo 'Name: $(PKG)'; \
+     echo 'Version: $($(PKG)_VERSION)'; \
+     echo 'Description: $($(PKG)_DESCR)'; \
+     echo 'Requires.private: libjpeg zlib'; \
+     echo 'Libs: -ldf'; \
+    ) > '$(PREFIX)/$(TARGET)/lib/pkgconfig/df.pc'
+    $(INSTALL) -d '$(PREFIX)/$(TARGET)/lib/pkgconfig'
+    (echo 'Name: $(PKG)'; \
+     echo 'Version: $($(PKG)_VERSION)'; \
+     echo 'Description: $($(PKG)_DESCR)'; \
+     echo 'Requires.private: df'; \
+     echo 'Libs: -lmfhdf'; \
+     echo 'Libs.private: -lportablexdr -lws2_32'; \
+    ) > '$(PREFIX)/$(TARGET)/lib/pkgconfig/mfhdf.pc'
+
 endef


### PR DESCRIPTION
This is required for correct linking of netcdf once it and hdf5 are upgraded.  Those upgrades are forthcoming, but since this doesn't patch doesn't interfere with anything else splitting it off to make subsequent patches smaller.

This are additional small parts of the GDAL 3.6.0 update #2918.
