### PR TITLE
Do not force cmake to Release type on successive configs.

### DIFF
--- a/src/cmake/conf/mxe-conf.cmake.in
+++ b/src/cmake/conf/mxe-conf.cmake.in
@@ -96,3 +96,6 @@ file(GLOB mxe_cmake_files
 foreach(mxe_cmake_file ${mxe_cmake_files})
     include(${mxe_cmake_file})
 endforeach()
+
+## Set a default build type in case it is not specified on the commandline.
+set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Default build type")

--- a/src/cmake/conf/target-cmake.in
+++ b/src/cmake/conf/target-cmake.in
@@ -17,10 +17,6 @@ else
     echo "     - warnings for unused CMAKE_POLICY_DEFAULT variables can be ignored"
     echo "== Using MXE toolchain: @CMAKE_TOOLCHAIN_FILE@"
     echo "== Using MXE runresult: @CMAKE_RUNRESULT_FILE@"
-    if ! ( echo "$@" | grep --silent "DCMAKE_BUILD_TYPE" ) ; then
-        echo '== Adding "-DCMAKE_BUILD_TYPE=Release"'
-        set -- "-DCMAKE_BUILD_TYPE=Release" "$@"
-    fi
     exec "@PREFIX@/@BUILD@/bin/cmake" \
               -DCMAKE_TOOLCHAIN_FILE="@CMAKE_TOOLCHAIN_FILE@" \
               `eval echo -DCMAKE_POLICY_DEFAULT_CMP{$POLICIES}=NEW` \


### PR DESCRIPTION
When configuration is done in multiple runs, such as when an initial run is done to populate the options and then succesive runs to apply the options, do not force Release type on second run.

qtcreator does exactly that: specify build type only on first run and then relies on cached variable.

Sorry, forgot to mention: My change is about the cmake wrapper and config scripts.
