### PR TITLE
[mdbtools.mk] Update sources and repo

### DIFF
--- a/src/mdbtools.mk
+++ b/src/mdbtools.mk
@@ -1,19 +1,17 @@
 # This file is part of MXE. See LICENSE.md for licensing information.
 
 PKG             := mdbtools
-$(PKG)_WEBSITE  := https://sourceforge.net/projects/mdbtools/
+$(PKG)_WEBSITE  := https://github.com/mdbtools/mdbtools
 $(PKG)_IGNORE   :=
-$(PKG)_VERSION  := 0.7.1
-$(PKG)_CHECKSUM := 4eac1bce55066a38d9ea6c52a8e8ecc101b79afe75118ecc16852990472c4721
-$(PKG)_SUBDIR   := brianb-mdbtools-f8ce1cc
-$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.gz
-$(PKG)_URL      := https://github.com/brianb/$(PKG)/tarball/$($(PKG)_VERSION)/$($(PKG)_FILE)
+$(PKG)_VERSION  := 1.0.0
+$(PKG)_CHECKSUM := 3446e1d71abdeb98d41e252777e67e1909b186496fda59f98f67032f7fbcd955
+$(PKG)_GH_CONF  := mdbtools/mdbtools/releases, v
 $(PKG)_DEPS     := cc glib
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://github.com/brianb/mdbtools/tags' | \
-    grep '<a href="/brianb/mdbtools/archive/' | \
-    $(SED) -n 's,.*href="/brianb/mdbtools/archive/\([0-9][^"_]*\)\.tar.*,\1,p' | \
+    $(WGET) -q -O- 'https://github.com/mdbtools/mdbtools/tags' | \
+    grep 'href="/mdbtools/mdbtools/archive/' | \
+    $(SED) -n 's,.*href="/mdbtools/mdbtools/archive/refs/tags/v\([0-9][^"_]*\)\.tar.*,\1,p' | \
     head -1
 endef
 
@@ -24,10 +22,11 @@ define $(PKG)_BUILD
         --build="`config.guess`" \
         --disable-shared \
         --disable-man \
+        --without-bash-completion-dir \
         --prefix='$(PREFIX)/$(TARGET)' \
         PKG_CONFIG='$(PREFIX)/bin/$(TARGET)-pkg-config'
-    $(MAKE) -C '$(1)' -j '$(JOBS)' install bin_PROGRAMS= sbin_PROGRAMS= noinst_PROGRAMS= html_DATA= || \
-    $(MAKE) -C '$(1)' -j 1 install bin_PROGRAMS= sbin_PROGRAMS= noinst_PROGRAMS= html_DATA=
+    $(MAKE) CFLAGS+='-Wno-deprecated-declarations' -C '$(1)' -j '$(JOBS)' install bin_PROGRAMS= sbin_PROGRAMS= noinst_PROGRAMS= html_DATA= || \
+    $(MAKE) CFLAGS+='-Wno-deprecated-declarations' -C '$(1)' -j 1 install bin_PROGRAMS= sbin_PROGRAMS= noinst_PROGRAMS= html_DATA=
 endef
 
 $(PKG)_BUILD_SHARED =


### PR DESCRIPTION
mdbtools maintainer and repo changed a while ago. MXE is building old 0.7.1 version which dates back october 2013, and still references older yet Sourceforge repo page.

Current one is  https://github.com/mdbtools/mdbtools.git

This patch should reference correct github repo, and add a temporary fix for the build of v1.0.0. which failed because of deprecation warnings. This warnings have been fixed upstream in dev branch, but not included in a release yet.

Please read http://mxe.cc/#creating-packages

In particular, make sure that your build rules:

  * install .pc file,
  * install bin/test-pkg.exe compiled with flags by pkg-config,
  * install .dll to bin/ and .a, .dll.a to lib/,
  * use $(TARGET)-cmake instead of cmake,
  * build in `$(BUILD_DIR)` instead of `$(SOURCE_DIR)`,
  * do not run target executables with Wine,
  * do not download anything while building,
  * do not install documentation,
  * do not install .exe files except test and build systems,

and .patch files are generated by tools/patch-tool-mxe.

If you add a package, you can use tool tools/skeleton.py.

Thanks!
