### PR TITLE
djvulibre: fix build failure

### DIFF
--- a/src/djvulibre-1-fixes.patch
+++ b/src/djvulibre-1-fixes.patch
@@ -4,28 +4,119 @@ Contains ad hoc patches for cross building.
 
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: darealshinji <djcj@gmx.de>
-Date: Sat, 1 Jul 2017 01:26:10 +0200
-Subject: [PATCH 1/1] enable static library builds
+Date: Mon, 23 Oct 2023 12:00:00 +0200
+Subject: [PATCH 1/1] ad hoc patches
+
+enable static library builds and fix compilation error in JPEGDecoder.cpp
 
 
+diff --git a/libdjvu/DjVuGlobal.h b/libdjvu/DjVuGlobal.h
+index 1111111..2222222 100644
+--- a/libdjvu/DjVuGlobal.h
++++ b/libdjvu/DjVuGlobal.h
+@@ -71,7 +71,9 @@
+ #endif
+ 
+ #ifndef DJVUAPI
+-# ifdef _WIN32
++# ifdef __GNUC__
++#  define DJVUAPI __attribute__((visibility("default")))
++# elif defined(_WIN32)
+ #  ifdef DJVUAPI_EXPORT
+ #   define DJVUAPI __declspec(dllexport)
+ #  else
+diff --git a/libdjvu/GThreads.h b/libdjvu/GThreads.h
+index 1111111..2222222 100644
+--- a/libdjvu/GThreads.h
++++ b/libdjvu/GThreads.h
+@@ -230,7 +230,7 @@ private:
+     as private members. It is therefore not possible to make multiple copies
+     of instances of this class, as implied by the class semantic. */
+ 
+-class GMonitor
++class DJVUAPI GMonitor
+ {
+ public:
+   GMonitor();
+@@ -340,7 +340,7 @@ public:
+     modification, which guarantees, that their state cannot be changed in
+     between of these operations. */
+ 
+-class GSafeFlags : public GMonitor
++class DJVUAPI GSafeFlags : public GMonitor
+ {
+ private:
+    volatile long flags;
+diff --git a/libdjvu/JPEGDecoder.cpp b/libdjvu/JPEGDecoder.cpp
+index 1111111..2222222 100644
+--- a/libdjvu/JPEGDecoder.cpp
++++ b/libdjvu/JPEGDecoder.cpp
+@@ -65,17 +65,10 @@
+ #ifdef __cplusplus
+ extern "C" {
+ #endif
+-#undef HAVE_STDLIB_H
+-#undef HAVE_STDDEF_H
+-#define INT32 jpeg_INT32
+-#define INT16 jpeg_INT16
+ #include <stdio.h>
+ #include <jconfig.h>
+ #include <jpeglib.h>
+ #include <jerror.h>
+-#undef FAR
+-#undef INT32
+-#undef INT16
+ #ifdef __cplusplus
+ }
+ #endif
 diff --git a/libdjvu/Makefile.am b/libdjvu/Makefile.am
 index 1111111..2222222 100644
 --- a/libdjvu/Makefile.am
 +++ b/libdjvu/Makefile.am
-@@ -35,6 +35,7 @@ libdjvulibre_la_LDFLAGS = -no-undefined -version-info $(version_info)
- if HAVE_OS_WIN32
- libdjvulibre_la_CPPFLAGS += -DDJVUAPI_EXPORT
- libdjvulibre_la_CPPFLAGS += -DDDJVUAPI_EXPORT -DMINILISPAPI_EXPORT
-+libdjvulibre_la_CPPFLAGS += $(EXTRA_CPPFLAGS)
- libdjvulibre_la_LDFLAGS += -Wl,--export-all-symbols
+@@ -29,15 +29,10 @@ libdjvulibre_la_SOURCES = Arrays.cpp BSByteStream.cpp			\
+ 
+ libdjvulibre_la_CPPFLAGS = -DDIR_DATADIR=\"$(datadir)\"
+ libdjvulibre_la_CXXFLAGS = $(JPEG_CFLAGS) $(PTHREAD_CFLAGS)
++libdjvulibre_la_CXXFLAGS += -fvisibility=hidden
+ libdjvulibre_la_LIBADD = $(JPEG_LIBS) $(PTHREAD_LIBS)
+ libdjvulibre_la_LDFLAGS = -no-undefined -version-info $(version_info)
+ 
+-if HAVE_OS_WIN32
+-libdjvulibre_la_CPPFLAGS += -DDJVUAPI_EXPORT 
+-libdjvulibre_la_CPPFLAGS += -DDDJVUAPI_EXPORT -DMINILISPAPI_EXPORT
+-libdjvulibre_la_LDFLAGS += -Wl,--export-all-symbols
+-endif
+-
+ if HAVE_OS_APPLE
+ libdjvulibre_la_LDFLAGS += -framework CoreFoundation
  endif
+diff --git a/libdjvu/ddjvuapi.h b/libdjvu/ddjvuapi.h
+index 1111111..2222222 100644
+--- a/libdjvu/ddjvuapi.h
++++ b/libdjvu/ddjvuapi.h
+@@ -69,7 +69,9 @@ extern "C" {
+ #include <stdio.h>
  
-@@ -46,7 +47,7 @@ sed_process = $(SED) \
-  -e 's,@includedir\@,$(includedir),g' \
-  -e 's,@Libs\@,-L$(libdir) -ldjvulibre,g' \
-  -e 's,@Libsprivate\@,$(JPEG_LIBS) $(PTHREAD_LIBS) $(LIBS),g' \
-- -e 's,@Cflags\@,-I$(includedir) $(JPEG_CFLAGS) $(PTHREAD_CFLAGS),g' \
-+ -e 's,@Cflags\@,-I$(includedir) $(JPEG_CFLAGS) $(PTHREAD_CFLAGS) $(EXTRA_CPPFLAGS),g' \
-  < $< > $@ || (rm $@; exit 1)
+ #ifndef DDJVUAPI
+-# ifdef _WIN32
++# ifdef __GNUC__
++#  define DDJVUAPI __attribute__((visibility("default")))
++# elif defined(_WIN32)
+ #  ifdef DDJVUAPI_EXPORT
+ #   define DDJVUAPI __declspec(dllexport)
+ #  else
+diff --git a/libdjvu/miniexp.h b/libdjvu/miniexp.h
+index 1739532..c277213 100644
+--- a/libdjvu/miniexp.h
++++ b/libdjvu/miniexp.h
+@@ -27,7 +27,9 @@ extern "C" {
+ #endif
  
- pc_verbose = $(pc_verbose_@AM_V@)
+ #ifndef MINILISPAPI
+-# ifdef _WIN32
++# ifdef __GNUC__
++#  define MINILISPAPI __attribute__((visibility("default")))
++# elif defined(_WIN32)
+ #  ifdef MINILISPAPI_EXPORT
+ #   define MINILISPAPI __declspec(dllexport)
+ #  else

--- a/src/djvulibre-1-fixes.patch
+++ b/src/djvulibre-1-fixes.patch
@@ -7,7 +7,9 @@ From: darealshinji <djcj@gmx.de>
 Date: Mon, 23 Oct 2023 12:00:00 +0200
 Subject: [PATCH 1/1] ad hoc patches
 
-enable static library builds and fix compilation error in JPEGDecoder.cpp
+* enable static library builds
+* fix compilation error in JPEGDecoder.cpp
+* enable pthreads
 
 
 diff --git a/libdjvu/DjVuGlobal.h b/libdjvu/DjVuGlobal.h
@@ -106,7 +108,7 @@ index 1111111..2222222 100644
  #   define DDJVUAPI __declspec(dllexport)
  #  else
 diff --git a/libdjvu/miniexp.h b/libdjvu/miniexp.h
-index 1739532..c277213 100644
+index 1111111..2222222 100644
 --- a/libdjvu/miniexp.h
 +++ b/libdjvu/miniexp.h
 @@ -27,7 +27,9 @@ extern "C" {
@@ -120,3 +122,32 @@ index 1739532..c277213 100644
  #  ifdef MINILISPAPI_EXPORT
  #   define MINILISPAPI __declspec(dllexport)
  #  else
+diff --git a/configure.ac b/configure.ac
+index 1111111..2222222 100755
+--- a/configure.ac
++++ b/configure.ac
+@@ -209,9 +209,9 @@ fi
+ # Test auxilliary packages
+ # ----------------------------------------
+ 
+-# Search for PTHREADS (when not on windows)
++# Search for PTHREADS
+ have_pthread=no
+-AM_COND_IF([HAVE_OS_WIN32],,[AC_PATH_PTHREAD([have_pthread=yes])])
++AC_PATH_PTHREAD([have_pthread=yes])
+ 
+ # Search JPEG library
+ AC_PATH_JPEG([have_jpeg="yes"], [have_jpeg="no"])
+diff --git a/libdjvu/miniexp.cpp b/libdjvu/miniexp.cpp
+index 1111111..2222222 100644
+--- a/libdjvu/miniexp.cpp
++++ b/libdjvu/miniexp.cpp
+@@ -71,7 +71,7 @@ assertfail(const char *fn, int ln)
+ /* -------------------------------------------------- */
+ 
+ #ifndef WITHOUT_THREADS
+-# ifdef _WIN32
++# if defined(_WIN32) && !defined(__MINGW32__)
+ #  include <windows.h>
+ #  define USE_WINTHREADS 1
+ # elif defined(HAVE_PTHREAD)

--- a/src/djvulibre-1-fixes.patch
+++ b/src/djvulibre-1-fixes.patch
@@ -8,8 +8,11 @@ Date: Mon, 23 Oct 2023 12:00:00 +0200
 Subject: [PATCH 1/1] ad hoc patches
 
 * enable static library builds
-* fix compilation error in JPEGDecoder.cpp
 * enable pthreads
+* fix compilation error in JPEGDecoder.cpp;
+  see https://sourceforge.net/p/djvu/djvulibre-git/ci/208a8d6c212e994071dbc56ee5eea3f931eb5860/
+  and comment in libjpeg source
+  https://github.com/libjpeg-turbo/libjpeg-turbo/blob/ec32420f6b5dfa4e86883d42b209e8371e55aeb5/jmorecfg.h#L128C1-L134C1
 
 
 diff --git a/libdjvu/Makefile.am b/libdjvu/Makefile.am
@@ -82,24 +85,26 @@ diff --git a/libdjvu/JPEGDecoder.cpp b/libdjvu/JPEGDecoder.cpp
 index 1111111..2222222 100644
 --- a/libdjvu/JPEGDecoder.cpp
 +++ b/libdjvu/JPEGDecoder.cpp
-@@ -65,17 +65,10 @@
+@@ -62,6 +62,10 @@
+ 
+ #ifdef NEED_JPEG_DECODER
+ 
++#include "GSmartPointer.h"
++#include "ByteStream.h"
++#include "GPixmap.h"
++
  #ifdef __cplusplus
  extern "C" {
  #endif
--#undef HAVE_STDLIB_H
--#undef HAVE_STDDEF_H
--#define INT32 jpeg_INT32
--#define INT16 jpeg_INT16
- #include <stdio.h>
- #include <jconfig.h>
- #include <jpeglib.h>
- #include <jerror.h>
--#undef FAR
--#undef INT32
--#undef INT16
- #ifdef __cplusplus
- }
+@@ -81,8 +85,6 @@
  #endif
+ 
+ #include "JPEGDecoder.h"
+-#include "ByteStream.h"
+-#include "GPixmap.h"
+ #ifdef LIBJPEGNAME
+ #include "DjVuDynamic.h"
+ #include "GString.h"
 diff --git a/configure.ac b/configure.ac
 index 1111111..2222222 100755
 --- a/configure.ac

--- a/src/djvulibre-1-fixes.patch
+++ b/src/djvulibre-1-fixes.patch
@@ -12,65 +12,6 @@ Subject: [PATCH 1/1] ad hoc patches
 * enable pthreads
 
 
-diff --git a/libdjvu/DjVuGlobal.h b/libdjvu/DjVuGlobal.h
-index 1111111..2222222 100644
---- a/libdjvu/DjVuGlobal.h
-+++ b/libdjvu/DjVuGlobal.h
-@@ -71,7 +71,9 @@
- #endif
- 
- #ifndef DJVUAPI
--# ifdef _WIN32
-+# ifdef __GNUC__
-+#  define DJVUAPI __attribute__((visibility("default")))
-+# elif defined(_WIN32)
- #  ifdef DJVUAPI_EXPORT
- #   define DJVUAPI __declspec(dllexport)
- #  else
-diff --git a/libdjvu/GThreads.h b/libdjvu/GThreads.h
-index 1111111..2222222 100644
---- a/libdjvu/GThreads.h
-+++ b/libdjvu/GThreads.h
-@@ -230,7 +230,7 @@ private:
-     as private members. It is therefore not possible to make multiple copies
-     of instances of this class, as implied by the class semantic. */
- 
--class GMonitor
-+class DJVUAPI GMonitor
- {
- public:
-   GMonitor();
-@@ -340,7 +340,7 @@ public:
-     modification, which guarantees, that their state cannot be changed in
-     between of these operations. */
- 
--class GSafeFlags : public GMonitor
-+class DJVUAPI GSafeFlags : public GMonitor
- {
- private:
-    volatile long flags;
-diff --git a/libdjvu/JPEGDecoder.cpp b/libdjvu/JPEGDecoder.cpp
-index 1111111..2222222 100644
---- a/libdjvu/JPEGDecoder.cpp
-+++ b/libdjvu/JPEGDecoder.cpp
-@@ -65,17 +65,10 @@
- #ifdef __cplusplus
- extern "C" {
- #endif
--#undef HAVE_STDLIB_H
--#undef HAVE_STDDEF_H
--#define INT32 jpeg_INT32
--#define INT16 jpeg_INT16
- #include <stdio.h>
- #include <jconfig.h>
- #include <jpeglib.h>
- #include <jerror.h>
--#undef FAR
--#undef INT32
--#undef INT16
- #ifdef __cplusplus
- }
- #endif
 diff --git a/libdjvu/Makefile.am b/libdjvu/Makefile.am
 index 1111111..2222222 100644
 --- a/libdjvu/Makefile.am
@@ -92,6 +33,21 @@ index 1111111..2222222 100644
  if HAVE_OS_APPLE
  libdjvulibre_la_LDFLAGS += -framework CoreFoundation
  endif
+diff --git a/libdjvu/DjVuGlobal.h b/libdjvu/DjVuGlobal.h
+index 1111111..2222222 100644
+--- a/libdjvu/DjVuGlobal.h
++++ b/libdjvu/DjVuGlobal.h
+@@ -71,7 +71,9 @@
+ #endif
+ 
+ #ifndef DJVUAPI
+-# ifdef _WIN32
++# ifdef __GNUC__
++#  define DJVUAPI __attribute__((visibility("default")))
++# elif defined(_WIN32)
+ #  ifdef DJVUAPI_EXPORT
+ #   define DJVUAPI __declspec(dllexport)
+ #  else
 diff --git a/libdjvu/ddjvuapi.h b/libdjvu/ddjvuapi.h
 index 1111111..2222222 100644
 --- a/libdjvu/ddjvuapi.h
@@ -122,6 +78,28 @@ index 1111111..2222222 100644
  #  ifdef MINILISPAPI_EXPORT
  #   define MINILISPAPI __declspec(dllexport)
  #  else
+diff --git a/libdjvu/JPEGDecoder.cpp b/libdjvu/JPEGDecoder.cpp
+index 1111111..2222222 100644
+--- a/libdjvu/JPEGDecoder.cpp
++++ b/libdjvu/JPEGDecoder.cpp
+@@ -65,17 +65,10 @@
+ #ifdef __cplusplus
+ extern "C" {
+ #endif
+-#undef HAVE_STDLIB_H
+-#undef HAVE_STDDEF_H
+-#define INT32 jpeg_INT32
+-#define INT16 jpeg_INT16
+ #include <stdio.h>
+ #include <jconfig.h>
+ #include <jpeglib.h>
+ #include <jerror.h>
+-#undef FAR
+-#undef INT32
+-#undef INT16
+ #ifdef __cplusplus
+ }
+ #endif
 diff --git a/configure.ac b/configure.ac
 index 1111111..2222222 100755
 --- a/configure.ac

--- a/src/djvulibre.mk
+++ b/src/djvulibre.mk
@@ -8,7 +8,7 @@ $(PKG)_CHECKSUM := fcd009ea7654fde5a83600eb80757bd3a76998e47d13c66b54c8db849f8f2
 $(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
 $(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.gz
 $(PKG)_URL      := https://$(SOURCEFORGE_MIRROR)/project/djvu/DjVuLibre/$($(PKG)_VERSION)/$($(PKG)_FILE)
-$(PKG)_DEPS     := cc jpeg tiff zlib
+$(PKG)_DEPS     := cc jpeg zlib
 
 define $(PKG)_UPDATE
     $(WGET) -q -O- 'https://sourceforge.net/projects/djvu/files/DjVuLibre/' | \
@@ -20,11 +20,9 @@ define $(PKG)_BUILD
     cd '$(SOURCE_DIR)' && autoreconf -fi
     cd '$(BUILD_DIR)' && $(SOURCE_DIR)/configure \
         $(MXE_CONFIGURE_OPTS)
-    $(MAKE) -C '$(BUILD_DIR)/libdjvu' -j '$(JOBS)' \
-        EXTRA_CPPFLAGS=$(if $(BUILD_STATIC),'-DDDJVUAPI= -DMINILISPAPI=')
+    $(MAKE) -C '$(BUILD_DIR)/libdjvu' -j '$(JOBS)'
     $(MAKE) -C '$(BUILD_DIR)/libdjvu' -j 1 install-strip \
-        $(MXE_DISABLE_CRUFT) dist_bin_SCRIPTS= \
-        EXTRA_CPPFLAGS=$(if $(BUILD_STATIC),'-DDDJVUAPI= -DMINILISPAPI=')
+        $(MXE_DISABLE_CRUFT) dist_bin_SCRIPTS=
 
     '$(TARGET)-g++' \
         -W -Wall -Werror -pedantic \

--- a/src/djvulibre.mk
+++ b/src/djvulibre.mk
@@ -8,7 +8,7 @@ $(PKG)_CHECKSUM := fcd009ea7654fde5a83600eb80757bd3a76998e47d13c66b54c8db849f8f2
 $(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
 $(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.gz
 $(PKG)_URL      := https://$(SOURCEFORGE_MIRROR)/project/djvu/DjVuLibre/$($(PKG)_VERSION)/$($(PKG)_FILE)
-$(PKG)_DEPS     := cc jpeg zlib
+$(PKG)_DEPS     := cc pthreads jpeg zlib
 
 define $(PKG)_UPDATE
     $(WGET) -q -O- 'https://sourceforge.net/projects/djvu/files/DjVuLibre/' | \


### PR DESCRIPTION
Also...
- remove dependency on "tiff"; it's not used despite the configure script looking for it
- better way to build static library
- don't export all DLL symbols
- enable pthreads

This will resolve https://github.com/mxe/mxe/issues/3012

PS: upstream discussion about MinGW build compatibility -> https://sourceforge.net/p/djvu/bugs/354/