### PR TITLE
argon2: adding new package

### DIFF
--- a/src/argon2.mk
+++ b/src/argon2.mk
@@ -1,0 +1,17 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+PKG             := argon2
+$(PKG)_WEBSITE  := https://github.com/P-H-C/phc-winner-argon2
+$(PKG)_VERSION  := 20190702
+$(PKG)_GH_CONF  := P-H-C/phc-winner-argon2/releases
+$(PKG)_CHECKSUM := daf972a89577f8772602bf2eb38b6a3dd3d922bf5724d45e7f9589b5e830442c
+$(PKG)_DEPS     := cc
+
+define $(PKG)_BUILD
+    $(MAKE) -C '$(1)' -j '$(JOBS)' \
+        CC=$(TARGET)-gcc \
+        AR=$(TARGET)-ar \
+        PREFIX=$(PREFIX)/$(TARGET)
+
+    $(MAKE) -C '$(1)' -j 1 PREFIX=$(PREFIX)/$(TARGET) install
+endef


### PR DESCRIPTION
Added the argon2 library. It creates and installs .a and .pc files, the file is named argon2.mk instead of libargon2.mk, and it uses $(PKG)_GH_CONF to download releases from GitHub. :slightly_smiling_face: 

Building this was tested on Debian 12 as follows:

```sh
git clone https://github.com/hax0rbana-adam/mxe
cd mxe
git checkout libargon2
sudo apt-get install -y autoconf automake autopoint bash bison bzip2 flex g++ g++-multilib gettext git gperf intltool libc6-dev-i386 libgdk-pixbuf2.0-dev libltdl-dev libgl-dev libpcre3-dev libssl-dev libtool-bin libxml-parser-perl lzip make openssl p7zip-full patch perl python3 python3-distutils python3-mako python3-packaging python3-pkg-resources python3-setuptools python-is-python3 ruby sed sqlite3 unzip wget xz-utils
time make MXE_TARGETS='x86_64-w64-mingw32.static i686-w64-mingw32.static' argon2
find . -name '*argon2*a'
find . -name '*argon2*.pc'
```
