### PR TITLE
assimp: update 3.2 -> 5.4.1

### DIFF
--- a/src/assimp.mk
+++ b/src/assimp.mk
@@ -1,26 +1,23 @@
 # This file is part of MXE. See LICENSE.md for licensing information.
 
 PKG             := assimp
-$(PKG)_WEBSITE  := https://assimp.sourceforge.io/
+$(PKG)_WEBSITE  := https://www.assimp.org/
 $(PKG)_DESCR    := Assimp Open Asset Import Library
 $(PKG)_IGNORE   :=
-$(PKG)_VERSION  := 3.2
-$(PKG)_CHECKSUM := 187f825c563e84b1b17527a4da0351aa3d575dfd696a9d204ae4bb19ee7df94a
+$(PKG)_VERSION  := 5.4.1
+$(PKG)_CHECKSUM := a1bf71c4eb851ca336bba301730cd072b366403e98e3739d6a024f6313b8f954
 $(PKG)_GH_CONF  := assimp/assimp/tags, v
-$(PKG)_DEPS     := cc boost minizip
+$(PKG)_DEPS     := cc minizip
 
 define $(PKG)_BUILD
     cd '$(BUILD_DIR)' && $(TARGET)-cmake \
-        -DASSIMP_ENABLE_BOOST_WORKAROUND=OFF \
-        -DASSIMP_BUILD_ASSIMP_TOOLS=OFF \
-        -DASSIMP_BUILD_SAMPLES=OFF \
         -DASSIMP_BUILD_TESTS=OFF \
         '$(SOURCE_DIR)'
     $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)'
     $(MAKE) -C '$(BUILD_DIR)' -j 1 install
 
-    '$(TARGET)-gcc' \
-        -W -Wall -Werror -ansi -pedantic \
+    '$(TARGET)-g++' \
+        -W -Wall -Werror -pedantic \
         '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-assimp.exe' \
         `'$(TARGET)-pkg-config' assimp minizip --cflags --libs`
 endef


### PR DESCRIPTION
New versions of `assimp` does not use Boost. Dependency removed.

Removed CMake options are the ones already by default.

Replaced gcc call by g++ to fix static builds (see https://github.com/assimp/assimp/blob/v5.4.1/code/CMakeLists.txt#L1348).