### PR TITLE
gcc: Avoid mmap() dependency in gcov, define getpagesize() for libbacktrace

### DIFF
--- a/src/gcc-1-fixes.patch
+++ b/src/gcc-1-fixes.patch
@@ -5,7 +5,7 @@ Contains ad hoc patches for cross building.
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tony Theodore <tonyt@logyst.com>
 Date: Sun, 10 May 2020 15:06:47 +1000
-Subject: [PATCH 1/3] allow native cpu detection when building with clang
+Subject: [PATCH 1/4] allow native cpu detection when building with clang
 
 function was disabled for non-gcc5 in:
 https://gcc.gnu.org/git/?p=gcc.git;a=commitdiff;h=b587c12551143c14f023860a1dbdf7316ae71f27;hp=43096b526a9f23008b9769372f11475ae63487bc
@@ -29,7 +29,7 @@ index 1111111..2222222 100644
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tony Theodore <tonyt@logyst.com>
 Date: Sun, 10 May 2020 15:09:58 +1000
-Subject: [PATCH 2/3] remove hard-coded mingw from paths
+Subject: [PATCH 2/4] remove hard-coded mingw from paths
 
 
 diff --git a/gcc/config.gcc b/gcc/config.gcc
@@ -71,7 +71,7 @@ index 1111111..2222222 100644
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Liu Hao <lh_mouse@126.com>
 Date: Wed, 6 May 2020 21:49:18 +0800
-Subject: [PATCH 3/3] libgomp: Don't hard-code MS printf attributes
+Subject: [PATCH 3/4] libgomp: Don't hard-code MS printf attributes
 
 Source: https://github.com/msys2/MINGW-packages/blob/9501ee2afc8d01dc7d85383e4b22e91c30d93ca7/mingw-w64-gcc/0020-libgomp-Don-t-hard-code-MS-printf-attributes.patch
 
@@ -119,3 +119,41 @@ index 1111111..2222222 100644
  
  struct gomp_task;
  struct gomp_taskgroup;
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Taj Morton <tajmorton@gmail.com>
+Date: Mon, 24 Mar 2025 16:47:31 +0000
+Subject: [PATCH 4/4] HAVE_DECL_GETPAGESIZE is defined to 0 if getpagesize() us
+ unavailable.
+
+AC_CHECK_DECLS(getpagesize) will define HAVE_DECL_GETPAGESIZE to 0 or 1
+based on if it is present or not. This adjusts the preprocessor logic
+so that getpagesize() will be declared (using the same logic used to
+check for strnlen in libbacktrace).
+
+diff --git a/libbacktrace/mmap.c b/libbacktrace/mmap.c
+index 1111111..2222222 100644
+--- a/libbacktrace/mmap.c
++++ b/libbacktrace/mmap.c
+@@ -42,7 +42,7 @@ POSSIBILITY OF SUCH DAMAGE.  */
+ #include "backtrace.h"
+ #include "internal.h"
+ 
+-#ifndef HAVE_DECL_GETPAGESIZE
++#if !defined(HAVE_DECL_GETPAGESIZE) || !HAVE_DECL_GETPAGESIZE
+ extern int getpagesize (void);
+ #endif
+ 
+diff --git a/libbacktrace/mmapio.c b/libbacktrace/mmapio.c
+index 1111111..2222222 100644
+--- a/libbacktrace/mmapio.c
++++ b/libbacktrace/mmapio.c
+@@ -40,7 +40,7 @@ POSSIBILITY OF SUCH DAMAGE.  */
+ #include "backtrace.h"
+ #include "internal.h"
+ 
+-#ifndef HAVE_DECL_GETPAGESIZE
++#if !defined(HAVE_DECL_GETPAGESIZE) || !HAVE_DECL_GETPAGESIZE
+ extern int getpagesize (void);
+ #endif
+ 

--- a/src/gcc.mk
+++ b/src/gcc.mk
@@ -106,6 +106,13 @@ define $(PKG)_BUILD_mingw-w64
     $(MAKE) -C '$(BUILD_DIR).pthreads' -j 1 $(INSTALL_STRIP_TOOLCHAIN)
 
     # build rest of gcc
+
+    # Force <sys/mman.h>'s presence to false when building target libgcc to prevent
+    # a dependency on mmap(). If mman-win32 package has been installed when gcc is built
+    # (which installs sys/mman.h), gcov (from libgcc) will depend on mmap(), and fail to link
+    # (undefined reference to `mmap') when building with --coverage.
+    ac_cv_header_sys_mman_h=no \
+        $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)' all-target-libgcc
     # `all-target-libstdc++-v3` sometimes has parallel failure
     $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)' all-target-libstdc++-v3 || $(MAKE) -C '$(BUILD_DIR)' -j 1 all-target-libstdc++-v3
     $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)'


### PR DESCRIPTION
Fixes 2 uncommon build issues with GCC:

 1. If the `mman-win32` package has been installed when `gcc` is (re-)built, gcov (as part of libgcc) will depend on `mmap()`, due to the presence of `sys/mman.h` (installed by mman-win32). This results in a link error building the test executable with `--coverage`.
 2. If `getpagesize()` is not defined when libbacktrace is built, libbacktrace will provide its own definition (which is typical for mingw builds, see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95012).
     However, the config macro was not used properly when added to gcc ([change implemented here](https://gcc.gnu.org/git/gitweb.cgi?p=gcc.git;h=47f4703c33c4936fd423c2a1180b2de144115d3d)). `AC_CHECK_DECLS` will define `HAVE_DECL_` to `0` or `1`, instead of `#define` or `#undef`. This patch modifies libbacktrace to test for `HAVE_DECL_GETPAGESIZE` properly (consistent with how libbacktrace tests for `strnlen` (the other function libbacktrace uses `AC_CHECK_DECL` on).