### PR TITLE
Fix build failure for package `guile` target `i686-w64-mingw32.static`

### DIFF
--- a/src/guile.mk
+++ b/src/guile.mk
@@ -29,7 +29,7 @@ define $(PKG)_BUILD
         --without-threads \
         scm_cv_struct_timespec=no \
         LIBS='-lunistring -lintl -liconv -ldl' \
-        CFLAGS='-Wno-unused-but-set-variable -Wno-unused-value $($(PKG)_EXTRA_WARNINGS)'
+        CFLAGS='-Wno-misleading-indentation -Wno-unused-but-set-variable -Wno-unused-value $($(PKG)_EXTRA_WARNINGS)'
     $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)' $(MXE_DISABLE_CRUFT) schemelib_DATA=
     $(MAKE) -C '$(BUILD_DIR)' -j 1 install $(MXE_DISABLE_CRUFT) schemelib_DATA=
 


### PR DESCRIPTION
Currently, package `guile` for target `i686-w64-mingw32.static` fails to build.  This is due to `-Werror` being specified and an indentation warning being issued, thus halting compilation.  This is a small change that adds `-Wno-misleading-indentation` to the compiler flags, which allows the package to be built successfully.  This will resolve issue #3055.