### PR TITLE
Fix ccache config location.

### DIFF
--- a/src/ccache.mk
+++ b/src/ccache.mk
@@ -21,7 +21,7 @@ endef
 BOOTSTRAP_PKGS += ccache
 
 $(PKG)_SYS_CONF := $(MXE_CCACHE_DIR)/etc/$(PKG).conf
-$(PKG)_USR_CONF := $(MXE_CCACHE_DIR)/$(PKG).conf
+$(PKG)_USR_CONF := $(MXE_CCACHE_CACHE_DIR)/$(PKG).conf
 
 ifeq (mxe,$(MXE_USE_CCACHE))
 define $(PKG)_BUILD_$(BUILD)


### PR DESCRIPTION
This patch fixes the location where MXE puts the cmake user configuration file. The previous location was not correct (anymore?) and the config file there was ignored.

This can be tested via e.g.  `ccache -s`. MXE increases the maximum cache size to 20G from the default 5G. Without this patch, ccache would generate its own configuration file with 5G as the maximum. With this patch, the one from MXE will be used with 20G as maximum. One can also test by putting invalid content, e.g. invalid number as the limit, to the files to confirm where they are read.


