### PR TITLE
poppler: move poppler-qt libraries into their own packages

### DIFF
--- a/src/poppler-qt5.mk
+++ b/src/poppler-qt5.mk
@@ -1,0 +1,23 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+PKG             := poppler-qt5
+$(PKG)_WEBSITE   = $(poppler_WEBSITE)
+$(PKG)_IGNORE    = $(poppler_IGNORE)
+$(PKG)_VERSION   = $(poppler_VERSION)
+$(PKG)_CHECKSUM  = $(poppler_CHECKSUM)
+$(PKG)_SUBDIR    = $(poppler_SUBDIR)
+$(PKG)_FILE      = $(poppler_FILE)
+$(PKG)_URL       = $(poppler_URL)
+$(PKG)_DEPS     := cc poppler qtbase
+
+define $(PKG)_BUILD
+    $(subst @build_with_cpp@,OFF, \
+    $(subst @build_with_glib@,OFF, \
+    $(subst @build_with_qt5@,ON, \
+    $(subst @build_with_qt6@,OFF, \
+    $(poppler_BUILD_COMMON)))))
+
+    $(MAKE) -C '$(BUILD_DIR)/qt5' -j 1 install
+    $(INSTALL) '$(BUILD_DIR)/poppler-qt5.pc' '$(PREFIX)/$(TARGET)/lib/pkgconfig/poppler-qt5.pc'
+endef
+

--- a/src/poppler-qt6.mk
+++ b/src/poppler-qt6.mk
@@ -1,0 +1,23 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+PKG             := poppler-qt6
+$(PKG)_WEBSITE   = $(poppler_WEBSITE)
+$(PKG)_IGNORE    = $(poppler_IGNORE)
+$(PKG)_VERSION   = $(poppler_VERSION)
+$(PKG)_CHECKSUM  = $(poppler_CHECKSUM)
+$(PKG)_SUBDIR    = $(poppler_SUBDIR)
+$(PKG)_FILE      = $(poppler_FILE)
+$(PKG)_URL       = $(poppler_URL)
+$(PKG)_DEPS     := cc poppler qt6-qtbase
+
+define $(PKG)_BUILD
+    $(subst @build_with_cpp@,OFF, \
+    $(subst @build_with_glib@,OFF, \
+    $(subst @build_with_qt5@,OFF, \
+    $(subst @build_with_qt6@,ON, \
+    $(poppler_BUILD_COMMON)))))
+
+    $(MAKE) -C '$(BUILD_DIR)/qt6' -j 1 install
+    $(INSTALL) '$(BUILD_DIR)/poppler-qt6.pc' '$(PREFIX)/$(TARGET)/lib/pkgconfig/poppler-qt6.pc'
+endef
+


### PR DESCRIPTION
Moving the poppler-qt libraries into their own packages so people don't have to build Qt5 and Qt6 if they just want poppler.
See my request https://github.com/mxe/mxe/issues/2968

Builds on all 4 targets for me.