### PR TITLE
Fix gtk3 failing to build because of cairo's stupid libstdc++ dependencies

### DIFF
--- a/src/gtk3.mk
+++ b/src/gtk3.mk
@@ -30,6 +30,7 @@ define $(PKG)_BUILD
         -Ddemos=false \
         -Dinstalled_tests=false \
         -Dbuiltin_immodules=yes \
+        -Dc_link_args='-lstdc++' \
         -Dintrospection=false \
         '$(BUILD_DIR)' '$(SOURCE_DIR)'
     '$(MXE_NINJA)' -C '$(BUILD_DIR)' -j '$(JOBS)'
@@ -37,7 +38,7 @@ define $(PKG)_BUILD
         '$(MXE_NINJA)' -C '$(BUILD_DIR)' -j '$(JOBS)' install
 
     # Just compile our MXE testfile
-    '$(TARGET)-gcc' \
+    '$(TARGET)-g++' \
         -W -Wall -ansi \
         '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-gtk3.exe' \
         `'$(TARGET)-pkg-config' gtk+-3.0 --cflags --libs`


### PR DESCRIPTION
This is yet another fix for yet another instance of cairo now needing to link against libstdc++, which the package's build process isn't expecting, which causes the linker to throw its hands up and bomb out because it's too dumb to automatically bring in the standard libraries when needed.