### PR TITLE
Prepare netcdf-cxx4 for HDF5 upgrade

### DIFF
--- a/src/netcdf-cxx4.mk
+++ b/src/netcdf-cxx4.mk
@@ -14,6 +14,15 @@ define $(PKG)_BUILD
     cd '$(BUILD_DIR)' && $(TARGET)-cmake '$(SOURCE_DIR)' \
         -DENABLE_DOXYGEN=OFF \
         -DNCXX_ENABLE_TESTS=OFF
+
+    # fix hdf5 target/libname mixup
+    $(if $(BUILD_SHARED), \
+      $(SED) -i -e 's!-lhdf5_hl-\(static\|shared\)!-lhdf5_hl!g' \
+          '$(BUILD_DIR)/cxx4/CMakeFiles/netcdf-cxx4.dir/linklibs.rsp'
+      $(SED) -i -e 's!-lhdf5-\(static\|shared\)!-lhdf5!g' \
+          '$(BUILD_DIR)/cxx4/CMakeFiles/netcdf-cxx4.dir/linklibs.rsp'
+    )
+
     $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)'
     $(MAKE) -C '$(BUILD_DIR)' -j 1 install
 


### PR DESCRIPTION
This is another small part of the #2918 (GDAL->3.6.0) upgrade.  It probably should be merged after the #2935 (PROJ) update as that's how I've tested it, but it's likely okay stand-alone.

This is not needed currently and the sole purpose of this patch is to make the final GDAL patch smaller.