### PR TITLE
adding new libbotan2 package

### DIFF
--- a/src/botan2.mk
+++ b/src/botan2.mk
@@ -1,0 +1,43 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+PKG             := botan2
+$(PKG)_WEBSITE  := https://botan.randombit.net/
+$(PKG)_DESCR    := botan2
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 2.19.5
+$(PKG)_CHECKSUM := dfeea0e0a6f26d6724c4af01da9a7b88487adb2d81ba7c72fcaf52db522c9ad4
+$(PKG)_SUBDIR   := Botan-$($(PKG)_VERSION)
+$(PKG)_FILE     := Botan-$($(PKG)_VERSION).tar.xz
+$(PKG)_URL      := https://botan.randombit.net/releases/$($(PKG)_FILE)
+$(PKG)_DEPS     := cc
+
+define $(PKG)_UPDATE
+     $(WGET) -q -O- 'https://botan.randombit.net/releases/' | \
+     grep 'a href="Botan-2' | \
+     $(SED) 's/.*Botan-\(2.[0-9.]*\)\..*/\1/' | \
+     $(SORT) -Vr | \
+     head -1
+endef
+
+# libbotan uses a custom made configure script that doesn't recognize
+# the option --host and fails on unknown options.
+# Therefor $(MXE_CONFIGURE_OPTS) can't be used here.
+define $(PKG)_BUILD
+    cd '$(1)' && ./configure.py \
+        --prefix=$(PREFIX)/$(TARGET) \
+        --os=mingw \
+        --cpu=x86_$(if $(findstring x86_64,$(TARGET)),64,32) \
+        --cc-bin=$(TARGET)-g++ \
+        --ar-command=$(TARGET)-ar \
+        --without-os-feature=threads \
+        $(if $(BUILD_SHARED), \
+            --enable-shared --disable-static \
+          ,\
+            --disable-shared --enable-static \
+        )
+        # Note: libbotan doesn't currently support shared libraries with mingw,
+        #       but if that ever changes, we'll have the code in place to
+        #       configure the library to take advantage of this
+    $(MAKE) -C '$(1)' -j '$(JOBS)'
+    $(MAKE) -C '$(1)' -j 1 install
+endef


### PR DESCRIPTION
This is my first time making a package for MXE, so please let me know if I am not following best practices. I have read http://mxe.cc/#creating-packages and borrowed heavily from existing packages.

I verified the .a and .pc files are installed, and was able to create a $(PKG)_UPDATE section.

Once this package is acceptable to merge in, I would like to make a .deb package for it so I can host it on my apt repo. Are there instructions on how to do so?

Here's how I tested my .mk file (on a fresh installation of Debian 12):

```sh
git clone https://github.com/hax0rbana-adam/mxe
cd mxe
git checkout libbotan2
sudo apt-get install -y autoconf automake autopoint bash bison bzip2 flex g++ g++-multilib gettext git gperf intltool libc6-dev-i386 libgdk-pixbuf2.0-dev libltdl-dev libgl-dev libpcre3-dev libssl-dev libtool-bin libxml-parser-perl lzip make openssl p7zip-full patch perl python3 python3-distutils python3-mako python3-packaging python3-pkg-resources python3-setuptools python-is-python3 ruby sed sqlite3 unzip wget xz-utils
time make MXE_TARGETS='x86_64-w64-mingw32.static i686-w64-mingw32.static' libbotan2
find . -name '*botan*a'
find . -name '*botan*.pc'
```