### PR TITLE
copydlldeps.sh: Fix --infile processing

### DIFF
--- a/tools/copydlldeps.sh
+++ b/tools/copydlldeps.sh
@@ -238,8 +238,8 @@ fi
 if [ "$infile" ]; then
     for curFile in $( echo "${infile}" | tr -s ' ' | tr ' ' '\n' ); do
     if [ `uname -s` == "Darwin" ]; then
-        curString=$( find $curPath -iname *.exe -or -iname *.dll | tr '\n' ' '  )
-        else curString=$( find $curPath -iregex '.*\(dll\|exe\)' | tr '\n' ' ' )
+        curString=$( find $curFile -iname *.exe -or -iname *.dll | tr '\n' ' '  )
+        else curString=$( find $curFile -iregex '.*\(dll\|exe\)' | tr '\n' ' ' )
     fi
         str_inputFileList+=" $curString"
     done


### PR DESCRIPTION
The --infile argument in copydlldeps.sh was not usable anymore since be2e33c9d4bfec190eea3b996579e551c1bf906f (copy-paste error in variable name "$curPath" vs "$curFile").
