### PR TITLE
qt6-qtvirtualkeyboard: add missing dependencies

### DIFF
--- a/src/qt/qt6/qt6-qtvirtualkeyboard.mk
+++ b/src/qt/qt6/qt6-qtvirtualkeyboard.mk
@@ -6,7 +6,7 @@ PKG := qt6-qtvirtualkeyboard
 $(eval $(QT6_METADATA))
 
 $(PKG)_CHECKSUM := 80059a38bdb836f0785292396970edc108f477a68d9a35bed8393750de3d281f
-$(PKG)_DEPS     := cc qt6-conf qt6-qtbase
+$(PKG)_DEPS     := cc qt6-conf qt6-qtbase qt6-qtdeclarative qt6-qtsvg
 
 QT6_PREFIX   = '$(PREFIX)/$(TARGET)/$(MXE_QT6_ID)'
 QT6_QT_CMAKE = '$(QT6_PREFIX)/$(if $(findstring mingw,$(TARGET)),bin,libexec)/qt-cmake-private' \


### PR DESCRIPTION
This PR fixes [this issue](https://github.com/mxe/mxe/issues/3237)