### PR TITLE
Fix build failure for pakage `gtk2`

### DIFF
--- a/src/gtk2.mk
+++ b/src/gtk2.mk
@@ -39,7 +39,7 @@ define $(PKG)_BUILD
     '$(TARGET)-gcc' \
         -W -Wall -Werror -Wno-error=deprecated-declarations -ansi \
         '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-gtk2.exe' \
-        `'$(TARGET)-pkg-config' gtk+-2.0 gmodule-2.0 --cflags --libs`
+        `'$(TARGET)-pkg-config' gtk+-2.0 gmodule-2.0 --cflags --libs` -lstdc++
 endef
 
 $(PKG)_BUILD_SHARED =

--- a/src/gtk2.mk
+++ b/src/gtk2.mk
@@ -36,10 +36,10 @@ define $(PKG)_BUILD
     # and *.def files aren't really relevant for MXE
     rm -f '$(PREFIX)/$(TARGET)/lib/gailutil.def'
 
-    '$(TARGET)-gcc' \
+    '$(TARGET)-g++' \
         -W -Wall -Werror -Wno-error=deprecated-declarations -ansi \
         '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-gtk2.exe' \
-        `'$(TARGET)-pkg-config' gtk+-2.0 gmodule-2.0 --cflags --libs` -lstdc++
+        `'$(TARGET)-pkg-config' gtk+-2.0 gmodule-2.0 --cflags --libs`
 endef
 
 $(PKG)_BUILD_SHARED =


### PR DESCRIPTION
Currently, package `gtk2` target `i686-w64-mingw32.static` fails to build.  This is due to linker errors while trying to run the test compilation in `src/gtk2.mk`.  For some reason or other, the linker is not informed that it needs to link against `libstdc++`, which causes a lot of `undefined reference` errors when trying to link `usr/i686-w64-mingw32.static/lib/libcairo.a`.  Simply adding `-lstdc++` fixes this problem and allows GTK2 to compile sucessfully.