### PR TITLE
enable optional verbose output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -798,7 +798,7 @@ $(PREFIX)/$(3)/installed/$(1): $(PKG_MAKEFILES) \
 	               $(MAKE) -f '$(MAKEFILE)' \
 	                   'build-only-$(1)_$(3)' \
 	                   WGET=false \
-	               ) &> '$(LOG_DIR)/$(TIMESTAMP)/$(1)_$(3)'; then \
+	               ) $(if $(filter-out 0,$(VERBOSE)),|& tee,&>) '$(LOG_DIR)/$(TIMESTAMP)/$(1)_$(3)'; then \
 	            echo; \
 	            echo 'Failed to build package $(1) for target $(3)!'; \
 	            echo '------------------------------------------------------------'; \


### PR DESCRIPTION
building with `make`, `make VERBOSE=` or `make VERBOSE=0` won't change anything, but setting VERBOSE to anything else will show the output that goes into the build log

Please read http://mxe.cc/#creating-packages

In particular, make sure that your build rules:

  * install .pc file,
  * install bin/test-pkg.exe compiled with flags by pkg-config,
  * install .dll to bin/ and .a, .dll.a to lib/,
  * use $(TARGET)-cmake instead of cmake,
  * build in `$(BUILD_DIR)` instead of `$(SOURCE_DIR)`,
  * do not run target executables with Wine,
  * do not download anything while building,
  * do not install documentation,
  * do not install .exe files except test and build systems,

and .patch files are generated by tools/patch-tool-mxe.

If you add a package, you can use tool tools/skeleton.py.

Thanks!
