### PR TITLE
Escape dollar character in update script.

### DIFF
--- a/src/eigen.mk
+++ b/src/eigen.mk
@@ -12,7 +12,7 @@ $(PKG)_DEPS     := cc
 
 define $(PKG)_UPDATE
     $(WGET) -q -O- 'https://eigen.tuxfamily.org/index.php?title=Main_Page#Download' | \
-    $(SED) -nr 's/^.*eigen-([0-9]+\.[0-9]+\.[0-9]+)\.tar\.bz2.*$/\1/p' | $(SORT) -Vr | $(SED) 1q
+    $(SED) -nr 's/^.*eigen-([0-9]+\.[0-9]+\.[0-9]+)\.tar\.bz2.*$$/\1/p' | $(SORT) -Vr | $(SED) 1q
 endef
 
 define $(PKG)_BUILD


### PR DESCRIPTION
This fixes the update script of the package: `$` has to be escaped in make file, otherwise the update results in:

```
sed: -e expression #1, char 51: unterminated `s' command
Unable to update version number of package eigen
```