### PR TITLE
installation requirements for Debian arm64

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -841,7 +841,7 @@ USE_OSGPLUGIN(&lt;plugin2&gt;)
     xz-utils</pre>
 
     <p>
-    On 32-bit installs,
+    On 32-bit installs and on arm64 installs,
     </p>
     <pre>
     g++-multilib


### PR DESCRIPTION
Add a similar note that g++-multilib and libc6-dev-i386 are not required.


