### PR TITLE
Declare (auto)dependency on brotli.

### DIFF
--- a/src/freetype-bootstrap.mk
+++ b/src/freetype-bootstrap.mk
@@ -9,7 +9,7 @@ $(PKG)_CHECKSUM = $(freetype_CHECKSUM)
 $(PKG)_SUBDIR   = $(freetype_SUBDIR)
 $(PKG)_FILE     = $(freetype_FILE)
 $(PKG)_URL      = $(freetype_URL)
-$(PKG)_DEPS    := cc bzip2 libpng zlib
+$(PKG)_DEPS    := cc brotli bzip2 libpng zlib
 
 define $(PKG)_UPDATE
     echo $(freetype_VERSION)

--- a/src/freetype.mk
+++ b/src/freetype.mk
@@ -8,7 +8,7 @@ $(PKG)_CHECKSUM := 12991c4e55c506dd7f9b765933e62fd2be2e06d421505d7950a132e4f1bb4
 $(PKG)_SUBDIR   := freetype-$($(PKG)_VERSION)
 $(PKG)_FILE     := freetype-$($(PKG)_VERSION).tar.xz
 $(PKG)_URL      := https://$(SOURCEFORGE_MIRROR)/project/freetype/freetype2/$(shell echo '$($(PKG)_VERSION)' | cut -d . -f 1,2,3)/$($(PKG)_FILE)
-$(PKG)_DEPS     := cc bzip2 harfbuzz libpng zlib
+$(PKG)_DEPS     := cc brotli bzip2 harfbuzz libpng zlib
 
 define $(PKG)_UPDATE
     $(WGET) -q -O- 'https://sourceforge.net/projects/freetype/files/freetype2/' | \


### PR DESCRIPTION
Freetype by default supports brotli when it finds it installed during the build, so declare a dependency on it to make sure brotli support presence is deterministic in the builds.