### PR TITLE
Qt6.8.0: Add virtualkeyboard and webview modules, extend deps of qt5compat

### DIFF
--- a/src/qt/qt6/qt6-qt5compat.mk
+++ b/src/qt/qt6/qt6-qt5compat.mk
@@ -6,7 +6,7 @@ PKG := qt6-qt5compat
 $(eval $(QT6_METADATA))
 
 $(PKG)_CHECKSUM := 3c9b05fdd70b6bd6ec152e6b43f2a5f4c7b31c9eb342d62fa8450d63f5835e30
-$(PKG)_DEPS     := cc qt6-conf qt6-qtbase
+$(PKG)_DEPS     := cc qt6-conf qt6-qtbase qt6-qtshadertools
 
 QT6_PREFIX   = '$(PREFIX)/$(TARGET)/$(MXE_QT6_ID)'
 QT6_QT_CMAKE = '$(QT6_PREFIX)/$(if $(findstring mingw,$(TARGET)),bin,libexec)/qt-cmake-private' \

--- a/src/qt/qt6/qt6-qtvirtualkeyboard.mk
+++ b/src/qt/qt6/qt6-qtvirtualkeyboard.mk
@@ -1,0 +1,19 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+include src/qt/qt6/qt6-conf.mk
+
+PKG := qt6-qtvirtualkeyboard
+$(eval $(QT6_METADATA))
+
+$(PKG)_CHECKSUM := 8f6502d7f40765fb4960b804927f9d86da39bdf42acc5021353c49527b6d0ce0
+$(PKG)_DEPS     := cc qt6-conf qt6-qtbase
+
+QT6_PREFIX   = '$(PREFIX)/$(TARGET)/$(MXE_QT6_ID)'
+QT6_QT_CMAKE = '$(QT6_PREFIX)/$(if $(findstring mingw,$(TARGET)),bin,libexec)/qt-cmake-private' \
+                   -DCMAKE_INSTALL_PREFIX='$(QT6_PREFIX)'
+
+define $(PKG)_BUILD
+    $(QT6_QT_CMAKE) -S '$(SOURCE_DIR)' -B '$(BUILD_DIR)'
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --build . -j '$(JOBS)'
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --install .
+endef

--- a/src/qt/qt6/qt6-qtwebview.mk
+++ b/src/qt/qt6/qt6-qtwebview.mk
@@ -1,0 +1,19 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+include src/qt/qt6/qt6-conf.mk
+
+PKG := qt6-qtwebview
+$(eval $(QT6_METADATA))
+
+$(PKG)_CHECKSUM := 7cb89d41593876b176368b15c1cded3d5a3c4fdf7e0a10f0c61021e3e8c179f3
+$(PKG)_DEPS     := cc qt6-conf qt6-qtbase
+
+QT6_PREFIX   = '$(PREFIX)/$(TARGET)/$(MXE_QT6_ID)'
+QT6_QT_CMAKE = '$(QT6_PREFIX)/$(if $(findstring mingw,$(TARGET)),bin,libexec)/qt-cmake-private' \
+                   -DCMAKE_INSTALL_PREFIX='$(QT6_PREFIX)'
+
+define $(PKG)_BUILD
+    $(QT6_QT_CMAKE) -S '$(SOURCE_DIR)' -B '$(BUILD_DIR)'
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --build . -j '$(JOBS)'
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --install .
+endef


### PR DESCRIPTION
I simply copied `qt-websockets.mk` and adjusted the names + checksums.

In addition, I included the `qtshadertools` as dependency in `qt5compat` module. This causes the `GraphicalEffects` module to being built, which is not the case if shadertools is not yet available during the build. I think this is the better default to have