### PR TITLE
SDL_image: fix package fail to build

### DIFF
--- a/src/sdl_image-1-fixes.patch
+++ b/src/sdl_image-1-fixes.patch
@@ -1,0 +1,288 @@
+This file is part of MXE. See LICENSE.md for licensing information.
+
+Contains ad hoc patches for cross building.
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: darealshinji <djcj@gmx.de>
+Date: Sun, 8 Dec 2024 13:21:52 +0100
+Subject: [PATCH 1/1] function arguments had different types
+
+const keywords were either missing or incorrectly placed, causing the
+build to fail. webp_get_features_internal must return VP8StatusCode.
+
+
+diff --git a/IMG_png.c b/IMG_png.c
+index 1111111..2222222 100644
+--- a/IMG_png.c
++++ b/IMG_png.c
+@@ -68,6 +68,12 @@
+ #ifdef macintosh
+ #define MACOS
+ #endif
++
++/* use a custom PNG export macro to create additional function pointer typedefs */
++#define PNG_EXPORTA(ordinal, type, name, args, attributes) \
++	attributes type name args; \
++	typedef type (*name##_fptr_t) args
++
+ #include <png.h>
+ 
+ /* Check for the older version of libpng */
+@@ -75,29 +81,31 @@
+ #define LIBPNG_VERSION_12
+ #endif
+ 
++#define ENTRY(x) x##_fptr_t x
++
+ static struct {
+ 	int loaded;
+ 	void *handle;
+-	png_infop (*png_create_info_struct) (png_structp png_ptr);
+-	png_structp (*png_create_read_struct) (png_const_charp user_png_ver, png_voidp error_ptr, png_error_ptr error_fn, png_error_ptr warn_fn);
+-	void (*png_destroy_read_struct) (png_structpp png_ptr_ptr, png_infopp info_ptr_ptr, png_infopp end_info_ptr_ptr);
+-	png_uint_32 (*png_get_IHDR) (png_structp png_ptr, png_infop info_ptr, png_uint_32 *width, png_uint_32 *height, int *bit_depth, int *color_type, int *interlace_method, int *compression_method, int *filter_method);
+-	png_voidp (*png_get_io_ptr) (png_structp png_ptr);
+-	png_byte (*png_get_channels) (png_structp png_ptr, png_infop info_ptr);
+-	png_uint_32 (*png_get_PLTE) (png_structp png_ptr, png_infop info_ptr, png_colorp *palette, int *num_palette);
+-	png_uint_32 (*png_get_tRNS) (png_structp png_ptr, png_infop info_ptr, png_bytep *trans, int *num_trans, png_color_16p *trans_values);
+-	png_uint_32 (*png_get_valid) (png_structp png_ptr, png_infop info_ptr, png_uint_32 flag);
+-	void (*png_read_image) (png_structp png_ptr, png_bytepp image);
+-	void (*png_read_info) (png_structp png_ptr, png_infop info_ptr);
+-	void (*png_read_update_info) (png_structp png_ptr, png_infop info_ptr);
+-	void (*png_set_expand) (png_structp png_ptr);
+-	void (*png_set_gray_to_rgb) (png_structp png_ptr);
+-	void (*png_set_packing) (png_structp png_ptr);
+-	void (*png_set_read_fn) (png_structp png_ptr, png_voidp io_ptr, png_rw_ptr read_data_fn);
+-	void (*png_set_strip_16) (png_structp png_ptr);
+-	int (*png_sig_cmp) (png_bytep sig, png_size_t start, png_size_t num_to_check);
++	ENTRY( png_create_info_struct );
++	ENTRY( png_create_read_struct );
++	ENTRY( png_destroy_read_struct );
++	ENTRY( png_get_IHDR );
++	ENTRY( png_get_io_ptr );
++	ENTRY( png_get_channels );
++	ENTRY( png_get_PLTE );
++	ENTRY( png_get_tRNS );
++	ENTRY( png_get_valid );
++	ENTRY( png_read_image );
++	ENTRY( png_read_info );
++	ENTRY( png_read_update_info );
++	ENTRY( png_set_expand );
++	ENTRY( png_set_gray_to_rgb );
++	ENTRY( png_set_packing );
++	ENTRY( png_set_read_fn );
++	ENTRY( png_set_strip_16 );
++	ENTRY( png_sig_cmp );
+ #ifndef LIBPNG_VERSION_12
+-	jmp_buf* (*png_set_longjmp_fn) (png_structp, png_longjmp_ptr, size_t);
++	ENTRY( png_set_longjmp_fn );
+ #endif
+ } lib;
+ 
+@@ -110,126 +118,126 @@ int IMG_InitPNG()
+ 			return -1;
+ 		}
+ 		lib.png_create_info_struct =
+-			(png_infop (*) (png_structp))
++			(png_create_info_struct_fptr_t)
+ 			SDL_LoadFunction(lib.handle, "png_create_info_struct");
+ 		if ( lib.png_create_info_struct == NULL ) {
+ 			SDL_UnloadObject(lib.handle);
+ 			return -1;
+ 		}
+ 		lib.png_create_read_struct =
+-			(png_structp (*) (png_const_charp, png_voidp, png_error_ptr, png_error_ptr))
++			(png_create_read_struct_fptr_t)
+ 			SDL_LoadFunction(lib.handle, "png_create_read_struct");
+ 		if ( lib.png_create_read_struct == NULL ) {
+ 			SDL_UnloadObject(lib.handle);
+ 			return -1;
+ 		}
+ 		lib.png_destroy_read_struct =
+-			(void (*) (png_structpp, png_infopp, png_infopp))
++			(png_destroy_read_struct_fptr_t)
+ 			SDL_LoadFunction(lib.handle, "png_destroy_read_struct");
+ 		if ( lib.png_destroy_read_struct == NULL ) {
+ 			SDL_UnloadObject(lib.handle);
+ 			return -1;
+ 		}
+ 		lib.png_get_IHDR =
+-			(png_uint_32 (*) (png_structp, png_infop, png_uint_32 *, png_uint_32 *, int *, int *, int *, int *, int *))
++			(png_get_IHDR_fptr_t)
+ 			SDL_LoadFunction(lib.handle, "png_get_IHDR");
+ 		if ( lib.png_get_IHDR == NULL ) {
+ 			SDL_UnloadObject(lib.handle);
+ 			return -1;
+ 		}
+ 		lib.png_get_channels =
+-			(png_byte (*) (png_structp, png_infop))
++			(png_get_channels_fptr_t)
+ 			SDL_LoadFunction(lib.handle, "png_get_channels");
+ 		if ( lib.png_get_channels == NULL ) {
+ 			SDL_UnloadObject(lib.handle);
+ 			return -1;
+ 		}
+ 		lib.png_get_io_ptr =
+-			(png_voidp (*) (png_structp))
++			(png_get_io_ptr_fptr_t)
+ 			SDL_LoadFunction(lib.handle, "png_get_io_ptr");
+ 		if ( lib.png_get_io_ptr == NULL ) {
+ 			SDL_UnloadObject(lib.handle);
+ 			return -1;
+ 		}
+ 		lib.png_get_PLTE =
+-			(png_uint_32 (*) (png_structp, png_infop, png_colorp *, int *))
++			(png_get_PLTE_fptr_t)
+ 			SDL_LoadFunction(lib.handle, "png_get_PLTE");
+ 		if ( lib.png_get_PLTE == NULL ) {
+ 			SDL_UnloadObject(lib.handle);
+ 			return -1;
+ 		}
+ 		lib.png_get_tRNS =
+-			(png_uint_32 (*) (png_structp, png_infop, png_bytep *, int *, png_color_16p *))
++			(png_get_tRNS_fptr_t)
+ 			SDL_LoadFunction(lib.handle, "png_get_tRNS");
+ 		if ( lib.png_get_tRNS == NULL ) {
+ 			SDL_UnloadObject(lib.handle);
+ 			return -1;
+ 		}
+ 		lib.png_get_valid =
+-			(png_uint_32 (*) (png_structp, png_infop, png_uint_32))
++			(png_get_valid_fptr_t)
+ 			SDL_LoadFunction(lib.handle, "png_get_valid");
+ 		if ( lib.png_get_valid == NULL ) {
+ 			SDL_UnloadObject(lib.handle);
+ 			return -1;
+ 		}
+ 		lib.png_read_image =
+-			(void (*) (png_structp, png_bytepp))
++			(png_read_image_fptr_t)
+ 			SDL_LoadFunction(lib.handle, "png_read_image");
+ 		if ( lib.png_read_image == NULL ) {
+ 			SDL_UnloadObject(lib.handle);
+ 			return -1;
+ 		}
+ 		lib.png_read_info =
+-			(void (*) (png_structp, png_infop))
++			(png_read_info_fptr_t)
+ 			SDL_LoadFunction(lib.handle, "png_read_info");
+ 		if ( lib.png_read_info == NULL ) {
+ 			SDL_UnloadObject(lib.handle);
+ 			return -1;
+ 		}
+ 		lib.png_read_update_info =
+-			(void (*) (png_structp, png_infop))
++			(png_read_update_info_fptr_t)
+ 			SDL_LoadFunction(lib.handle, "png_read_update_info");
+ 		if ( lib.png_read_update_info == NULL ) {
+ 			SDL_UnloadObject(lib.handle);
+ 			return -1;
+ 		}
+ 		lib.png_set_expand =
+-			(void (*) (png_structp))
++			(png_set_expand_fptr_t)
+ 			SDL_LoadFunction(lib.handle, "png_set_expand");
+ 		if ( lib.png_set_expand == NULL ) {
+ 			SDL_UnloadObject(lib.handle);
+ 			return -1;
+ 		}
+ 		lib.png_set_gray_to_rgb =
+-			(void (*) (png_structp))
++			(png_set_gray_to_rgb_fptr_t)
+ 			SDL_LoadFunction(lib.handle, "png_set_gray_to_rgb");
+ 		if ( lib.png_set_gray_to_rgb == NULL ) {
+ 			SDL_UnloadObject(lib.handle);
+ 			return -1;
+ 		}
+ 		lib.png_set_packing =
+-			(void (*) (png_structp))
++			(png_set_packing_fptr_t)
+ 			SDL_LoadFunction(lib.handle, "png_set_packing");
+ 		if ( lib.png_set_packing == NULL ) {
+ 			SDL_UnloadObject(lib.handle);
+ 			return -1;
+ 		}
+ 		lib.png_set_read_fn =
+-			(void (*) (png_structp, png_voidp, png_rw_ptr))
++			(png_set_read_fn_fptr_t)
+ 			SDL_LoadFunction(lib.handle, "png_set_read_fn");
+ 		if ( lib.png_set_read_fn == NULL ) {
+ 			SDL_UnloadObject(lib.handle);
+ 			return -1;
+ 		}
+ 		lib.png_set_strip_16 =
+-			(void (*) (png_structp))
++			(png_set_strip_16_fptr_t)
+ 			SDL_LoadFunction(lib.handle, "png_set_strip_16");
+ 		if ( lib.png_set_strip_16 == NULL ) {
+ 			SDL_UnloadObject(lib.handle);
+ 			return -1;
+ 		}
+ 		lib.png_sig_cmp =
+-			(int (*) (png_bytep, png_size_t, png_size_t))
++			(png_sig_cmp_fptr_t)
+ 			SDL_LoadFunction(lib.handle, "png_sig_cmp");
+ 		if ( lib.png_sig_cmp == NULL ) {
+ 			SDL_UnloadObject(lib.handle);
+@@ -237,7 +245,7 @@ int IMG_InitPNG()
+ 		}
+ #ifndef LIBPNG_VERSION_12
+ 		lib.png_set_longjmp_fn =
+-			(jmp_buf * (*) (png_structp, png_longjmp_ptr, size_t))
++			(png_set_longjmp_fn_fptr_t)
+ 			SDL_LoadFunction(lib.handle, "png_set_longjmp_fn");
+ 		if ( lib.png_set_longjmp_fn == NULL ) {
+ 			SDL_UnloadObject(lib.handle);
+diff --git a/IMG_webp.c b/IMG_webp.c
+index 1111111..2222222 100644
+--- a/IMG_webp.c
++++ b/IMG_webp.c
+@@ -44,12 +44,16 @@
+ #endif
+ #include <webp/decode.h>
+ 
++typedef VP8StatusCode (*webp_get_features_internal_fptr_t) (const uint8_t* data, size_t data_size,  WebPBitstreamFeatures* features, int decoder_abi_version);
++typedef uint8_t* (*webp_decode_rgb_into_fprt_t) (const uint8_t* data, size_t data_size, uint8_t* output_buffer, size_t output_buffer_size, int output_stride);
++typedef uint8_t* (*webp_decode_rgba_into_fptr_t) (const uint8_t* data, size_t data_size, uint8_t* output_buffer, size_t output_buffer_size, int output_stride);
++
+ static struct {
+ 	int loaded;
+ 	void *handle;
+-	int/*VP8StatuCode*/ (*webp_get_features_internal) (const uint8_t *data, uint32_t data_size, WebPBitstreamFeatures* const features, int decoder_abi_version);
+-	uint8_t*	(*webp_decode_rgb_into) (const uint8_t* data, uint32_t data_size, uint8_t* output_buffer, int output_buffer_size, int output_stride);
+-	uint8_t*	(*webp_decode_rgba_into) (const uint8_t* data, uint32_t data_size, uint8_t* output_buffer, int output_buffer_size, int output_stride);
++	webp_get_features_internal_fptr_t webp_get_features_internal;
++	webp_decode_rgb_into_fprt_t webp_decode_rgb_into;
++	webp_decode_rgba_into_fptr_t webp_decode_rgba_into;
+ } lib;
+ 
+ #ifdef LOAD_WEBP_DYNAMIC
+@@ -61,7 +65,7 @@ int IMG_InitWEBP()
+ 			return -1;
+ 		}
+ 		lib.webp_get_features_internal = 
+-			( int (*) (const uint8_t *, uint32_t, WebPBitstreamFeatures* const, int) )
++			( webp_get_features_internal_fptr_t )
+ 			SDL_LoadFunction(lib.handle, "WebPGetFeaturesInternal" );
+ 		if ( lib.webp_get_features_internal == NULL ) {
+ 			SDL_UnloadObject(lib.handle);
+@@ -69,7 +73,7 @@ int IMG_InitWEBP()
+ 		}
+ 
+ 		lib.webp_decode_rgb_into = 
+-			( uint8_t* (*) (const uint8_t*, uint32_t, uint8_t*, int, int ) )
++			( webp_decode_rgb_into_fprt_t )
+ 			SDL_LoadFunction(lib.handle, "WebPDecodeRGBInto" );
+ 		if ( lib.webp_decode_rgb_into == NULL ) {
+ 			SDL_UnloadObject(lib.handle);
+@@ -77,8 +81,8 @@ int IMG_InitWEBP()
+ 		}
+ 
+ 		lib.webp_decode_rgba_into = 
+-			( uint8_t* (*) (const uint8_t*, uint32_t, uint8_t*, int, int ) )
+-			SDL_LoadFunction(lib.handle, "WebPDecodeRGBInto" );
++			( webp_decode_rgba_into_fptr_t )
++			SDL_LoadFunction(lib.handle, "WebPDecodeRGBAInto" );
+ 		if ( lib.webp_decode_rgba_into == NULL ) {
+ 			SDL_UnloadObject(lib.handle);
+ 			return -1;


### PR DESCRIPTION
Function arguments had different types. const keywords were either missing or incorrectly placed, causing the build to fail. webp_get_features_internal must return VP8StatusCode.

Tested on x86_64-w64-mingw32.static and i686-w64-mingw32.shared.

Closes https://github.com/mxe/mxe/issues/3111