### PR TITLE
Add meson-wrapper dependency to cairo and pixman

### DIFF
--- a/src/cairo.mk
+++ b/src/cairo.mk
@@ -8,7 +8,7 @@ $(PKG)_CHECKSUM := 243a0736b978a33dee29f9cca7521733b78a65b5418206fef7bd1c3d4cf10
 $(PKG)_SUBDIR   := cairo-$($(PKG)_VERSION)
 $(PKG)_FILE     := cairo-$($(PKG)_VERSION).tar.xz
 $(PKG)_URL      := https://cairographics.org/releases/$($(PKG)_FILE)
-$(PKG)_DEPS     := cc fontconfig freetype-bootstrap glib libpng lzo pixman zlib
+$(PKG)_DEPS     := cc meson-wrapper fontconfig freetype-bootstrap glib libpng lzo pixman zlib
 
 define $(PKG)_UPDATE
     $(WGET) -q -O- 'https://cairographics.org/releases/?C=M;O=D' | \

--- a/src/pixman.mk
+++ b/src/pixman.mk
@@ -9,7 +9,7 @@ $(PKG)_SUBDIR   := pixman-$($(PKG)_VERSION)
 $(PKG)_FILE     := pixman-$($(PKG)_VERSION).tar.gz
 $(PKG)_URL      := https://cairographics.org/releases/$($(PKG)_FILE)
 $(PKG)_URL_2    := https://xorg.freedesktop.org/archive/individual/lib/$($(PKG)_FILE)
-$(PKG)_DEPS     := cc libpng
+$(PKG)_DEPS     := cc meson-wrapper libpng
 
 define $(PKG)_UPDATE
     $(WGET) -q -O- 'https://cairographics.org/releases/?C=M;O=D' | \


### PR DESCRIPTION
Since 1125fa7, cairo and pixman builds use meson-wrapper but it is not in dependencies.
Now clean build always installs meson-wrapper first.