### PR TITLE
qt6: Add qthttpserver Qt module

### DIFF
--- a/src/qt/qt6/qt6-qthttpserver.mk
+++ b/src/qt/qt6/qt6-qthttpserver.mk
@@ -1,0 +1,19 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+include src/qt/qt6/qt6-conf.mk
+
+PKG := qt6-qthttpserver
+$(eval $(QT6_METADATA))
+
+$(PKG)_CHECKSUM := f8fa2b5d1278d05c8841fe14d3a81c91196a126219d491562f7c179b5202dcac
+$(PKG)_DEPS     := cc qt6-conf qt6-qtbase
+
+QT6_PREFIX   = '$(PREFIX)/$(TARGET)/$(MXE_QT6_ID)'
+QT6_QT_CMAKE = '$(QT6_PREFIX)/$(if $(findstring mingw,$(TARGET)),bin,libexec)/qt-cmake-private' \
+                   -DCMAKE_INSTALL_PREFIX='$(QT6_PREFIX)'
+
+define $(PKG)_BUILD
+    $(QT6_QT_CMAKE) -S '$(SOURCE_DIR)' -B '$(BUILD_DIR)'
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --build . -j '$(JOBS)'
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --install .
+endef


### PR DESCRIPTION
Add Qt HTTP server module (https://doc.qt.io/qt-6/qthttpserver-index.html) to mxe.

Used the existing qt6-qtsvg and simply changed PKG and CHECKSUM. Compiles in a clean docker container for `x86_64-w64-mingw32.static`.

Once PR #2987 is merged, this module should also depend on QtWebsockets as some optional features require it.