### PR TITLE
upgrade/fix lapack and armadillo

### DIFF
--- a/src/armadillo.mk
+++ b/src/armadillo.mk
@@ -4,12 +4,12 @@ PKG             := armadillo
 $(PKG)_WEBSITE  := https://arma.sourceforge.io/
 $(PKG)_DESCR    := Armadillo C++ linear algebra library
 $(PKG)_IGNORE   :=
-$(PKG)_VERSION  := 8.200.2
-$(PKG)_CHECKSUM := 63845e36235f2bd78b4f6890fe5013b6ce51a4e92e3176b20bbc6631b340050a
+$(PKG)_VERSION  := 11.4.3
+$(PKG)_CHECKSUM := 87603263664988af41da2ca4f36205e36ea47a9281fa6cfd463115f3797a1da2
 $(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
 $(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.xz
 $(PKG)_URL      := https://$(SOURCEFORGE_MIRROR)/project/arma/$($(PKG)_FILE)
-$(PKG)_DEPS     := cc hdf5 openblas
+$(PKG)_DEPS     := cc hdf5 openblas lapack
 
 define $(PKG)_UPDATE
     $(WGET) -q -O- 'https://sourceforge.net/projects/arma/files/' | \
@@ -20,8 +20,10 @@ endef
 define $(PKG)_BUILD
     # build and install the library
     cd '$(BUILD_DIR)' && $(TARGET)-cmake '$(SOURCE_DIR)' \
-        -DDETECT_HDF5=ON \
-        -DARMA_USE_WRAPPER=ON
+        -DARMA_HDF5_INCLUDE_DIR=$(PREFIX)/$(TARGET)/include \
+        -DDETECT_HDF5=OFF \
+        -DARMA_USE_WRAPPER=ON \
+        -DBUILD_SMOKE_TEST=OFF
     $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)'
     $(MAKE) -C '$(BUILD_DIR)' -j 1 install VERBOSE=1
 
@@ -36,7 +38,7 @@ define $(PKG)_BUILD
 
     # compile test
     '$(TARGET)-g++' \
-        -W -Wall -Werror \
+        -W -Wall -Werror -fopenmp \
         '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-$(PKG).exe' \
-        `'$(TARGET)-pkg-config' $(PKG) --cflags --libs`
+        `'$(TARGET)-pkg-config' $(PKG) --cflags --libs` -lgomp
 endef

--- a/src/blas.mk
+++ b/src/blas.mk
@@ -20,7 +20,8 @@ define $(PKG)_BUILD
         -DCMAKE_AR='$(PREFIX)/bin/$(TARGET)-ar' \
         -DCMAKE_RANLIB='$(PREFIX)/bin/$(TARGET)-ranlib' \
         -DCBLAS=OFF \
-        -DLAPACKE=OFF
+        -DLAPACKE=OFF \
+        -DTEST_FORTRAN_COMPILER:BOOL=OFF
     $(MAKE) -C '$(BUILD_DIR)/BLAS' -j '$(JOBS)'
     $(MAKE) -C '$(BUILD_DIR)/BLAS' -j 1 install
 endef

--- a/src/lapack.mk
+++ b/src/lapack.mk
@@ -4,19 +4,20 @@ PKG             := lapack
 $(PKG)_WEBSITE  := https://www.netlib.org/lapack/
 $(PKG)_DESCR    := Reference LAPACK — Linear Algebra PACKage
 $(PKG)_IGNORE   :=
-$(PKG)_VERSION  := 3.10.0
-$(PKG)_CHECKSUM := 328c1bea493a32cac5257d84157dc686cc3ab0b004e2bea22044e0a59f6f8a19
+$(PKG)_VERSION  := 3.11.0
+$(PKG)_CHECKSUM := 4b9ba79bfd4921ca820e83979db76ab3363155709444a787979e81c22285ffa9
 $(PKG)_GH_CONF  := Reference-LAPACK/lapack/tags,v
 $(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.gz
 $(PKG)_DEPS     := cc cblas
 
 define $(PKG)_BUILD
-    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' '$(SOURCE_DIR)' \
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --trace-expand '$(SOURCE_DIR)' \
         -DCMAKE_AR='$(PREFIX)/bin/$(TARGET)-ar' \
         -DCMAKE_RANLIB='$(PREFIX)/bin/$(TARGET)-ranlib' \
         -DBLAS_LIBRARIES=blas \
         -DCBLAS=OFF \
-        -DLAPACKE=ON
+        -DLAPACKE=ON \
+        -DTEST_FORTRAN_COMPILER:BOOL=OFF
     $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)'
     $(MAKE) -C '$(BUILD_DIR)' -j 1 install
 


### PR DESCRIPTION
GDAL 3.6.2 (see #2943) changed how armadillo is tested on configuration, and passing those tests correctly requires these fixes.  I also include some changes that would otherwise have been part of the GDAL PR here.