### PR TITLE
Add qtkeychain-qt6 package

### DIFF
--- a/src/pkgconf.mk
+++ b/src/pkgconf.mk
@@ -18,7 +18,7 @@ endef
 define $(PKG)_BUILD
     # create pkg-config script
     (echo '#!/bin/sh'; \
-     echo 'PKG_CONFIG_PATH="$(PREFIX)/$(TARGET)/qt5/lib/pkgconfig":"$$PKG_CONFIG_PATH_$(subst .,_,$(subst -,_,$(TARGET)))" \
+     echo 'PKG_CONFIG_PATH="$(PREFIX)/$(TARGET)/qt5/lib/pkgconfig":"$(PREFIX)/$(TARGET)/$(MXE_QT6_ID)/lib/pkgconfig":"$$PKG_CONFIG_PATH_$(subst .,_,$(subst -,_,$(TARGET)))" \
            PKG_CONFIG_SYSROOT_DIR= \
            PKG_CONFIG_LIBDIR="$(PREFIX)/$(TARGET)/lib/pkgconfig" \
            PKG_CONFIG_SYSTEM_INCLUDE_PATH="$(PREFIX)/$(TARGET)/include" \

--- a/src/qt/qt6/qt6-qtbase.mk
+++ b/src/qt/qt6/qt6-qtbase.mk
@@ -65,6 +65,11 @@ define $(PKG)_BUILD
 	      -e 's/^QMAKE_PRL_LIBS_FOR_CMAKE .*/&;-lodbc32/;' \
               '$(PREFIX)/$(TARGET)/$(MXE_QT6_ID)/plugins/sqldrivers/qsqlodbc.prl',)
 
+    # QTBUG-103019 MinGW Qt6Platform.pc has an extra '>' after '-D_UNICODE'
+    # https://bugreports.qt.io/browse/QTBUG-103019
+    $(SED) -i 's/-D_UNICODE>/-D_UNICODE/' \
+              '$(PREFIX)/$(TARGET)/$(MXE_QT6_ID)/lib/pkgconfig/Qt6Platform.pc'
+
     mkdir -p '$(CMAKE_TOOLCHAIN_DIR)'
     echo 'set(QT_HOST_PATH "$(PREFIX)/$(BUILD)/$(MXE_QT6_ID)")' \
         > '$(CMAKE_TOOLCHAIN_DIR)/$(PKG).cmake'

--- a/src/qtkeychain-qt6.mk
+++ b/src/qtkeychain-qt6.mk
@@ -1,0 +1,15 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+PKG := qtkeychain-qt6
+$(PKG)_WEBSITE  = $(qtkeychain_WEBSITE)
+$(PKG)_DESCR    = $(qtkeychain_DESCR)
+$(PKG)_IGNORE   = $(qtkeychain_IGNORE)
+$(PKG)_VERSION  = $(qtkeychain_VERSION)
+$(PKG)_CHECKSUM = $(qtkeychain_CHECKSUM)
+$(PKG)_GH_CONF  = $(qtkeychain_GH_CONF)
+$(PKG)_DEPS     = cc qt6-qttools
+
+$(PKG)_BUILD = $(subst @build_with_qt6@,on, \
+               $(subst @qt_version_prefix@,qt6, \
+               $(subst @qtcore_pkgconfig_module@,Qt6Core, \
+               $(qtkeychain_BUILD_COMMON))))

--- a/src/qtkeychain.mk
+++ b/src/qtkeychain.mk
@@ -9,29 +9,35 @@ $(PKG)_CHECKSUM := cc547d58c1402f6724d3ff89e4ca83389d9e2bdcfd9ae3d695fcdffa50a62
 $(PKG)_GH_CONF  := frankosterfeld/qtkeychain/tags,v
 $(PKG)_DEPS     := cc qttools
 
-define $(PKG)_BUILD
+define $(PKG)_BUILD_COMMON
     cd '$(BUILD_DIR)' && $(TARGET)-cmake '$(SOURCE_DIR)' \
         -DQTKEYCHAIN_STATIC=$(CMAKE_STATIC_BOOL) \
-        -DBUILD_TEST_APPLICATION="OFF"
+        -DBUILD_TEST_APPLICATION="OFF" \
+        -DBUILD_WITH_QT6=@build_with_qt6@
     $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)'
     $(MAKE) -C '$(BUILD_DIR)' -j 1 install
 
     '$(TARGET)-g++' \
-        -W -Wall -Werror -ansi -pedantic -std=c++11 \
-        '$(SOURCE_DIR)/testclient.cpp' -o '$(PREFIX)/$(TARGET)/bin/test-qt5keychain.exe' \
-        `'$(TARGET)-pkg-config' Qt5Core --cflags --libs` \
-        '-I$(PREFIX)/$(TARGET)/include/qt5keychain' -lqt5keychain
+        -W -Wall -Werror -ansi -pedantic -std=c++17 \
+        '$(SOURCE_DIR)/testclient.cpp' -o '$(PREFIX)/$(TARGET)/bin/test-$(PKG).exe' \
+        `'$(TARGET)-pkg-config' @qtcore_pkgconfig_module@ --cflags --libs` \
+        '-I$(PREFIX)/$(TARGET)/include/@qt_version_prefix@keychain' -l@qt_version_prefix@keychain
 
     # create a batch file to run the test (as the test program requires arguments)
     # Note: the keychain uses APIs that are only available on Windows7 and newer.
     (printf 'REM Run the common actions against the test program.\r\n'; \
      printf 'REM First add a new user to the keychain, with the password badpass\r\n'; \
-     printf 'test-qt5keychain.exe store username badpass\r\n'; \
+     printf 'test-@qt_version_prefix@keychain.exe store username badpass\r\n'; \
      printf 'REM The result of the next command should read badpass\r\n'; \
-     printf 'test-qt5keychain.exe restore username\r\n'; \
+     printf 'test-@qt_version_prefix@keychain.exe restore username\r\n'; \
      printf 'REM Now we delete the user from the keychain\r\n'; \
-     printf 'test-qt5keychain.exe delete username\r\n'; \
+     printf 'test-@qt_version_prefix@keychain.exe delete username\r\n'; \
      printf 'REM The result of the next command should fail as the user has been removed from the keychain\r\n'; \
-     printf 'test-qt5keychain.exe delete username\r\n';) \
-> '$(PREFIX)/$(TARGET)/bin/test-qt5keychain.bat'
+     printf 'test-@qt_version_prefix@keychain.exe delete username\r\n';) \
+> '$(PREFIX)/$(TARGET)/bin/test-@qt_version_prefix@keychain.bat'
 endef
+
+$(PKG)_build = $(subst @build_with_qt6@,off, \
+               $(subst @qt_version_prefix@,qt5, \
+               $(subst @qtcore_pkgconfig_module@,Qt5Core, \
+               $($(PKG)_BUILD_COMMON))))


### PR DESCRIPTION
QtKeychain (https://github.com/frankosterfeld/qtkeychain/) supports both Qt5 and Qt6. mxe's qtkeychain package only builds for Qt5 today. This Pull Request adds a qtkeychain-qt6 package based on the existing qtkeychain package.

The first two commits solve issues with Qt6's pkgconfig support, which the qtkeychain relies on for its test program.