### PR TITLE
Add libslirp 4.7.0

### DIFF
--- a/src/libslirp-1.patch
+++ b/src/libslirp-1.patch
@@ -1,0 +1,34 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Matt Borgerson <contact@mborgerson.com>
+Date: Mon, 23 Jan 2023 03:06:46 -0700
+Subject: [PATCH] Rename pingtest's slirp_inet_aton
+
+---
+ test/pingtest.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/test/pingtest.c b/test/pingtest.c
+index 3bb0488..04b63ce 100644
+--- a/test/pingtest.c
++++ b/test/pingtest.c
+@@ -24,7 +24,7 @@
+ #ifdef _WIN32
+ //#include <sys/select.h>
+ #include <winsock2.h>
+-int slirp_inet_aton(const char *cp, struct in_addr *ia)
++int pingtest_inet_aton(const char *cp, struct in_addr *ia)
+ {
+     uint32_t addr = inet_addr(cp);
+     if (addr == 0xffffffff) {
+@@ -33,7 +33,7 @@ int slirp_inet_aton(const char *cp, struct in_addr *ia)
+     ia->s_addr = addr;
+     return 1;
+ }
+-#define inet_aton slirp_inet_aton
++#define inet_aton pingtest_inet_aton
+ #else
+ #include <poll.h>
+ #endif
+-- 
+2.34.1
+

--- a/src/libslirp-test.c
+++ b/src/libslirp-test.c
@@ -1,0 +1,23 @@
+/*
+ * This file is part of MXE. See LICENSE.md for licensing information.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <libslirp.h>
+
+int main(int argc, char *argv[])
+{
+    Slirp *slirp;
+    SlirpConfig config;
+
+    printf("Slirp version %s\n", slirp_version_string());
+
+    memset(&config, 0, sizeof(config));
+    config.version = 1;
+
+    slirp = slirp_new(&config, NULL, NULL);
+    slirp_cleanup(slirp);
+
+    return 0;
+}

--- a/src/libslirp.mk
+++ b/src/libslirp.mk
@@ -1,0 +1,22 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+PKG             := libslirp
+$(PKG)_WEBSITE  := https://gitlab.freedesktop.org/slirp/libslirp
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 4.7.0
+$(PKG)_SUBDIR   := libslirp-v$($(PKG)_VERSION)
+$(PKG)_FILE     := libslirp-v$($(PKG)_VERSION).tar.gz
+$(PKG)_CHECKSUM := 9398f0ec5a581d4e1cd6856b88ae83927e458d643788c3391a39e61b75db3d3b
+$(PKG)_URL      := https://gitlab.freedesktop.org/slirp/$(PKG)/-/archive/v$($(PKG)_VERSION)/$($(PKG)_FILE)
+$(PKG)_DEPS     := cc glib meson-wrapper
+
+define $(PKG)_BUILD
+    '$(MXE_MESON_WRAPPER)' $(MXE_MESON_OPTS) \
+        $(PKG_MESON_OPTS) \
+        '$(BUILD_DIR)' '$(SOURCE_DIR)'
+    '$(MXE_NINJA)' -C '$(BUILD_DIR)' -j '$(JOBS)' install
+
+    '$(TARGET)-gcc' \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-libslirp.exe' \
+        `'$(TARGET)-pkg-config' slirp --cflags --libs`
+endef


### PR DESCRIPTION
> A general purpose TCP-IP emulator used by virtual machine hypervisors to provide virtual networking services.

[libslirp](https://gitlab.freedesktop.org/slirp/libslirp)