### PR TITLE
DjVuLibre: update to 3.5.28

### DIFF
--- a/src/djvulibre-1-fixes.patch
+++ b/src/djvulibre-1-fixes.patch
@@ -4,80 +4,10 @@ Contains ad hoc patches for cross building.
 
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: darealshinji <djcj@gmx.de>
-Date: Sun, 24 Jul 2016 09:33:22 +0200
-Subject: [PATCH 1/3] define XXX_EXPORT symbols
-
-
-diff --git a/libdjvu/Makefile.am b/libdjvu/Makefile.am
-index 1111111..2222222 100644
---- a/libdjvu/Makefile.am
-+++ b/libdjvu/Makefile.am
-@@ -33,6 +33,8 @@ libdjvulibre_la_LIBADD = $(JPEG_LIBS) $(PTHREAD_LIBS)
- libdjvulibre_la_LDFLAGS = -no-undefined -version-info $(version_info)
- 
- if HAVE_OS_WIN32
-+libdjvulibre_la_CPPFLAGS += -DDJVUAPI_EXPORT
-+libdjvulibre_la_CPPFLAGS += -DDDJVUAPI_EXPORT -DMINILISPAPI_EXPORT
- libdjvulibre_la_LDFLAGS += -Wl,--export-all-symbols
- endif
- 
-
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: darealshinji <djcj@gmx.de>
-Date: Sun, 24 Jul 2016 09:36:49 +0200
-Subject: [PATCH 2/3] disable unknown pragma warnings
-
-
-diff --git a/libdjvu/miniexp.cpp b/libdjvu/miniexp.cpp
-index 1111111..2222222 100644
---- a/libdjvu/miniexp.cpp
-+++ b/libdjvu/miniexp.cpp
-@@ -382,6 +382,7 @@ static void NTAPI gctls_cb(PVOID, DWORD dwReason, PVOID) {
-     {CSLOCK(r);TlsFree(tlsIndex);tlsIndex=TLS_OUT_OF_INDEXES;}
- }
- # endif
-+#ifdef __MSC_VER
- // -- Very black magic to clean tls variables.
- # ifdef _M_IX86
- #  pragma comment (linker, "/INCLUDE:_tlscb")
-@@ -391,6 +392,7 @@ static void NTAPI gctls_cb(PVOID, DWORD dwReason, PVOID) {
- # pragma const_seg(".CRT$XLB")
- extern "C" PIMAGE_TLS_CALLBACK tlscb = gctls_cb;
- # pragma const_seg()
-+#endif  //__MSC_VER
- 
- #else
- // No threads
-
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: darealshinji <djcj@gmx.de>
 Date: Sat, 1 Jul 2017 01:26:10 +0200
-Subject: [PATCH 3/3] enable static library builds
+Subject: [PATCH 1/1] enable static library builds
 
 
-diff --git a/libdjvu/DjVuGlobal.h b/libdjvu/DjVuGlobal.h
-index 1111111..2222222 100644
---- a/libdjvu/DjVuGlobal.h
-+++ b/libdjvu/DjVuGlobal.h
-@@ -70,11 +70,13 @@
- # include <new> // try standard c++ anyway!
- #endif
- 
--#ifdef _WIN32
--# ifdef DJVUAPI_EXPORT
--#  define DJVUAPI __declspec(dllexport)
--# else
--#  define DJVUAPI __declspec(dllimport)
-+#ifndef DJVUAPI
-+# ifdef _WIN32
-+#  ifdef DJVUAPI_EXPORT
-+#   define DJVUAPI __declspec(dllexport)
-+#  else
-+#   define DJVUAPI __declspec(dllimport)
-+#  endif
- # endif
- #endif
- #ifndef DJVUAPI
 diff --git a/libdjvu/Makefile.am b/libdjvu/Makefile.am
 index 1111111..2222222 100644
 --- a/libdjvu/Makefile.am

--- a/src/djvulibre.mk
+++ b/src/djvulibre.mk
@@ -3,8 +3,8 @@
 PKG             := djvulibre
 $(PKG)_WEBSITE  := https://djvu.sourceforge.io/
 $(PKG)_DESCR    := DjVuLibre
-$(PKG)_VERSION  := 3.5.27
-$(PKG)_CHECKSUM := e69668252565603875fb88500cde02bf93d12d48a3884e472696c896e81f505f
+$(PKG)_VERSION  := 3.5.28
+$(PKG)_CHECKSUM := fcd009ea7654fde5a83600eb80757bd3a76998e47d13c66b54c8db849f8f2edc
 $(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
 $(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.gz
 $(PKG)_URL      := https://$(SOURCEFORGE_MIRROR)/project/djvu/DjVuLibre/$($(PKG)_VERSION)/$($(PKG)_FILE)


### PR DESCRIPTION
Most of the patches are not needed anymore.

Please read http://mxe.cc/#creating-packages

In particular, make sure that your build rules:

  * install .pc file,
  * install bin/test-pkg.exe compiled with flags by pkg-config,
  * install .dll to bin/ and .a, .dll.a to lib/,
  * use $(TARGET)-cmake instead of cmake,
  * build in `$(BUILD_DIR)` instead of `$(SOURCE_DIR)`,
  * do not run target executables with Wine,
  * do not download anything while building,
  * do not install documentation,
  * do not install .exe files except test and build systems,

and .patch files are generated by tools/patch-tool-mxe.

If you add a package, you can use tool tools/skeleton.py.

Thanks!
