### PR TITLE
SDL2_Mixer version to 2.8.1. Fixes gcc15 issue.

### DIFF
--- a/src/sdl2_mixer.mk
+++ b/src/sdl2_mixer.mk
@@ -4,8 +4,8 @@ PKG             := sdl2_mixer
 $(PKG)_WEBSITE  := https://www.libsdl.org/
 $(PKG)_DESCR    := SDL2_mixer
 $(PKG)_IGNORE   :=
-$(PKG)_VERSION  := 2.0.4
-$(PKG)_CHECKSUM := 5605b6f230717acf6d09549671f7fe03f006700c61a61b86042888f81792e2b3
+$(PKG)_VERSION  := 2.8.1
+$(PKG)_CHECKSUM := 63804b4b2ba503865c0853f102231aeff489b1dfc6dea4750a69e2a8ef54b2bb
 $(PKG)_GH_CONF  := libsdl-org/SDL_mixer/releases/tag,release-,,
 $(PKG)_DEPS     := cc libmodplug mpg123 ogg opusfile sdl2 smpeg2 vorbis
 


### PR DESCRIPTION
The command 
```
make MXE_PLUGIN_DIRS=./plugins/gcc15/ sdl2_mixer
```
currently fails.

SDL2_mixer version 2.0.4 had a type incompatibility with mpg123 1.31.1. The issue was in music_mpg123.c where the function pointer type for mpg123_read expected unsigned char * but the modern mpg123 library uses void * for the output buffer parameter.

This PR will make `make MXE_PLUGIN_DIRS=./plugins/gcc15/ sdl2_mixer` work again.
