### PR TITLE
This fixes #3006

### DIFF
--- a/src/zlib.mk
+++ b/src/zlib.mk
@@ -8,7 +8,7 @@ $(PKG)_CHECKSUM := d14c38e313afc35a9a8760dadf26042f51ea0f5d154b0630a31da0540107f
 $(PKG)_SUBDIR   := zlib-$($(PKG)_VERSION)
 $(PKG)_FILE     := zlib-$($(PKG)_VERSION).tar.xz
 $(PKG)_URL      := https://zlib.net/$($(PKG)_FILE)
-$(PKG)_URL_2    := https://$(SOURCEFORGE_MIRROR)/project/libpng/$(PKG)/$($(PKG)_VERSION)/$($(PKG)_FILE)
+$(PKG)_URL_2    := https://github.com/madler/zlib/releases/download/v$($(PKG)_VERSION)/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc
 $(PKG)_TARGETS  := $(BUILD) $(MXE_TARGETS)
 


### PR DESCRIPTION
> As of today, it seems zlib is no longer supplying their version 1.2.13 in favor of 1.3, which was released 4 days ago. This means building MXE's zlib package which is still on 1.2.13 fails as all downloads 404 out.