### PR TITLE
Disable introspection to fix native build.

### DIFF
--- a/src/glib.mk
+++ b/src/glib.mk
@@ -30,6 +30,7 @@ define $(PKG)_BUILD_$(BUILD)
     '$(MXE_MESON_NATIVE_WRAPPER)' \
         --buildtype=release \
         -Dtests=false \
+        $(if $(BUILD_STATIC),-Dintrospection=disabled) \
         '$(BUILD_DIR)' '$(SOURCE_DIR)'
     '$(MXE_NINJA)' -C '$(BUILD_DIR)' -j '$(JOBS)'
     '$(MXE_NINJA)' -C '$(BUILD_DIR)' -j '$(JOBS)' install


### PR DESCRIPTION
This fixes the build of the native part of glib2, when targeting static libraries, on systems where gobject introspection is detected to be present, such as Ubuntu 24.04. Without the fix, the build fails compiling `girparser.c` on the grounds of null pointer dereference (-Wnull-dereference); this warning can be disabled, but the build then still fails for another reason.

From my reading, gobject instrumentation cannot be built as a static library and static libraries cannot have introspection data. When building the target/windows version of glib, gobject instrumentation is automatically disabled because it is not present. Some other MXE packages disable introspection explicitly and unconditionally for the target build. 

