### PR TITLE
remove expat cmake files...

### DIFF
--- a/src/expat.mk
+++ b/src/expat.mk
@@ -24,4 +24,9 @@ define $(PKG)_BUILD
         --without-docbook
     $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)'
     $(MAKE) -C '$(BUILD_DIR)' -j 1 install
+
+    # Remove cmake folder since we're not using cmake here and it's
+    # prebuilt misconfigured for MXE
+    $(RM) -r '$(PREFIX)/$(TARGET)/lib/cmake/expat-$($(PKG)_VERSION)'
+
 endef


### PR DESCRIPTION
because MXE does not configure with cmake so those files cause downstream processes that use them to fail (e.g. GDAL 3.6.x).

This is part of the forthcoming GDAL upgrade (#2943).

