### PR TITLE
Enable SSH support. Always use system PCRE. Declare dependency on zlib.

### DIFF
--- a/src/libgit2.mk
+++ b/src/libgit2.mk
@@ -6,12 +6,13 @@ $(PKG)_IGNORE   :=
 $(PKG)_VERSION  := 1.7.1
 $(PKG)_CHECKSUM := 17d2b292f21be3892b704dddff29327b3564f96099a1c53b00edc23160c71327
 $(PKG)_GH_CONF  := libgit2/libgit2/releases/latest,v
-$(PKG)_DEPS     := cc libssh2 pcre zlib
+$(PKG)_DEPS     := cc libssh2 pcre2 zlib
 
 define $(PKG)_BUILD
     cd '$(BUILD_DIR)' && $(TARGET)-cmake '$(SOURCE_DIR)' \
         -DDLLTOOL='$(PREFIX)/bin/$(TARGET)-dlltool' \
-        -DUSE_SSH=ON
+        -DUSE_SSH=ON \
+        -DREGEX_BACKEND=pcre2
     $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)' VERBOSE=1 || $(MAKE) -C '$(BUILD_DIR)' -j 1 VERBOSE=1
     $(MAKE) -C '$(BUILD_DIR)' -j 1 install VERBOSE=1
 endef

--- a/src/libgit2.mk
+++ b/src/libgit2.mk
@@ -6,11 +6,12 @@ $(PKG)_IGNORE   :=
 $(PKG)_VERSION  := 1.7.1
 $(PKG)_CHECKSUM := 17d2b292f21be3892b704dddff29327b3564f96099a1c53b00edc23160c71327
 $(PKG)_GH_CONF  := libgit2/libgit2/releases/latest,v
-$(PKG)_DEPS     := cc libssh2
+$(PKG)_DEPS     := cc libssh2 pcre zlib
 
 define $(PKG)_BUILD
     cd '$(BUILD_DIR)' && $(TARGET)-cmake '$(SOURCE_DIR)' \
-        -DDLLTOOL='$(PREFIX)/bin/$(TARGET)-dlltool'
+        -DDLLTOOL='$(PREFIX)/bin/$(TARGET)-dlltool' \
+        -DUSE_SSH=ON
     $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)' VERBOSE=1 || $(MAKE) -C '$(BUILD_DIR)' -j 1 VERBOSE=1
     $(MAKE) -C '$(BUILD_DIR)' -j 1 install VERBOSE=1
 endef


### PR DESCRIPTION
This patch enables SSH (libssh2) support with libgit2. SSH support is disabled by default, even when libssh2 is available. I assume it was the intention to use libssh2 as it was already declared as MXE dependency in libgit2.mk.

This patch also explicitly sets pcre as a dependency. Without this setting, the result would depend on whether MXE package pcre has already been built or not: either the MXE pcre would get used, or a bundled pcre. This patch makes libgit2 predictably use "system" PCRE from MXE. In principle, one could instead use pcre2, as Msys2 does via `-DREGEX_BACKEND=pcre2`.

This patch also explicitly sets zlib as a dependency. Zlib is used (and is correctly declared as pkg-config dependency).
