### PR TITLE
libmpeg2: fix for win64

### DIFF
--- a/src/libmpeg2-9999-fix-win64.patch
+++ b/src/libmpeg2-9999-fix-win64.patch
@@ -1,0 +1,51 @@
+Index: libmpeg2-0.5.1/configure
+===================================================================
+--- libmpeg2-0.5.1.orig/configure
++++ libmpeg2-0.5.1/configure
+@@ -27071,7 +27071,7 @@ _ACEOF
+ cat confdefs.h >>conftest.$ac_ext
+ cat >>conftest.$ac_ext <<_ACEOF
+ /* end confdefs.h.  */
+-
++#include <stdint.h>
+ int
+ main ()
+ {
+@@ -27081,10 +27081,10 @@ static struct s {
+                 } S = {0, 0};
+                 switch (1) {
+                     case 0:
+-                    case (long)(&((struct s *)0)->b) == $ac_cv_c_attr_align_try:
++                    case (uintptr_t)(&((struct s *)0)->b) == $ac_cv_c_attr_align_try:
+                         return 0;
+                 }
+-                return (long)&S;
++                return (uintptr_t)&S;
+   ;
+   return 0;
+ }
+Index: libmpeg2-0.5.1/m4/keywords.m4
+===================================================================
+--- libmpeg2-0.5.1.orig/m4/keywords.m4
++++ libmpeg2-0.5.1/m4/keywords.m4
+@@ -72,17 +72,17 @@ AC_DEFUN([AC_C_ATTRIBUTE_ALIGNED],
+         [ac_cv_c_attribute_aligned],
+         [ac_cv_c_attribute_aligned=0
+         for ac_cv_c_attr_align_try in 2 4 8 16 32 64; do
+-            AC_TRY_COMPILE([],
++            AC_TRY_COMPILE([#include <stdint.h>],
+                 [static struct s {
+                     char a;
+                     char b __attribute__ ((aligned($ac_cv_c_attr_align_try)));
+                 } S = {0, 0};
+                 switch (1) {
+                     case 0:
+-                    case (long)(&((struct s *)0)->b) == $ac_cv_c_attr_align_try:
++                    case (uintptr_t)(&((struct s *)0)->b) == $ac_cv_c_attr_align_try:
+                         return 0;
+                 }
+-                return (long)&S;],
++                return (uintptr_t)&S;],
+                 [ac_cv_c_attribute_aligned=$ac_cv_c_attr_align_try])
+         done])
+     if test x"$ac_cv_c_attribute_aligned" != x"0"; then


### PR DESCRIPTION
https://github.com/scummvm/dockerized-bb/blob/master/toolchains/mxe/packages/libmpeg2/libmpeg2-9999-fix-win64.patch

https://forums.scummvm.org/viewtopic.php?f=2&t=16293



```
Thread 1 received signal SIGSEGV, Segmentation fault.
0x00007ff66119b240 in mpeg2_idct_copy_sse2 ()
(gdb) backtrace
#0  0x00007ff66119b240 in mpeg2_idct_copy_sse2 ()
#1  0x00007ff661195952 in mpeg2_slice ()
#2  0x00007ff66118aaa4 in mpeg2_parse ()
```

