### PR TITLE
Add `python3-packaging` and `sqlite3` to Debian requirements list

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -829,10 +829,12 @@ USE_OSGPLUGIN(&lt;plugin2&gt;)
     python3 \
     python3-distutils \
     python3-mako \
+    python3-packaging \
     python3-pkg-resources \
     python-is-python3 \
     ruby \
     sed \
+    sqlite3 \
     unzip \
     wget \
     xz-utils</pre>


### PR DESCRIPTION
Package proj fails to build without sqlite3, and package glib fails to build without the python module packaging, so add them to the requirements.

This should probably be revisited later to add the packages for other distros, but it's good enough for right now.