### PR TITLE
Add qt6-qtscxml

### DIFF
--- a/src/qt/qt6/qt6-qtscxml.mk
+++ b/src/qt/qt6/qt6-qtscxml.mk
@@ -1,0 +1,21 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+include src/qt/qt6/qt6-conf.mk
+
+PKG := qt6-qtscxml
+$(eval $(QT6_METADATA))
+
+$(PKG)_CHECKSUM := 57ecd0db5d8b063d0334c4b21461585b4904d4884c88de125bd72e967e8a1043
+$(PKG)_TARGETS       := $(BUILD) $(MXE_TARGETS)
+$(PKG)_DEPS_$(BUILD) := qt6-conf qt6-qtbase
+$(PKG)_DEPS          := cc $($(PKG)_DEPS_$(BUILD)) $(BUILD)~$(PKG)
+
+QT6_PREFIX   = '$(PREFIX)/$(TARGET)/$(MXE_QT6_ID)'
+QT6_QT_CMAKE = '$(QT6_PREFIX)/bin/qt-cmake-private' \
+                   -DCMAKE_INSTALL_PREFIX='$(QT6_PREFIX)'
+
+define $(PKG)_BUILD
+    $(QT6_QT_CMAKE) -S '$(SOURCE_DIR)' -B '$(BUILD_DIR)'
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --build . -j '$(JOBS)'
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --install .
+endef


### PR DESCRIPTION
This supersedes #2964, comes in a single commit, and works with the current Qt6 version of MXE (6.6.0).