### PR TITLE
Fixed issues in argon2

### DIFF
--- a/src/argon2.mk
+++ b/src/argon2.mk
@@ -9,9 +9,10 @@ $(PKG)_DEPS     := cc
 
 define $(PKG)_BUILD
     $(MAKE) -C '$(1)' -j '$(JOBS)' \
-        CC='$(TARGET)-gcc' \
-        AR='$(TARGET)-ar' \
-        PREFIX='$(PREFIX)/$(TARGET)'
+        CC=$(TARGET)-gcc \
+        AR=$(TARGET)-ar \
+        $(if $(BUILD_SHARED), KERNEL_NAME=MINGW,) \
+        PREFIX=$(PREFIX)/$(TARGET)
 
-    $(MAKE) -C '$(1)' -j 1 PREFIX='$(PREFIX)/$(TARGET)' install
+    $(MAKE) -C '$(1)' -j 1 $(if $(BUILD_SHARED), KERNEL_NAME=MINGW) PREFIX=$(PREFIX)/$(TARGET) install
 endef


### PR DESCRIPTION
Fixed issue where it wasn't creating any files with .dll extensions.

```sh
git clone https://github.com/hax0rbana-adam/mxe
cd mxe
git checkout libargon2
sudo apt-get install -y autoconf automake autopoint bash bison bzip2 flex g++ g++-multilib gettext git gperf intltool libc6-dev-i386 libgdk-pixbuf2.0-dev libltdl-dev libgl-dev libpcre3-dev libssl-dev libtool-bin libxml-parser-perl lzip make openssl p7zip-full patch perl python3 python3-distutils python3-mako python3-packaging python3-pkg-resources python3-setuptools python-is-python3 ruby sed sqlite3 unzip wget xz-utils

time make MXE_TARGETS='x86_64-w64-mingw32.static x86_64-w64-mingw32.shared i686-w64-mingw32.static i686-w64-mingw32.shared' argon2

find . -name '*argon2.a' -exec md5sum {} \;
find . -name '*argon2.dll*' -exec md5sum {} \;
```

I was unable to reproduce the issue with files being overwritten, but that might be irrelevant now that we're writing out .dll files for the shared build.

```sh
$ find . -name '*argon2.a' -exec md5sum {} \;
bc9211afe13bb182491e9639a535bea8  ./usr/x86_64-w64-mingw32.static/lib/libargon2.a
dfcf37ade29da576dd346ff5b0422dfb  ./usr/i686-w64-mingw32.static/lib/libargon2.a
$ find . -name '*argon2.dll' -exec md5sum {} \;
e5650abf4cf02b1fa32d7dff9ebd4160  ./usr/i686-w64-mingw32.shared/lib/libargon2.dll
61c5edae81df99a33c97b573330c0add  ./usr/x86_64-w64-mingw32.shared/lib/libargon2.dll
```