### PR TITLE
Add spdlog package

### DIFF
--- a/src/spdlog-1-fixes.patch
+++ b/src/spdlog-1-fixes.patch
@@ -1,0 +1,62 @@
+This file is part of MXE. See LICENSE.md for licensing information.
+
+Contains ad hoc patches for cross building.
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Zeus James <39390245+zEuS0390@users.noreply.github.com>
+Date: Sun, 12 Feb 2023 16:34:22 +0800
+Subject: [PATCH] Fix MinGW build issue on example (#2642)
+
+* Fix MinGW build issue on example #2638
+
+* Move the cmake change to example\CMakeLists.txt
+
+* Update CMakeLists.txt on the example
+
+Signed-off-by: Jan200101 <sentrycraft123@gmail.com>
+---
+ example/CMakeLists.txt                      |  2 +-
+ include/spdlog/details/udp_client-windows.h | 10 ++++++----
+ 2 files changed, 7 insertions(+), 5 deletions(-)
+
+diff --git a/example/CMakeLists.txt b/example/CMakeLists.txt
+index 83336e98..a7863493 100644
+--- a/example/CMakeLists.txt
++++ b/example/CMakeLists.txt
+@@ -12,7 +12,7 @@ endif()
+ # Example of using pre-compiled library
+ # ---------------------------------------------------------------------------------------
+ add_executable(example example.cpp)
+-target_link_libraries(example PRIVATE spdlog::spdlog)
++target_link_libraries(example PRIVATE spdlog::spdlog $<$<BOOL:${MINGW}>:ws2_32>)
+ 
+ # ---------------------------------------------------------------------------------------
+ # Example of using header-only library
+diff --git a/include/spdlog/details/udp_client-windows.h b/include/spdlog/details/udp_client-windows.h
+index 8e763356..7d25f037 100644
+--- a/include/spdlog/details/udp_client-windows.h
++++ b/include/spdlog/details/udp_client-windows.h
+@@ -15,9 +15,11 @@
+ #include <stdio.h>
+ #include <string>
+ 
+-#pragma comment(lib, "Ws2_32.lib")
+-#pragma comment(lib, "Mswsock.lib")
+-#pragma comment(lib, "AdvApi32.lib")
++#if defined(_MSC_VER)
++#	pragma comment(lib, "Ws2_32.lib")
++#	pragma comment(lib, "Mswsock.lib")
++#	pragma comment(lib, "AdvApi32.lib")
++#endif
+ 
+ namespace spdlog {
+ namespace details {
+@@ -25,7 +27,7 @@ class udp_client
+ {
+     static constexpr int TX_BUFFER_SIZE = 1024 * 10;
+     SOCKET socket_ = INVALID_SOCKET;
+-    sockaddr_in addr_ = {0};
++    sockaddr_in addr_ = {};
+ 
+     static void init_winsock_()
+     {

--- a/src/spdlog-test.cpp
+++ b/src/spdlog-test.cpp
@@ -1,0 +1,9 @@
+
+#include "spdlog/spdlog.h"
+
+int main() 
+{
+    spdlog::info("spdlog test");
+    spdlog::error("spdlog error {}", "with format");
+}
+

--- a/src/spdlog.mk
+++ b/src/spdlog.mk
@@ -1,0 +1,16 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+PKG             := spdlog
+$(PKG)_WEBSITE  := https://github.com/gabime/$(PKG)
+$(PKG)_DESCR    := Fast C++ logging library.
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 1.11.0
+$(PKG)_CHECKSUM := ca5cae8d6cac15dae0ec63b21d6ad3530070650f68076f3a4a862ca293a858bb
+$(PKG)_GH_CONF  := gabime/spdlog/releases,v
+$(PKG)_DEPS     := cc
+
+define $(PKG)_BUILD
+    '$(TARGET)-cmake' -S $(SOURCE_DIR) -B $(BUILD_DIR)
+    $(MAKE) -C '$(BUILD_DIR)' -j $(JOBS)
+    $(MAKE) -C '$(BUILD_DIR)' install
+endef


### PR DESCRIPTION
upstream: https://github.com/gabime/spdlog

spdlog is a general purpose C++ logging library.

One commit had to be picked from upstream and applied on the latest release to make mingw builds function
https://github.com/gabime/spdlog/commit/da14258533cb951ce85087ceb45556e0b8253660

I didn't end up using patch-tool-mxe and skeleton.py and things appear to be working without issue.