### PR TITLE
GCC 11.5/Debian 12 Package Build Fixes

### DIFF
--- a/src/agg.mk
+++ b/src/agg.mk
@@ -23,7 +23,8 @@ define $(PKG)_BUILD
     cd '$(1)' && autoreconf -fi -I $(PREFIX)/$(TARGET)/share/aclocal
     cd '$(1)' && ./configure \
         $(MXE_CONFIGURE_OPTS) \
-        --without-x
+        --without-x \
+        CXXFLAGS="-fpermissive"
     $(MAKE) -C '$(1)' -j '$(JOBS)' install bin_PROGRAMS= sbin_PROGRAMS= noinst_PROGRAMS=
 endef
 

--- a/src/aubio.mk
+++ b/src/aubio.mk
@@ -23,6 +23,7 @@ define $(PKG)_BUILD
         AR='$(TARGET)-ar'                         \
         CC='$(TARGET)-gcc'                        \
         PKGCONFIG='$(TARGET)-pkg-config'          \
+        WAFDIR=$(BUILD_DIR)/$(waf_SUBDIR)         \
         $(PYTHON2)                                \
         '$(BUILD_DIR)/$(waf_SUBDIR)/waf'          \
             configure                             \
@@ -38,7 +39,7 @@ define $(PKG)_BUILD
     # disable txt2man and doxygen
     $(SED) -i '/\(TXT2MAN\|DOXYGEN\)/d' '$(1)/build/c4che/_cache.py'
 
-    cd '$(1)' && $(PYTHON2) '$(BUILD_DIR)/$(waf_SUBDIR)/waf' build install
+    cd '$(1)' && WAFDIR=$(BUILD_DIR)/$(waf_SUBDIR) $(PYTHON2) '$(BUILD_DIR)/$(waf_SUBDIR)/waf' build install
 
     '$(TARGET)-gcc'                               \
         -W -Wall -Werror -ansi -pedantic          \

--- a/src/icu4c.mk
+++ b/src/icu4c.mk
@@ -28,7 +28,8 @@ define $(PKG)_BUILD_$(BUILD)
 endef
 
 define $(PKG)_BUILD_COMMON
-    rm -fv $(shell echo "$(PREFIX)/$(TARGET)"/{bin,lib}/{lib,libs,}icu'*'.{a,dll,dll.a})
+    # '?*' to avoid matching plain "libicu.a" from gcc.
+    rm -fv $(shell echo "$(PREFIX)/$(TARGET)"/{bin,lib}/{lib,libs,}icu'?*'.{a,dll,dll.a})
     cd '$(BUILD_DIR)' && '$(SOURCE_DIR)/source/configure' \
         $(MXE_CONFIGURE_OPTS) \
         --with-cross-build='$(PREFIX)/$(BUILD)/$(PKG)' \

--- a/src/upx.mk
+++ b/src/upx.mk
@@ -18,6 +18,7 @@ define $(PKG)_BUILD
         CC='$(TARGET)-gcc' \
         LD='$(TARGET)-ld' \
         AR='$(TARGET)-ar' \
+        CXXFLAGS='-Wno-misleading-indentation -funsigned-char' \
         CHECK_WHITESPACE= \
         exeext='.exe'
     cp '$(SOURCE_DIR)/src/upx.exe' '$(PREFIX)/$(TARGET)/bin/'
@@ -27,6 +28,7 @@ define $(PKG)_BUILD_$(BUILD)
     $(MAKE) -C '$(SOURCE_DIR)' -j '$(JOBS)' all \
         CXX='$(BUILD_CXX)' \
         CC='$(BUILD_CC)' \
+        CXXFLAGS='-Wno-misleading-indentation -funsigned-char' \
         LIBS='-L$(PREFIX)/$(BUILD)/lib -lucl -lz' \
         UPX_UCLDIR='$(PREFIX)/$(TARGET)' \
         CHECK_WHITESPACE= \

