### PR TITLE
Add package flint, version 3.1.3-p1 to MXE

### DIFF
--- a/src/flint-1-fixes.patch
+++ b/src/flint-1-fixes.patch
@@ -1,0 +1,61 @@
+This file is part of MXE. See LICENSE.md for licensing information.
+
+This patch has been taken from:
+https://github.com/flintlib/flint/issues/2098
+
+diff -ruN flint-3.1.3-p1/Makefile.in flint-3.1.3-p1-patched/Makefile.in
+--- flint-3.1.3-p1/Makefile.in	2024-05-24 08:52:40
++++ flint-3.1.3-p1-patched/Makefile.in	2024-10-20 23:32:18
+@@ -416,6 +416,10 @@
+ ifneq ($(SHARED), 0)
+ shared: $(FLINT_DIR)/$(FLINT_LIB_FULL)
+ 
++ifneq ($(strip $(filter gnu% linux-gnu%,@FLINT_BUILD_OS@)),)
++# No command line length limitations under build_os=gnu*|linux-gnu*
++MERGED_LOBJS := $(foreach dir,$(DIRS),$($(dir)_LOBJS))
++else
+ # The following is to avoid reaching the maximum length of command line
+ # arguments, mainly present on MinGW.
+ define xxx_merged_lobj_rule
+@@ -424,6 +428,7 @@
+ endef
+ $(foreach dir, $(DIRS), $(eval $(call xxx_merged_lobj_rule,$(dir))))
+ MERGED_LOBJS:=$(foreach dir, $(DIRS),$(BUILD_DIR)/$(dir)_merged.lo)
++endif
+ 
+ $(FLINT_DIR)/$(FLINT_LIB_FULL): $(MERGED_LOBJS)
+ 	@echo "Building $(FLINT_LIB_FULL)"
+@@ -437,6 +442,10 @@
+ ifneq ($(STATIC), 0)
+ static: $(FLINT_DIR)/$(FLINT_LIB_STATIC)
+ 
++ifneq ($(strip $(filter gnu% linux-gnu%,@FLINT_BUILD_OS@)),)
++# No command line length limitations under build_os=gnu*|linux-gnu*
++MERGED_OBJS := $(foreach dir,$(DIRS),$($(dir)_OBJS))
++else
+ # The following is to avoid reaching the maximum length of command line
+ # arguments, mainly present on MinGW.
+ define xxx_merged_obj_rule
+@@ -445,6 +454,7 @@
+ endef
+ $(foreach dir, $(DIRS), $(eval $(call xxx_merged_obj_rule,$(dir))))
+ MERGED_OBJS:=$(foreach dir, $(DIRS),$(BUILD_DIR)/$(dir)_merged.o)
++endif
+ 
+ $(FLINT_DIR)/$(FLINT_LIB_STATIC): $(MERGED_OBJS)
+ 	@echo "Building $(FLINT_LIB_STATIC)"
+diff -ruN flint-3.1.3-p1/configure.ac flint-3.1.3-p1-patched/configure.ac
+--- flint-3.1.3-p1/configure.ac	2024-05-24 08:52:40
++++ flint-3.1.3-p1-patched/configure.ac	2024-10-20 23:25:02
+@@ -129,7 +129,11 @@
+ 
+ dnl Get system triplet
+ dnl NOTE: This is already invoked from LT_INIT
++dnl AC_CANONICAL_BUILD
+ dnl AC_CANONICAL_HOST
++
++FLINT_BUILD_OS="${build_os}"
++AC_SUBST(FLINT_BUILD_OS)
+ 
+ ################################################################################
+ # configure headers

--- a/src/flint-test.c
+++ b/src/flint-test.c
@@ -1,0 +1,17 @@
+/* This file is part of MXE. See LICENSE.md for licensing information. */
+
+#include <flint/arb.h>
+
+int main(void)
+{
+    arb_t x, y;
+    int e;
+    arb_init(x);
+    arb_init(y);
+    arb_one(x);
+    arb_set_si(y, 1);
+    e = arb_equal(x, y);
+    arb_clear(x);
+    arb_clear(y);
+    return (e) ? 0 : 1;
+}

--- a/src/flint.mk
+++ b/src/flint.mk
@@ -1,0 +1,32 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+PKG             := flint
+$(PKG)_WEBSITE  := https://www.flintlib.org/
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 3.1.3-p1
+$(PKG)_CHECKSUM := 5763d4b68be20360da5f5ab41f2b3c481208fe3356fbbbe65bcf168b17acd96f
+$(PKG)_GH_CONF  := flintlib/flint/releases,v
+$(PKG)_DEPS     := cc gmp mpfr pthreads
+
+define $(PKG)_BUILD
+    cd '$(SOURCE_DIR)' && ./bootstrap.sh
+    cd '$(SOURCE_DIR)' && ./configure \
+        $(MXE_CONFIGURE_OPTS) \
+        --enable-pthread \
+        --with-gmp-include='$(PREFIX)/$(TARGET)/include' \
+        --with-gmp-lib='$(PREFIX)/$(TARGET)/lib' \
+        --with-mpfr-include='$(PREFIX)/$(TARGET)/include' \
+        --with-mpfr-lib='$(PREFIX)/$(TARGET)/lib' \
+        --without-blas \
+        --without-gc \
+        --without-ntl
+    $(MAKE) -C '$(SOURCE_DIR)' -j '$(JOBS)' $(MXE_DISABLE_CRUFT)
+    $(MAKE) -C '$(SOURCE_DIR)' -j 1 install $(MXE_DISABLE_CRUFT)
+
+    '$(TARGET)-gcc' \
+        -Wall -Werror -std=c99 -pedantic \
+        '$(PWD)/src/$(PKG)-test.c' \
+        -o \
+        '$(PREFIX)/$(TARGET)/bin/test-$(PKG).exe' \
+        `'$(TARGET)-pkg-config' $(PKG) --cflags --libs`
+endef


### PR DESCRIPTION
This PR adds C library FLINT (https://flintlib.org/).  Currently, FLINT does not support out-of-tree builds, so we build in `$(SOURCE_DIR)`.  There are plans for this to be fixed in an upcoming release:

https://github.com/flintlib/flint/issues/2077

The patch addresses non-portable use in their `Makefile.in` of linker option `-r` to merge object files.  The MinGW back-end of LLVM's linker `lld` does not support it.  The patch has been provided upstream:

https://github.com/flintlib/flint/issues/2098

I've already succeeded in using my fork to cross-compile FLINT for `x86_64` and `aarch64`, and I've tested each of the resulting builds locally inside of Msys2.  No problems so far.

Please let me know if I've missed anything!