### PR TITLE
Fix update script (update to newer versions).

### DIFF
--- a/src/libxml2.mk
+++ b/src/libxml2.mk
@@ -14,7 +14,7 @@ $(PKG)_DEPS     := cc xz zlib
 define $(PKG)_UPDATE
     $(WGET) -q -O- 'https://gitlab.gnome.org/GNOME/libxml2/tags' | \
     $(SED) -n "s,.*<a [^>]\+>v\([0-9,\.]\+\)<.*,\\1,p" | \
-    head -1
+    $(SORT) -Vr | head -1
 endef
 
 define $(PKG)_BUILD


### PR DESCRIPTION
This fixes the update script to look at newer versions. Without the fix, one gets something like:

```
OLD      libxml2  2.13.5 --> 2.12.10 ignoring
```