### PR TITLE
Fix `freeimage`'s broken build

### DIFF
--- a/src/freeimage-1-fixes.patch
+++ b/src/freeimage-1-fixes.patch
@@ -90,7 +90,7 @@ index 1111111..2222222 100644
  CFLAGS ?= -O3 -fexceptions -DNDEBUG $(WIN32_CFLAGS)
  CFLAGS += $(INCLUDE)
 -CXXFLAGS ?= -O3 -fexceptions -Wno-ctor-dtor-privacy -DNDEBUG $(WIN32_CXXFLAGS)
-+CXXFLAGS ?= -O3 -fexceptions -Wno-ctor-dtor-privacy -Wno-narrowing -DNDEBUG $(WIN32_CXXFLAGS)
++CXXFLAGS ?= -DWIN32 --std=c++14 -O3 -fexceptions -Wno-ctor-dtor-privacy -Wno-narrowing -DNDEBUG $(WIN32_CXXFLAGS)
  CXXFLAGS += $(INCLUDE)
  RCFLAGS ?= -DNDEBUG
  LDFLAGS ?= -s -shared -static -Wl,-soname,$(SOLIBNAME) $(WIN32_LDFLAGS)


### PR DESCRIPTION
Freeimage's build is currently broken, this unbrokens it.  It throws lots of nasty errors because "ISO C++17 does not allow dynamic exception specifications" according to the compiler.  Enforcing C++14 fixes this.  Another very, very weird thing is that somehow, somewhy, `WIN32` isn't defined **anywhere** in the build process, and this completely breaks a **lot** of conditional compilation stuff, which cropped up in a lot of weird ways.  Simply adding it to the compiler flags fixes everything.  It was that simple, yet it took me 4 days, several false starts, and having to go figure out completely unrelated problems (that patch file has **mixed line endings** in it!) to get to this point.  I hate everything now and have almost lost my sanity, but at least it's fixed.

Also, I can add a proper patch to the patch file if you want me to.  I was just editing the existing one because lazy.

Also also please ignore the typo in the commit message, it's currently 2:49am for me (-_-);