### PR TITLE
update x264

### DIFF
--- a/src/x264.mk
+++ b/src/x264.mk
@@ -3,27 +3,26 @@
 PKG             := x264
 $(PKG)_WEBSITE  := https://www.videolan.org/developers/x264.html
 $(PKG)_IGNORE   :=
-$(PKG)_VERSION  := 20180806-2245
-$(PKG)_CHECKSUM := 9f876c88aeb21fa9315e4a078931faf6fc0d3c3f47e05a306d2fdc62ea0afea2
-$(PKG)_SUBDIR   := $(PKG)-snapshot-$($(PKG)_VERSION)
-$(PKG)_FILE     := $(PKG)-snapshot-$($(PKG)_VERSION).tar.bz2
-$(PKG)_URL      := https://download.videolan.org/pub/videolan/$(PKG)/snapshots/$($(PKG)_FILE)
+$(PKG)_VERSION  := b35605ace3ddf7c1a5d67a2eb553f034aef41d55
+$(PKG)_CHECKSUM := 6eeb82934e69fd51e043bd8c5b0d152839638d1ce7aa4eea65a3fedcf83ff224
+$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.bz2
+$(PKG)_URL      := https://code.videolan.org/videolan/x264/-/archive/$($(PKG)_VERSION)/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc liblsmash $(BUILD)~nasm
 
 define $(PKG)_UPDATE
-    $(WGET) -q -O- 'https://git.videolan.org/?p=x264.git;a=shortlog' | \
-    $(SED) -n 's,.*\([0-9]\{4\}\)-\([0-9]\{2\}\)-\([0-9]\{2\}\).*,\1\2\3-2245,p' | \
-    $(SORT) | \
-    tail -1
+    $(WGET) -q -O- 'https://code.videolan.org/videolan/x264/-/commits/master.atom' | \
+    $(SED) -n 's,.*<id>.*commit/\([^<]*\)</id>.*,\1,p' | \
+    head -1
 endef
 
 define $(PKG)_BUILD
     cd '$(BUILD_DIR)' && AS='$(PREFIX)/$(BUILD)/bin/nasm' '$(SOURCE_DIR)/configure'\
         $(MXE_CONFIGURE_OPTS) \
         --cross-prefix='$(TARGET)'- \
-        --enable-win32thread \
         --disable-lavf \
-        --disable-swscale   # Avoid circular dependency with ffmpeg. Remove if undesired.
+        --disable-swscale \ # Avoid circular dependency with ffmpeg. Remove if undesired.
+        --enable-win32thread
     $(MAKE) -C '$(BUILD_DIR)' -j 1 uninstall
     $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)'
     $(MAKE) -C '$(BUILD_DIR)' -j 1 install


### PR DESCRIPTION
update x264, snapshots no longer available, change url and update to drect git repository

reorder the ffmpeg library exclusions so they can be simply toggled with a comment
