### PR TITLE
Build curl with http2 support

### DIFF
--- a/src/curl.mk
+++ b/src/curl.mk
@@ -9,7 +9,7 @@ $(PKG)_CHECKSUM := 0f58bb95fc330c8a46eeb3df5701b0d90c9d9bfcc42bd1cd08791d12551d4
 $(PKG)_SUBDIR   := curl-$($(PKG)_VERSION)
 $(PKG)_FILE     := curl-$($(PKG)_VERSION).tar.xz
 $(PKG)_URL      := https://curl.haxx.se/download/$($(PKG)_FILE)
-$(PKG)_DEPS     := cc brotli libidn2 libpsl libssh2 pthreads
+$(PKG)_DEPS     := cc brotli libidn2 libpsl libssh2 pthreads libnghttp2
 
 define $(PKG)_UPDATE
     $(WGET) -q -O- 'https://curl.haxx.se/download/?C=M;O=D' | \
@@ -25,6 +25,7 @@ define $(PKG)_BUILD
         --enable-sspi \
         --enable-ipv6 \
         --with-libssh2 \
+        --with-nghttp2 \
         LIBS="`'$(TARGET)-pkg-config' libpsl libbrotlidec pthreads --libs`"
     $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)' $(MXE_DISABLE_DOCS)
     $(MAKE) -C '$(BUILD_DIR)' -j 1 install $(MXE_DISABLE_DOCS)


### PR DESCRIPTION
Now that `libnghttp2` was added in #3078, curl can be built with http2 support
