### PR TITLE
poppler-qt static build fixes

### DIFF
--- a/src/poppler-qt5-1-win32.patch
+++ b/src/poppler-qt5-1-win32.patch
@@ -1,0 +1,24 @@
+This file is part of MXE. See LICENSE.md for licensing information.
+
+Contains ad hoc patches for cross building.
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Stefan=20L=C3=B6ffler?= <st.loeffler@gmail.com>
+Date: Sat, 26 Jun 2021 19:49:25 +0200
+Subject: [PATCH 1/1] Fix static builds
+
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 1111111..2222222 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -83,7 +83,7 @@ option(USE_FLOAT "Use single precision arithmetic in the Splash backend" OFF)
+ option(BUILD_SHARED_LIBS "Build poppler as a shared library" ON)
+ option(RUN_GPERF_IF_PRESENT "Run gperf if it is found" ON)
+ if(WIN32)
+-  option(ENABLE_RELOCATABLE "Do not hardcode the poppler library location (on Windows)." ON)
++  option(ENABLE_RELOCATABLE "Do not hardcode the poppler library location (on Windows)." ${BUILD_SHARED_LIBS})
+ else()
+   set(ENABLE_RELOCATABLE OFF)
+ endif()
+

--- a/src/poppler-qt5.mk
+++ b/src/poppler-qt5.mk
@@ -8,7 +8,7 @@ $(PKG)_CHECKSUM  = $(poppler_CHECKSUM)
 $(PKG)_SUBDIR    = $(poppler_SUBDIR)
 $(PKG)_FILE      = $(poppler_FILE)
 $(PKG)_URL       = $(poppler_URL)
-$(PKG)_DEPS     := cc poppler qtbase
+$(PKG)_DEPS     := cc poppler qtbase qtimageformats
 
 define $(PKG)_BUILD
     $(subst @build_with_cpp@,OFF, \

--- a/src/poppler-qt6-1-win32.patch
+++ b/src/poppler-qt6-1-win32.patch
@@ -1,0 +1,48 @@
+This file is part of MXE. See LICENSE.md for licensing information.
+
+Contains ad hoc patches for cross building.
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Stefan=20L=C3=B6ffler?= <st.loeffler@gmail.com>
+Date: Sat, 26 Jun 2021 19:49:25 +0200
+Subject: [PATCH 1/2] Fix static builds
+
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 1111111..2222222 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -83,7 +83,7 @@ option(USE_FLOAT "Use single precision arithmetic in the Splash backend" OFF)
+ option(BUILD_SHARED_LIBS "Build poppler as a shared library" ON)
+ option(RUN_GPERF_IF_PRESENT "Run gperf if it is found" ON)
+ if(WIN32)
+-  option(ENABLE_RELOCATABLE "Do not hardcode the poppler library location (on Windows)." ON)
++  option(ENABLE_RELOCATABLE "Do not hardcode the poppler library location (on Windows)." ${BUILD_SHARED_LIBS})
+ else()
+   set(ENABLE_RELOCATABLE OFF)
+ endif()
+
+This file is part of MXE. See LICENSE.md for licensing information.
+
+Contains ad hoc patches for cross building.
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: MXE
+Date: Fri, 5 May 2023 18:00:00 +0200
+Subject: [PATCH 2/2] Fix static builds involving qtimageformats
+
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 1111111..2222222 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -203,7 +203,7 @@ if (ENABLE_QT5)
+ endif()
+ 
+ if (ENABLE_QT6)
+-  SET(QT_NO_CREATE_VERSIONLESS_TARGETS ON)
++  SET(QT_NO_CREATE_VERSIONLESS_TARGETS ${BUILD_SHARED_LIBS})
+   find_package(Qt6 6.2 COMPONENTS Core Gui Widgets Test QUIET)
+   if (NOT (Qt6Core_FOUND AND Qt6Gui_FOUND AND Qt6Widgets_FOUND AND Qt6Test_FOUND))
+     message("-- Package Qt6Core or Qt6Gui or Qt6Widgets or Qt6Test not found")
+

--- a/src/poppler-qt6.mk
+++ b/src/poppler-qt6.mk
@@ -8,7 +8,7 @@ $(PKG)_CHECKSUM  = $(poppler_CHECKSUM)
 $(PKG)_SUBDIR    = $(poppler_SUBDIR)
 $(PKG)_FILE      = $(poppler_FILE)
 $(PKG)_URL       = $(poppler_URL)
-$(PKG)_DEPS     := cc poppler qt6-qtbase
+$(PKG)_DEPS     := cc poppler qt6-qtbase qt6-qtimageformats
 
 define $(PKG)_BUILD
     $(subst @build_with_cpp@,OFF, \


### PR DESCRIPTION
- fix static Qt6 build involving qt6-qtimageformats
- apply the ENABLE_RELOCATABLE patch on the poppler-qt builds
- add qtimageformats/qt6-qtimageformats to the dependencies

Please read http://mxe.cc/#creating-packages

In particular, make sure that your build rules:

  * install .pc file,
  * install bin/test-pkg.exe compiled with flags by pkg-config,
  * install .dll to bin/ and .a, .dll.a to lib/,
  * use $(TARGET)-cmake instead of cmake,
  * build in `$(BUILD_DIR)` instead of `$(SOURCE_DIR)`,
  * do not run target executables with Wine,
  * do not download anything while building,
  * do not install documentation,
  * do not install .exe files except test and build systems,

and .patch files are generated by tools/patch-tool-mxe.

If you add a package, you can use tool tools/skeleton.py.

Thanks!
