### PR TITLE
re-enable building windeployqt

### DIFF
--- a/src/qttools-1-fixes.patch
+++ b/src/qttools-1-fixes.patch
@@ -3,29 +3,9 @@ This file is part of MXE. See LICENSE.md for licensing information.
 Contains ad hoc patches for cross building.
 
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Mark Brand <mabrand@mabrand.nl>
-Date: Sun, 28 Apr 2019 23:07:09 +1000
-Subject: [PATCH 1/2] disable windeployqt (MXE specific)
-
-
-diff --git a/src/src.pro b/src/src.pro
-index 1111111..2222222 100644
---- a/src/src.pro
-+++ b/src/src.pro
-@@ -36,7 +36,7 @@ macos {
- 
- qtHaveModule(dbus): SUBDIRS += qdbus
- 
--win32|winrt:SUBDIRS += windeployqt
-+#win32|winrt:SUBDIRS += windeployqt
- winrt:SUBDIRS += winrtrunner
- qtHaveModule(gui):!wasm:!android:!uikit:!qnx:!winrt: SUBDIRS += qtdiag
- 
-
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tony Theodore <tonyt@logyst.com>
 Date: Sun, 28 Apr 2019 23:12:41 +1000
-Subject: [PATCH 2/2] disable qdoc (MXE specific - requires libclang-devel)
+Subject: [PATCH 1/1] disable qdoc (MXE specific - requires libclang-devel)
 
 
 diff --git a/src/assistant/help/Qt5HelpConfigExtras.cmake.in b/src/assistant/help/Qt5HelpConfigExtras.cmake.in


### PR DESCRIPTION
This PR removes the patch which disables building windeployqt.

# Background
I need windeployqt for building KeePassXC with MXE, but it was patched out of qttools when [fixing a problem with building documentation](https://github.com/mxe/mxe/issues/2324) back in 2019. I don't know if [that patch](https://github.com/mxe/mxe/pull/2325/files) was needed at the time, but I can confirm that it is not needed now.

# Steps to reproduce

Tested on Debian 12.

```sh
sudo apt-get install -y autoconf automake autopoint bash bison bzip2 flex g++ g++-multilib gettext git gperf intltool libc6-dev-i386 libgdk-pixbuf2.0-dev libltdl-dev libgl-dev libpcre3-dev libssl-dev libtool-bin libxml-parser-perl lzip make openssl p7zip-full patch perl python3 python3-distutils python3-mako python3-packaging python3-pkg-resources python3-setuptools python-is-python3 ruby sed sqlite3 unzip wget xz-utils

git clone https://github.com/hax0rbana-adam/mxe
cd mxe/
git checkout re-enable-windeployqt

time make MXE_TARGETS='x86_64-w64-mingw32.static  i686-w64-mingw32.static x86_64-w64-mingw32.shared  i686-w64-mingw32.shared' qttools

file ./usr/*/qt5/bin/windeployqt
```

Note: currently the mariadb-connector-c is failing on i686/shared (#3219), but when that is fixed I expect windeployqt will be able to be built for that target. The x86_64/{static,shared} and i686/shared targets all build windeployqt just fine.