### PR TITLE
Debian: require libpcre3-dev and python3-distutils

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -816,6 +816,7 @@ USE_OSGPLUGIN(&lt;plugin2&gt;)
     libgdk-pixbuf2.0-dev \
     libltdl-dev \
     libgl-dev \
+    libpcre3-dev \
     libssl-dev \
     libtool-bin \
     libxml-parser-perl \
@@ -826,6 +827,7 @@ USE_OSGPLUGIN(&lt;plugin2&gt;)
     patch \
     perl \
     python3 \
+    python3-distutils \
     python3-mako \
     python3-pkg-resources \
     python-is-python3 \


### PR DESCRIPTION
On Ubuntu glib will fail to build if these 2 packages are missing. See the discussion here: https://github.com/mxe/mxe/issues/2875

Apparently missing on Alpine Linux too but I don't know much about its packaging system.

Please read http://mxe.cc/#creating-packages

In particular, make sure that your build rules:

  * install .pc file,
  * install bin/test-pkg.exe compiled with flags by pkg-config,
  * install .dll to bin/ and .a, .dll.a to lib/,
  * use $(TARGET)-cmake instead of cmake,
  * build in `$(BUILD_DIR)` instead of `$(SOURCE_DIR)`,
  * do not run target executables with Wine,
  * do not download anything while building,
  * do not install documentation,
  * do not install .exe files except test and build systems,

and .patch files are generated by tools/patch-tool-mxe.

If you add a package, you can use tool tools/skeleton.py.

Thanks!
