### PR TITLE
Removed qhelpgenerator and qcollectiongenerator references for Qt5::Help

### DIFF
--- a/src/qttools-1-fixes.patch
+++ b/src/qttools-1-fixes.patch
@@ -45,3 +45,50 @@ index 1111111..2222222 100644
  
  !android|android_app: SUBDIRS += qtpaths
  
+diff --git a/src/assistant/help/Qt5HelpConfigExtras.cmake.in b/src/assistant/help/Qt5HelpConfigExtras.cmake.in
+deleted file mode 100644
+index 1f7544b..0000000
+--- a/src/assistant/help/Qt5HelpConfigExtras.cmake.in
++++ /dev/null
+@@ -1,41 +0,0 @@
+-
+-if (NOT TARGET Qt5::qcollectiongenerator)
+-    add_executable(Qt5::qcollectiongenerator IMPORTED)
+-
+-!!IF isEmpty(CMAKE_BIN_DIR_IS_ABSOLUTE)
+-    set(imported_location \"${_qt5Help_install_prefix}/$${CMAKE_BIN_DIR}qcollectiongenerator$$CMAKE_BIN_SUFFIX\")
+-!!ELSE
+-    set(imported_location \"$${CMAKE_BIN_DIR}qcollectiongenerator$$CMAKE_BIN_SUFFIX\")
+-!!ENDIF
+-    _qt5_Help_check_file_exists(${imported_location})
+-
+-    set_target_properties(Qt5::qcollectiongenerator PROPERTIES
+-        IMPORTED_LOCATION ${imported_location}
+-    )
+-endif()
+-
+-if (NOT TARGET Qt5::qhelpgenerator)
+-    add_executable(Qt5::qhelpgenerator IMPORTED)
+-
+-!!IF isEmpty(CMAKE_BIN_DIR_IS_ABSOLUTE)
+-    set(imported_location \"${_qt5Help_install_prefix}/$${CMAKE_BIN_DIR}qhelpgenerator$$CMAKE_BIN_SUFFIX\")
+-!!ELSE
+-    set(imported_location \"$${CMAKE_BIN_DIR}qhelpgenerator$$CMAKE_BIN_SUFFIX\")
+-!!ENDIF
+-    _qt5_Help_check_file_exists(${imported_location})
+-
+-    set_target_properties(Qt5::qhelpgenerator PROPERTIES
+-        IMPORTED_LOCATION ${imported_location}
+-    )
+-endif()
+-
+-# Create versionless tool targets.
+-foreach(__qt_tool qcollectiongenerator qhelpgenerator)
+-    if(NOT \"${QT_NO_CREATE_VERSIONLESS_TARGETS}\" AND NOT TARGET Qt::${__qt_tool}
+-       AND TARGET Qt5::${__qt_tool})
+-        add_executable(Qt::${__qt_tool} IMPORTED)
+-        get_target_property(__qt_imported_location Qt5::${__qt_tool} IMPORTED_LOCATION)
+-        set_target_properties(Qt::${__qt_tool}
+-                              PROPERTIES IMPORTED_LOCATION \"${__qt_imported_location}\")
+-    endif()
+-endforeach()


### PR DESCRIPTION
This PR adds to the patch file `src/qttools-1-fixes.patch` with an extra patch which removes the file `src/assistant/help/Qt5HelpConfigExtras.cmake.in` from `qttools` as it is blocking CMake builds which rely on the `Qt5::Help` module.

These two binaries are used to generate Qt Help Documentation so it serves no use in the context of the cross-compiler. My solution has been to install `qhelpgenerator` via. my base system repositories so that I can generate all documentation before feeding it into the MinGW compiler and this works fine.

See #2995 for more information.