### PR TITLE
Add missing dependency to qt6-qtcharts.mk

### DIFF
--- a/src/qt/qt6/qt6-qtcharts.mk
+++ b/src/qt/qt6/qt6-qtcharts.mk
@@ -6,7 +6,7 @@ PKG := qt6-qtcharts
 $(eval $(QT6_METADATA))
 
 $(PKG)_CHECKSUM := 9f01f15f64e73f18ee8b17b490c1b0ca02e969bc58919cf46bd1152c01a4ff4b
-$(PKG)_DEPS     := cc qt6-conf qt6-qtbase
+$(PKG)_DEPS     := cc qt6-conf qt6-qtbase qt6-qtdeclarative
 
 QT6_PREFIX   = '$(PREFIX)/$(TARGET)/$(MXE_QT6_ID)'
 QT6_QT_CMAKE = '$(QT6_PREFIX)/$(if $(findstring mingw,$(TARGET)),bin,libexec)/qt-cmake-private' \


### PR DESCRIPTION
The qtcharts module does not correctly build without a dependency to qtdeclarative

