### PR TITLE
Add missing std::numeric_limits include for itk.

### DIFF
--- a/src/itk-1-fixes.patch
+++ b/src/itk-1-fixes.patch
@@ -5,7 +5,7 @@ Contains ad hoc patches for cross building.
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Rashad Kanavath <rashad.kanavath@c-s.fr>
 Date: Wed, 2 Dec 2015 15:00:54 +0100
-Subject: [PATCH 1/2] fix shared build
+Subject: [PATCH 1/3] fix shared build
 
 
 diff --git a/Modules/ThirdParty/GDCM/src/gdcm/Utilities/socketxx/socket++/CMakeLists.txt b/Modules/ThirdParty/GDCM/src/gdcm/Utilities/socketxx/socket++/CMakeLists.txt
@@ -30,7 +30,7 @@ index 1111111..2222222 100644
  add_library(${SOCKETXX_LIBRARY_NAME} ${libsocket___la_SOURCES})
  set_target_properties (${SOCKETXX_LIBRARY_NAME}
    PROPERTIES DEFINE_SYMBOL  "socketxx_EXPORTS" )
-@@ -105,4 +109,3 @@ if(NOT SOCKETXX_INSTALL_NO_DEVELOPMENT)
+@@ -110,4 +114,3 @@ if(NOT SOCKETXX_INSTALL_NO_DEVELOPMENT)
      DESTINATION ${SOCKETXX_INSTALL_INCLUDE_DIR} COMPONENT Headers
    )
  endif()
@@ -39,7 +39,7 @@ index 1111111..2222222 100644
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Boris Nagaev <bnagaev@gmail.com>
 Date: Mon, 24 Oct 2016 02:01:07 +0300
-Subject: [PATCH 2/2] disable try-run
+Subject: [PATCH 2/3] disable try-run
 
 It is impossible to run while cross-compiling.
 
@@ -109,3 +109,22 @@ index 1111111..2222222 100644
  endmacro()
  
  #
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Taj Morton <tajmorton@gmail.com>
+Date: Sun, 16 Mar 2025 19:26:24 +0000
+Subject: [PATCH 3/3] Add #include to bring in std::numeric_limits.
+
+
+diff --git a/Modules/ThirdParty/VNL/src/vxl/core/vnl/vnl_bignum.cxx b/Modules/ThirdParty/VNL/src/vxl/core/vnl/vnl_bignum.cxx
+index 1111111..2222222 100644
+--- a/Modules/ThirdParty/VNL/src/vxl/core/vnl/vnl_bignum.cxx
++++ b/Modules/ThirdParty/VNL/src/vxl/core/vnl/vnl_bignum.cxx
+@@ -6,6 +6,7 @@
+ #include <algorithm>
+ #include <vector>
+ #include <iostream>
++#include <limits>
+ #include "vnl_bignum.h"
+ //:
+ // \file


### PR DESCRIPTION
# Add missing std::numeric_limits include for itk.

Resolves issue #3056.

VNL's `vnl_bignum.cxx` referenced `std::numeric_limits` without including the `<limits>` header (https://en.cppreference.com/w/cpp/types/numeric_limits). Presumably more permissive compilers used to bring in this header directly, or other STL headers used to include it.

After applying this patch, itk builds cleanly for i686.

Original error:
```
../../../../../../../../ITK-5.0.1/Modules/ThirdParty/VNL/src/vxl/core/vnl/vnl_bignum.cxx: In member function 'vnl_bignum::operator float() const':
../../../../../../../../ITK-5.0.1/Modules/ThirdParty/VNL/src/vxl/core/vnl/vnl_bignum.cxx:716:37: error: 'numeric_limits' is not a member of 'std'
../../../../../../../../ITK-5.0.1/Modules/ThirdParty/VNL/src/vxl/core/vnl/vnl_bignum.cxx:716:52: error: expected primary-expression before 'float'
../../../../../../../../ITK-5.0.1/Modules/ThirdParty/VNL/src/vxl/core/vnl/vnl_bignum.cxx: In member function 'vnl_bignum::operator double() const':
../../../../../../../../ITK-5.0.1/Modules/ThirdParty/VNL/src/vxl/core/vnl/vnl_bignum.cxx:727:37: error: 'numeric_limits' is not a member of 'std'
../../../../../../../../ITK-5.0.1/Modules/ThirdParty/VNL/src/vxl/core/vnl/vnl_bignum.cxx:727:52: error: expected primary-expression before 'double'
../../../../../../../../ITK-5.0.1/Modules/ThirdParty/VNL/src/vxl/core/vnl/vnl_bignum.cxx: In member function 'vnl_bignum::operator long double() const':
../../../../../../../../ITK-5.0.1/Modules/ThirdParty/VNL/src/vxl/core/vnl/vnl_bignum.cxx:738:37: error: 'numeric_limits' is not a member of 'std'
../../../../../../../../ITK-5.0.1/Modules/ThirdParty/VNL/src/vxl/core/vnl/vnl_bignum.cxx:738:52: error: expected primary-expression before 'long'
```