### PR TITLE
qt6: Add qtwebsockets Qt module

### DIFF
--- a/src/qt/qt6/qt6-qtwebsockets.mk
+++ b/src/qt/qt6/qt6-qtwebsockets.mk
@@ -1,0 +1,19 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+include src/qt/qt6/qt6-conf.mk
+
+PKG := qt6-qtwebsockets
+$(eval $(QT6_METADATA))
+
+$(PKG)_CHECKSUM := bc087bd656bb34da120ccab6e927036a219f75fd88f1543744c426bfca616308
+$(PKG)_DEPS     := cc qt6-conf qt6-qtbase
+
+QT6_PREFIX   = '$(PREFIX)/$(TARGET)/$(MXE_QT6_ID)'
+QT6_QT_CMAKE = '$(QT6_PREFIX)/$(if $(findstring mingw,$(TARGET)),bin,libexec)/qt-cmake-private' \
+                   -DCMAKE_INSTALL_PREFIX='$(QT6_PREFIX)'
+
+define $(PKG)_BUILD
+    $(QT6_QT_CMAKE) -S '$(SOURCE_DIR)' -B '$(BUILD_DIR)'
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --build . -j '$(JOBS)'
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --install .
+endef


### PR DESCRIPTION
Add Qt Websockets module (https://doc.qt.io/qt-6/qtwebsockets-index.html) to mxe.

Used the existing qt6-qtsvg and simply changed PKG and CHECKSUM. Compiles locally.
