### PR TITLE
Avoid python version detection when not installed.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ OPENSSL    := openssl
 PATCH      := $(shell gpatch --help >/dev/null 2>&1 && echo g)patch
 PYTHON     := $(shell PATH="$(ORIG_PATH)" which python)
 PYTHON3    := $(shell PATH="$(ORIG_PATH)" which python3)
-PY_XY_VER  := $(shell $(PYTHON) -c "import sys; print('{0[0]}.{0[1]}'.format(sys.version_info))")
+PY_XY_VER  := $(if $(PYTHON),$(shell $(PYTHON) -c "import sys; print('{0[0]}.{0[1]}'.format(sys.version_info))"))
 SED        := $(shell gsed --help >/dev/null 2>&1 && echo g)sed
 SORT       := $(shell gsort --help >/dev/null 2>&1 && echo g)sort
 TOUCH      := $(shell gtouch --help >/dev/null 2>&1 && echo g)touch


### PR DESCRIPTION
When "python" is not installed, PYTHON is empty and the (eager) evaluation of PY_XY_VER causes an error from the shell, which could be rather puzzling. This change  silences such error by not attempting to detect the version of "python" when it is not installed. With "bash", the error is "bash: - : invalid option".
