### PR TITLE
nlohmann-json: Add new package

### DIFF
--- a/src/nlohmann-json-test.cpp
+++ b/src/nlohmann-json-test.cpp
@@ -1,0 +1,8 @@
+#include <nlohmann/json.hpp>
+
+using nlohmann::json;
+
+int main() {
+    json j = json::parse(R"({"status": "success"})");
+    return (j["status"] != "success");
+}

--- a/src/nlohmann-json.mk
+++ b/src/nlohmann-json.mk
@@ -1,0 +1,43 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+PKG             := nlohmann-json
+$(PKG)_WEBSITE  := https://json.nlohmann.me/
+$(PKG)_DESCR    := JSON for Modern C++
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 3.11.3
+$(PKG)_CHECKSUM := 0d8ef5af7f9794e3263480193c491549b2ba6cc74bb018906202ada498a79406
+$(PKG)_SUBDIR   := json-$($(PKG)_VERSION)
+$(PKG)_FILE     := v$($(PKG)_VERSION).tar.gz
+$(PKG)_URL      := https://github.com/nlohmann/json/archive/refs/tags/$($(PKG)_FILE)
+$(PKG)_DEPS     := cc
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- 'https://github.com/nlohmann/json/tags' | \
+		grep '<a .*href="/nlohmann/json/archive/refs/tags/' | \
+		$(SED) -n 's,.*href="/nlohmann/json/archive/refs/tags/v\([0-9][^"_]*\)\.tar.*,\1,p' | \
+		head -1
+endef
+
+define $(PKG)_BUILD
+    # build and install the library
+    cd '$(BUILD_DIR)' && $(TARGET)-cmake '$(SOURCE_DIR)' \
+        -DBUILD_TESTING=OFF \
+		-DJSON_32bitTest=OFF \
+		-DJSON_BuildTests=OFF \
+		-DJSON_Install=ON
+    $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)'
+    $(MAKE) -C '$(BUILD_DIR)' -j 1 install VERBOSE=1
+
+    # create pkg-config file
+    $(INSTALL) -d '$(PREFIX)/$(TARGET)/lib/pkgconfig'
+    (echo 'Name: $(PKG)'; \
+     echo 'Version: $($(PKG)_VERSION)'; \
+     echo 'Description: $($(PKG)_DESCR)'; \
+    ) > '$(PREFIX)/$(TARGET)/lib/pkgconfig/$(PKG).pc'
+
+    # compile test
+    '$(TARGET)-g++' \
+        -W -Wall -Werror \
+        '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-$(PKG).exe' \
+        `'$(TARGET)-pkg-config' $(PKG) --cflags --libs`
+endef


### PR DESCRIPTION
Add new package for [nlohmann-json](https://github.com/nlohmann/json).

Also tested with GCC 6-10 & 12-14 from the `plugins/` directory.
GCC 5 is not working.

- [x] install .pc file,
- [x] install bin/test-pkg.exe compiled with flags by pkg-config,
- [x] install .dll to bin/ and .a, .dll.a to lib/,
- [x] use $(TARGET)-cmake instead of cmake,
- [x] build in `$(BUILD_DIR)` instead of `$(SOURCE_DIR)`,
- [x] do not run target executables with Wine,
- [x] do not download anything while building,
- [x] do not install documentation,
- [x] do not install .exe files except test and build systems,
- [x] and .patch files are generated by tools/patch-tool-mxe.