--- a/src/waf-1-fixes.patch
+++ b/src/waf-1-fixes.patch
@@ -1,0 +1,182 @@
+This file is part of MXE. See LICENSE.md for licensing information.
+
+Contains ad hoc patches for cross building.
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Taj Morton <tajmorton@gmail.com>
+Date: Sat, 1 Mar 2025 07:07:17 +0000
+Subject: [PATCH 1/3] Upgrade to support Python 3.11
+
+Apply patches from waf 68997828c850ce7fb30b73b4adfde35053e539d1
+https://gitlab.com/ita1024/waf/-/commit/68997828c850ce7fb30b73b4adfde35053e539d1
+
+diff --git a/build_system_kit/extpy/extpy.py b/build_system_kit/extpy/extpy.py
+index 1111111..2222222 100644
+--- a/build_system_kit/extpy/extpy.py
++++ b/build_system_kit/extpy/extpy.py
+@@ -27,7 +27,7 @@ class Context(mod.Context):
+ 				cache[node] = True
+ 				self.pre_recurse(node)
+ 				try:
+-					function_code = node.read('rU')
++					function_code = node.read('r')
+ 					exec(compile(function_code, node.abspath(), 'exec'), self.exec_dict)
+ 				finally:
+ 					self.post_recurse(node)
+diff --git a/waflib/ConfigSet.py b/waflib/ConfigSet.py
+index 1111111..2222222 100644
+--- a/waflib/ConfigSet.py
++++ b/waflib/ConfigSet.py
+@@ -299,7 +299,7 @@ class ConfigSet(object):
+ 		:type filename: string
+ 		"""
+ 		tbl = self.table
+-		code = Utils.readf(filename, m='rU')
++		code = Utils.readf(filename, m='r')
+ 		for m in re_imp.finditer(code):
+ 			g = m.group
+ 			tbl[g(2)] = eval(g(3))
+diff --git a/waflib/Context.py b/waflib/Context.py
+index 1111111..2222222 100644
+--- a/waflib/Context.py
++++ b/waflib/Context.py
+@@ -284,7 +284,7 @@ class Context(ctx):
+ 				cache[node] = True
+ 				self.pre_recurse(node)
+ 				try:
+-					function_code = node.read('rU', encoding)
++					function_code = node.read('r', encoding)
+ 					exec(compile(function_code, node.abspath(), 'exec'), self.exec_dict)
+ 				finally:
+ 					self.post_recurse(node)
+@@ -642,7 +642,7 @@ def load_module(path, encoding=None):
+ 
+ 	module = imp.new_module(WSCRIPT_FILE)
+ 	try:
+-		code = Utils.readf(path, m='rU', encoding=encoding)
++		code = Utils.readf(path, m='r', encoding=encoding)
+ 	except EnvironmentError:
+ 		raise Errors.WafError('Could not read the file %r' % path)
+ 
+diff --git a/waflib/Logs.py b/waflib/Logs.py
+index 1111111..2222222 100644
+--- a/waflib/Logs.py
++++ b/waflib/Logs.py
+@@ -243,10 +243,10 @@ def error(*k, **kw):
+ 
+ def warn(*k, **kw):
+ 	"""
+-	Wrap logging.warn
++	Wrap logging.warning
+ 	"""
+ 	global log
+-	log.warn(*k, **kw)
++	log.warning(*k, **kw)
+ 
+ def info(*k, **kw):
+ 	"""
+diff --git a/wscript b/wscript
+index 1111111..2222222 100644
+--- a/wscript
++++ b/wscript
+@@ -34,7 +34,7 @@ Configure.autoconfig = 1
+ 
+ def sub_file(fname, lst):
+ 
+-	f = open(fname, 'rU')
++	f = open(fname, 'ru')
+ 	try:
+ 		txt = f.read()
+ 	finally:
+@@ -165,7 +165,7 @@ def process_tokens(tokens):
+ 	body = "".join(accu)
+ 	return body
+ 
+-deco_re = re.compile('(def|class)\\s+(\w+)\\(.*')
++deco_re = re.compile('(def|class)\\s+(\\w+)\\(.*')
+ def process_decorators(body):
+ 	lst = body.splitlines()
+ 	accu = []
+@@ -296,7 +296,7 @@ def create_waf(self, *k, **kw):
+ 	tar.close()
+ 	z.close()
+ 
+-	f = open('waf-light', 'rU')
++	f = open('waf-light', 'ru')
+ 	try:
+ 		code1 = f.read()
+ 	finally:
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Taj Morton <tajmorton@gmail.com>
+Date: Sat, 1 Mar 2025 07:10:11 +0000
+Subject: [PATCH 2/3] Patch for Python 3.12 compatibility.
+
+
+diff --git a/waflib/Context.py b/waflib/Context.py
+index 1111111..2222222 100644
+--- a/waflib/Context.py
++++ b/waflib/Context.py
+@@ -6,7 +6,7 @@
+ Classes and functions required for waf commands
+ """
+ 
+-import os, re, imp, sys
++import os, re, sys, types
+ from waflib import Utils, Errors, Logs
+ import waflib.Node
+ 
+@@ -640,7 +640,7 @@ def load_module(path, encoding=None):
+ 	except KeyError:
+ 		pass
+ 
+-	module = imp.new_module(WSCRIPT_FILE)
++	module = types.ModuleType(WSCRIPT_FILE)
+ 	try:
+ 		code = Utils.readf(path, m='r', encoding=encoding)
+ 	except EnvironmentError:
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Taj Morton <tajmorton@gmail.com>
+Date: Sat, 1 Mar 2025 08:11:06 +0000
+Subject: [PATCH 3/3] Apply Python 3.7 compatibility patch.
+
+Applies facdc0b173d933073832c768ec1917c553cb369c
+https://gitlab.com/ita1024/waf/-/commit/facdc0b173d933073832c768ec1917c553cb369c
+
+diff --git a/playground/daemon/daemon.py b/playground/daemon/daemon.py
+index 1111111..2222222 100644
+--- a/playground/daemon/daemon.py
++++ b/playground/daemon/daemon.py
+@@ -107,7 +107,6 @@ class DirWatch(object):
+ 					yield k
+ 		except AttributeError:
+ 			pass
+-		raise StopIteration
+ 
+ 	def wait_pyinotify(self, bld):
+ 
+diff --git a/waflib/Node.py b/waflib/Node.py
+index 1111111..2222222 100644
+--- a/waflib/Node.py
++++ b/waflib/Node.py
+@@ -537,7 +537,6 @@ class Node(object):
+ 					if maxdepth:
+ 						for k in node.ant_iter(accept=accept, maxdepth=maxdepth - 1, pats=npats, dir=dir, src=src, remove=remove):
+ 							yield k
+-		raise StopIteration
+ 
+ 	def ant_glob(self, *k, **kw):
+ 		"""
+diff --git a/waflib/extras/distnet.py b/waflib/extras/distnet.py
+index 1111111..2222222 100644
+--- a/waflib/extras/distnet.py
++++ b/waflib/extras/distnet.py
+@@ -403,7 +403,6 @@ class package_reader(Context.Context):
+ 			if x.pkgname == self.myproject:
+ 				continue
+ 			yield x
+-		raise StopIteration
+ 
+ 	def execute(self):
+ 		self.compute_dependencies()


### PR DESCRIPTION
This PR adds some simple fixes for issues I encountered while building packages for a Debian 12 (bookworm) aarch64 build environment (with a target of i686-w64-mingw32.static-gcc (GCC) 11.5.0).

 * icu4c: This package (I believe unintentionally) removed `libicu.a` from mingw32, which led to issues building the mingw32 package when `libicu.a` had disappeared.
 * agg: add `-fpermissive` due to some pointer arithmetic that now throws a compiler warning without `-fpermissive`.
 * upx: Disable "misleading indentation" warning from a macro, and build with `-funsigned-char` (as required by this package, expressed in a `static_assert`).
 * aubio/waf: Backport some waf build system patches for compatibility with Python 3.11. Another option would be to upgrade Waf to the 2.x release and patch aubio to use Waf 2 (which should be minor). It looks like aubio is the only package that uses waf.