### PR TITLE
SDL_mixer: fix package fails to build

### DIFF
--- a/src/sdl_mixer-1-fixes.patch
+++ b/src/sdl_mixer-1-fixes.patch
@@ -5,7 +5,7 @@ Contains ad hoc patches for cross building.
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tony Theodore <tonyt@logyst.com>
 Date: Sun, 11 Mar 2018 18:57:48 +1100
-Subject: [PATCH 1/2] fix double free
+Subject: [PATCH 1/3] fix double free
 
 https://bugs.gentoo.org/show_bug.cgi?id=406739
 Nikos Chantziaras 2012-03-03 03:13:39 EST
@@ -46,7 +46,7 @@ index 1111111..2222222 100644
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tony Theodore <tonyt@logyst.com>
 Date: Sun, 11 Mar 2018 19:00:16 +1100
-Subject: [PATCH 2/2] fix ogg linking
+Subject: [PATCH 2/3] fix ogg linking
 
 This patch has been taken from: https://hg.libsdl.org/SDL_mixer/rev/0aadc9b6daac
 
@@ -82,3 +82,36 @@ index 1111111..2222222 100755
  cat >conftest.$ac_ext <<_ACEOF
  /* confdefs.h.  */
  _ACEOF
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: darealshinji <djcj@gmx.de>
+Date: Sun, 8 Dec 2024 13:31:52 +0100
+Subject: [PATCH 3/3] argument 3 of ov_open_callbacks must be const char*
+
+
+diff --git a/dynamic_ogg.c b/dynamic_ogg.c
+index 1111111..2222222 100644
+--- a/dynamic_ogg.c
++++ b/dynamic_ogg.c
+@@ -52,7 +52,7 @@ int Mix_InitOgg()
+ 			return -1;
+ 		}
+ 		vorbis.ov_open_callbacks =
+-			(int (*)(void *, OggVorbis_File *, char *, long, ov_callbacks))
++			(int (*)(void *, OggVorbis_File *, const char *, long, ov_callbacks))
+ 			SDL_LoadFunction(vorbis.handle, "ov_open_callbacks");
+ 		if ( vorbis.ov_open_callbacks == NULL ) {
+ 			SDL_UnloadObject(vorbis.handle);
+diff --git a/dynamic_ogg.h b/dynamic_ogg.h
+index 1111111..2222222 100644
+--- a/dynamic_ogg.h
++++ b/dynamic_ogg.h
+@@ -31,7 +31,7 @@ typedef struct {
+ 	void *handle;
+ 	int (*ov_clear)(OggVorbis_File *vf);
+ 	vorbis_info *(*ov_info)(OggVorbis_File *vf,int link);
+-	int (*ov_open_callbacks)(void *datasource, OggVorbis_File *vf, char *initial, long ibytes, ov_callbacks callbacks);
++	int (*ov_open_callbacks)(void *datasource, OggVorbis_File *vf, const char *initial, long ibytes, ov_callbacks callbacks);
+ 	ogg_int64_t (*ov_pcm_total)(OggVorbis_File *vf,int i);
+ #ifdef OGG_USE_TREMOR
+ 	long (*ov_read)(OggVorbis_File *vf,char *buffer,int length, int *bitstream);


### PR DESCRIPTION
argument 3 of ov_open_callbacks in dynamic_ogg.[c|h] must be const char* otherwise the build fails

Tested on x86_64-w64-mingw32.static and i686-w64-mingw32.shared.

Closes https://github.com/mxe/mxe/issues/3110