### PR TITLE
Fix static build.

### DIFF
--- a/plugins/examples/host-toolchain/pkgconf-host.mk
+++ b/plugins/examples/host-toolchain/pkgconf-host.mk
@@ -18,7 +18,7 @@ define $(PKG)_BUILD
     cd '$(SOURCE_DIR)' && ./autogen.sh
     cd '$(BUILD_DIR)' && '$(SOURCE_DIR)/configure' \
         $(MXE_CONFIGURE_OPTS) \
-        CFLAGS="$(CFLAGS) $(if $(BUILD_STATIC),-DPKGCONFIG_IS_STATIC)"
+        CFLAGS="$(if $(BUILD_STATIC),-DPKGCONFIG_IS_STATIC)"
     $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)'
     $(MAKE) -C '$(BUILD_DIR)' -j 1 install
 

--- a/plugins/examples/host-toolchain/pkgconf-host.mk
+++ b/plugins/examples/host-toolchain/pkgconf-host.mk
@@ -17,7 +17,8 @@ endef
 define $(PKG)_BUILD
     cd '$(SOURCE_DIR)' && ./autogen.sh
     cd '$(BUILD_DIR)' && '$(SOURCE_DIR)/configure' \
-        $(MXE_CONFIGURE_OPTS)
+        $(MXE_CONFIGURE_OPTS) \
+        CFLAGS="$(CFLAGS) $(if $(BUILD_STATIC),-DPKGCONFIG_IS_STATIC)"
     $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)'
     $(MAKE) -C '$(BUILD_DIR)' -j 1 install
 


### PR DESCRIPTION
This is needed for a static build, otherwise one runs into linking errors such as "undefined reference to `__imp_pkgconf_strlcpy'."

