### PR TITLE
lua: update 5.3.3 -> 5.4.4

### DIFF
--- a/src/lua-1-fixes.patch
+++ b/src/lua-1-fixes.patch
@@ -12,41 +12,21 @@ diff --git a/src/Makefile b/src/Makefile
 index 1111111..2222222 100644
 --- a/src/Makefile
 +++ b/src/Makefile
-@@ -102,15 +102,15 @@ c89:
+@@ -113,7 +113,7 @@ c89:
+ 	@echo ''
  
- 
- freebsd:
--	$(MAKE) $(ALL) SYSCFLAGS="-DLUA_USE_LINUX" SYSLIBS="-Wl,-E -lreadline"
-+	$(MAKE) $(ALL) SYSCFLAGS="-DLUA_USE_LINUX"
+ FreeBSD NetBSD OpenBSD freebsd:
+-	$(MAKE) $(ALL) SYSCFLAGS="-DLUA_USE_LINUX -DLUA_USE_READLINE -I/usr/include/edit" SYSLIBS="-Wl,-E -ledit" CC="cc"
++	$(MAKE) $(ALL) SYSCFLAGS="-DLUA_USE_LINUX -I/usr/include/edit" SYSLIBS="-Wl,-E -ledit" CC="cc"
  
  generic: $(ALL)
  
- linux:
--	$(MAKE) $(ALL) SYSCFLAGS="-DLUA_USE_LINUX" SYSLIBS="-Wl,-E -ldl -lreadline"
-+	$(MAKE) $(ALL) SYSCFLAGS="-DLUA_USE_LINUX" SYSLIBS="-Wl,-E -ldl"
+@@ -126,7 +126,7 @@ linux-readline:
+ 	$(MAKE) $(ALL) SYSCFLAGS="-DLUA_USE_LINUX -DLUA_USE_READLINE" SYSLIBS="-Wl,-E -ldl -lreadline"
  
- macosx:
--	$(MAKE) $(ALL) SYSCFLAGS="-DLUA_USE_MACOSX" SYSLIBS="-lreadline" CC=cc
-+	$(MAKE) $(ALL) SYSCFLAGS="-DLUA_USE_MACOSX" CC=cc
+ Darwin macos macosx:
+-	$(MAKE) $(ALL) SYSCFLAGS="-DLUA_USE_MACOSX -DLUA_USE_READLINE" SYSLIBS="-lreadline"
++	$(MAKE) $(ALL) SYSCFLAGS="-DLUA_USE_MACOSX"
  
  mingw:
- 	$(MAKE) "LUA_A=lua53.dll" "LUA_T=lua.exe" \
-diff --git a/src/luaconf.h b/src/luaconf.h
-index 1111111..2222222 100644
---- a/src/luaconf.h
-+++ b/src/luaconf.h
-@@ -61,14 +61,12 @@
- #if defined(LUA_USE_LINUX)
- #define LUA_USE_POSIX
- #define LUA_USE_DLOPEN		/* needs an extra library: -ldl */
--#define LUA_USE_READLINE	/* needs some extra libraries */
- #endif
- 
- 
- #if defined(LUA_USE_MACOSX)
- #define LUA_USE_POSIX
- #define LUA_USE_DLOPEN		/* MacOS does not need -ldl */
--#define LUA_USE_READLINE	/* needs an extra library: -lreadline */
- #endif
- 
- 
+ 	$(MAKE) "LUA_A=lua54.dll" "LUA_T=lua.exe" \

--- a/src/lua.mk
+++ b/src/lua.mk
@@ -4,11 +4,11 @@ PKG             := lua
 $(PKG)_WEBSITE  := https://www.lua.org/
 $(PKG)_DESCR    := Lua
 $(PKG)_IGNORE   :=
-$(PKG)_VERSION  := 5.3.3
+$(PKG)_VERSION  := 5.4.4
 # Shared version and luarocks subdir
 $(PKG)_SHORTVER := $(call SHORT_PKG_VERSION,$(PKG))
 $(PKG)_DLLVER   := $(subst .,,$($(PKG)_SHORTVER))
-$(PKG)_CHECKSUM := 5113c06884f7de453ce57702abaac1d618307f33f6789fa870e87a59d772aca2
+$(PKG)_CHECKSUM := 164c7849653b80ae67bec4b7473b884bf5cc8d2dca05653475ec2ed27b9ebf61
 $(PKG)_SUBDIR   := lua-$($(PKG)_VERSION)
 $(PKG)_FILE     := lua-$($(PKG)_VERSION).tar.gz
 $(PKG)_URL      := https://www.lua.org/ftp/$($(PKG)_FILE)


### PR DESCRIPTION
Please note that `src/lua-1-fixes.patch` had to be changed in a non-trivial way. Lua built fine on my machine, but some more testing (with a clean install and/or on FreeBSD) could be useful.