### PR TITLE
opensubdiv: add opensubdiv.mk package definition

### DIFF
--- a/src/clew.mk
+++ b/src/clew.mk
@@ -1,0 +1,24 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+PKG             := clew
+$(PKG)_DESCR    := OpenCL Extension Wrangler Library (CLEW) for OpenCL runtime extension loading
+$(PKG)_WEBSITE  := https://github.com/hkunz/clew
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 0.11
+$(PKG)_CHECKSUM := ee056db60b4f70c988f71a13c19c52b73401bc88e79369e3680886b59d69e53b
+# Using fork from hkunz/clew instead of the original martijnberger/clew to work around https://github.com/martijnberger/clew/issues/19 and https://github.com/martijnberger/clew/issues/21
+$(PKG)_GH_CONF  := hkunz/clew/tags,v
+$(PKG)_DEPS     := cc
+
+define $(PKG)_BUILD
+    cd '$(BUILD_DIR)' && $(TARGET)-cmake '$(SOURCE_DIR)' \
+        -DBUILD_SHARED_LIBS=$(CMAKE_SHARED_BOOL) \
+        -DBUILD_STATIC_LIBS=$(CMAKE_STATIC_BOOL)
+
+    $(MAKE) -C "$(BUILD_DIR)" -j "$(JOBS)"
+    $(MAKE) -C "$(BUILD_DIR)" -j 1 install
+
+    # note cuew.pc is also generated in hkunz/clew fork (https://github.com/martijnberger/clew/issues/21)
+    # clew library already automatically compiles a test executable:
+    # $(PREFIX)/$(TARGET)/bin/clewTest.exe
+endef

--- a/src/common/library.pc.in
+++ b/src/common/library.pc.in
@@ -1,0 +1,17 @@
+prefix=@PREFIX@
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+Name: @NAME@
+Description: @DESCRIPTION@
+Version: @VERSION@
+
+Requires: @REQUIRES@
+Requires.private: @REQUIRES_PRIVATE@
+
+Libs: -L${libdir} @LIBS@
+Libs.private: @LIBS_PRIVATE@
+
+Cflags: -I${includedir} @CFLAGS@
+Cflags.private: @CFLAGS_PRIVATE@

--- a/src/common/pkgutils.mk
+++ b/src/common/pkgutils.mk
@@ -1,0 +1,58 @@
+# ----------------------------------------------------------------------
+# GENERATE_PC
+# ----------------------------------------------------------------------
+# Generates a pkg-config (.pc) file for a library that does not provide one.
+# This allows downstream builds and tools to discover the library and its
+# compiler/linker flags via pkg-config.
+#
+# Usage:
+# $(call GENERATE_PC, \
+#     <prefix>,           # Installation prefix (e.g., $(PREFIX)/$(TARGET))
+#     <name>,             # Package name (e.g., libraw)
+#     <description>,      # Package description
+#     <version>,          # Package version
+#     <requires>,         # Public Dependencies (space-separated)
+#     <requires_private>, # Private dependencies (optional)
+#     <libs>,             # Public linker flags (-L${libdir} already included)
+#     <libs_private>,     # Private linker flags (optional)
+#     <cflags>,           # Public Compiler flags (I${includedir} already included)
+#     <cflags_private>    # Private compiler flags (optional)
+# )
+#
+# Example:
+# $(call GENERATE_PC, \
+#     $(PREFIX)/$(TARGET), \
+#     libraw, \
+#     Raw image decoder library, \
+#     $($(PKG)_VERSION), \
+#     lcms2 zlib, \
+#     jasper jpeg, \
+#     -lraw_r -lstdc++ -fopenmp some/path, \
+#     -ljasper -ljpeg, \
+#     libraw lnextlib some/path, \
+#     -DLIBRAW_NODLL -DANOTHER_CFLAG \
+# )
+#
+# Notes:
+#   - Any field can be left empty; pkg-config will ignore it.
+#   - Template variables in library.pc.in are replaced with the provided values.
+#   - Public linker flags (Libs) already include -L${libdir}. Any additional paths containing slashes are added explicitly as -L/full/path.
+#   - Public compiler flags (Cflags) already include -I${includedir}. Any additional entries containing slashes are added explicitly as -I/full/path.
+# ----------------------------------------------------------------------
+include src/common/library.pc.in
+
+define GENERATE_PC
+$(INSTALL) -d $(strip $1)/lib/pkgconfig
+sed \
+    -e 's|@PREFIX@|$(strip $1)|g' \
+    -e 's|@NAME@|$(strip $2)|g' \
+    -e 's|@DESCRIPTION@|$(strip $3)|g' \
+    -e 's|@VERSION@|$(strip $4)|g' \
+    -e 's|@REQUIRES@|$(strip $5)|g' \
+    -e 's|@REQUIRES_PRIVATE@|$(strip $6)|g' \
+    -e 's|@LIBS@|$(strip $(foreach f,$7,$(if $(findstring /,$f),-L$(f),$f)))|g' \
+    -e 's|@LIBS_PRIVATE@|$(strip $8)|g' \
+    -e 's|@CFLAGS@|$(strip $(foreach f,$(9),$(if $(findstring /,$f),-I$(f),-I$${includedir}/$(f))))|g' \
+    -e 's|@CFLAGS_PRIVATE@|$(strip ${10})|g' \
+    src/common/library.pc.in > $(strip $1)/lib/pkgconfig/$(strip $2).pc
+endef

--- a/src/cuew.mk
+++ b/src/cuew.mk
@@ -1,0 +1,54 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+include src/common/pkgutils.mk
+
+PKG             := cuew
+$(PKG)_DESCR    := CUDA Extension Wrangler Library (CUEW) for runtime CUDA API/extension loading
+$(PKG)_WEBSITE  := https://github.com/CudaWrangler/cuew
+$(PKG)_IGNORE   :=
+$(PKG)_URL      := https://github.com/CudaWrangler/cuew/archive/refs/heads/master.tar.gz
+# Using master because there are no tags yet (https://github.com/CudaWrangler/cuew/issues/11)
+$(PKG)_VERSION  := master
+$(PKG)_CHECKSUM := b9f8ac63ebdcad04642bf6bac47189d01e30a46f869174a2e852b147d4c41db4
+$(PKG)_GH_CONF  := CudaWranglercuew/cuew/tags
+$(PKG)_DEPS     := cc
+
+define $(PKG)_BUILD
+    # Configure with CMake
+    cd '$(BUILD_DIR)' && $(TARGET)-cmake '$(SOURCE_DIR)' \
+        -DBUILD_SHARED_LIBS=$(CMAKE_SHARED_BOOL) \
+        -DBUILD_STATIC_LIBS=$(CMAKE_STATIC_BOOL)
+
+    # Build available targets (cuew only builds test executable; library is not automatically created)
+    $(MAKE) -C "$(BUILD_DIR)" -j "$(JOBS)"
+
+    # workaround until https://github.com/CudaWrangler/cuew/issues/11 is fixed
+    # cuew CMakeLists.txt does not provide an 'install' target.
+	# manually create the static library from object files for MXE installation.
+    mkdir -p "$(BUILD_DIR)/CMakeFiles/cuew.dir/src"
+    $(TARGET)-ar rcs "$(BUILD_DIR)/libcuew.a" "$(BUILD_DIR)/CMakeFiles/cuew.dir/src/"*.obj
+
+    # Mimic install: copy library and headers
+    mkdir -p '$(PREFIX)/$(TARGET)/lib'
+    mkdir -p '$(PREFIX)/$(TARGET)/include'
+    cp -f "$(BUILD_DIR)/libcuew.a" '$(PREFIX)/$(TARGET)/lib/'
+    cp -Rf "$(SOURCE_DIR)/include/"* '$(PREFIX)/$(TARGET)/include/'
+
+    # Generate pkg-config (.pc) file for cuew
+    $(call GENERATE_PC, \
+        $(PREFIX)/$(TARGET), \
+        cuew, \
+        CUDA Extension Wrangler Library, \
+        $($(PKG)_VERSION), \
+        , \
+        , \
+        -lcuew, \
+    )
+
+	# Build the test executable
+	 $(TARGET)-g++ -Wall \
+        '$(SOURCE_DIR)/cuewTest/cuewTest.c' \
+        -o '$(PREFIX)/$(TARGET)/bin/test-$(PKG).exe' \
+        `$(TARGET)-pkg-config $(PKG) --cflags --libs`
+
+endef

--- a/src/opencl-headers.mk
+++ b/src/opencl-headers.mk
@@ -1,0 +1,18 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+PKG             := opencl-headers
+$(PKG)_DESCR    := Khronos OpenCL C headers for OpenCL API development
+$(PKG)_WEBSITE  := https://github.com/KhronosGroup/OpenCL-Headers
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 2025.07.22
+$(PKG)_CHECKSUM := 98f0a3ea26b4aec051e533cb1750db2998ab8e82eda97269ed6efe66ec94a240
+$(PKG)_GH_CONF  := KhronosGroup/OpenCL-Headers/tags,v
+$(PKG)_DEPS     := cc
+
+define $(PKG)_BUILD
+    cd '$(BUILD_DIR)'
+    # Normally, the CMakeLists.txt builds an INTERFACE library
+    # No compilation needed; just copy the headers
+    mkdir -p '$(PREFIX)/$(TARGET)/include'
+    cp -r '$(SOURCE_DIR)/CL' '$(PREFIX)/$(TARGET)/include/'
+endef

--- a/src/opensubdiv-test.cpp
+++ b/src/opensubdiv-test.cpp
@@ -1,0 +1,27 @@
+/*
+    Minimal OpenSubdiv Test
+    Build with MXE (Windows):
+
+    ./usr/bin/x86_64-w64-mingw32.static-g++ \
+        -Wall \
+        src/opensubdiv-test.cpp \
+        -I usr/x86_64-w64-mingw32.static/include \
+        -L usr/x86_64-w64-mingw32.static/lib \
+        -losdCPU -ltbb12 \
+        -o usr/x86_64-w64-mingw32.static/bin/test-opensubdiv.exe
+*/
+
+#include <opensubdiv/osd/cpuVertexBuffer.h>
+#include <iostream>
+
+class TestBuffer : public OpenSubdiv::Osd::CpuVertexBuffer {
+public:
+    TestBuffer(int elements, int verts) : CpuVertexBuffer(elements, verts) {}
+};
+
+int main() {
+    TestBuffer buffer(3, 3);
+
+    std::cout << "OpenSubdiv CPU link test succeeded." << std::endl;
+    return 0;
+}

--- a/src/opensubdiv.mk
+++ b/src/opensubdiv.mk
@@ -1,0 +1,50 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+include src/common/pkgutils.mk
+
+PKG             := opensubdiv
+$(PKG)_DESCR    := Pixar OpenSubdiv library for subdivision surface evaluation
+$(PKG)_WEBSITE  := https://github.com/PixarAnimationStudios/OpenSubdiv
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 3_7_0
+$(PKG)_CHECKSUM := f843eb49daf20264007d807cbc64516a1fed9cdb1149aaf84ff47691d97491f9
+$(PKG)_GH_CONF  := PixarAnimationStudios/OpenSubdiv/tags,v
+$(PKG)_DEPS     := cc onetbb zlib glfw3 clew cuew ptex
+
+define $(PKG)_BUILD
+    # build and install the library
+    cd '$(BUILD_DIR)' && $(TARGET)-cmake '$(SOURCE_DIR)' \
+        -DCLEW_LIBRARY='$(PREFIX)/$(TARGET)/lib/libclew.a' \
+        -DBUILD_SHARED_LIBS=$(CMAKE_SHARED_BOOL) \
+        -DBUILD_STATIC_LIBS=$(CMAKE_STATIC_BOOL) \
+        -DOPENSUBDIV_PTEX_SUPPORT=OFF \
+        -DNO_DX=1 \
+        -DNO_OPENCL=1 \
+        -DNO_CUDA=1 \
+        -DNO_PTEX=0 \
+        -DNO_REGRESSION=1 \
+        -DNO_EXAMPLES=1 \
+        -DNO_TUTORIALS=1 \
+        -DNO_DOC=1 \
+        -DNO_OPENGL=0
+
+    $(MAKE) -C "$(BUILD_DIR)" -j "$(JOBS)"
+    $(MAKE) -C "$(BUILD_DIR)" -j 1 install
+
+    # Generate missing pkg-config (.pc) file for OpenSubdiv
+    $(call GENERATE_PC, \
+        $(PREFIX)/$(TARGET), \
+        opensubdiv, \
+        Pixar OpenSubdiv library for subdivision surface evaluation, \
+        $($(PKG)_VERSION), \
+        tbb zlib clew, \
+        , \
+        -losdCPU -ltbb12 -lz -lclew -lcuew -lPtex, \
+    )
+
+    # compile test
+    '$(TARGET)-g++' -Wall \
+        '$(TEST_FILE)' \
+        -o '$(PREFIX)/$(TARGET)/bin/test-$(PKG).exe' \
+        `'$(TARGET)-pkg-config' $(PKG) --cflags --libs`
+endef

--- a/src/ptex.mk
+++ b/src/ptex.mk
@@ -10,8 +10,10 @@ $(PKG)_GH_CONF  := wdas/ptex/tags,v
 $(PKG)_DEPS     := cc zlib libdeflate
 
 define $(PKG)_BUILD
-	# Patch Windows.h include to lowercase for MinGW (https://github.com/wdas/ptex/issues/85 is fixed but no tag yet)
-    sed -i 's/#include <Windows.h>/#include <windows.h>/' '$(SOURCE_DIR)/src/ptex/PtexPlatform.h'
+	# Patch Windows.h include to lowercase for MinGW (https://github.com/wdas/ptex/issues/85)
+	sed 's|#include <Windows.h>|#include <windows.h>|' "$(SOURCE_DIR)/src/ptex/PtexPlatform.h" \
+		> tmpfile && \
+		mv tmpfile "$(SOURCE_DIR)/src/ptex/PtexPlatform.h"
 
 	cd '$(BUILD_DIR)' && $(TARGET)-cmake '$(SOURCE_DIR)' \
 		-DCMAKE_BUILD_TYPE=Release \

--- a/src/ptex.mk
+++ b/src/ptex.mk
@@ -1,0 +1,28 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+PKG             := ptex
+$(PKG)_DESCR    := Pixar Ptex library for per-face textures
+$(PKG)_WEBSITE  := https://github.com/wdas/ptex
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 2.5.1
+$(PKG)_CHECKSUM := 6b4b55f562a0f9492655fcb7686ecc335a2a4dacc1de9f9a057a32f3867a9d9e
+$(PKG)_GH_CONF  := wdas/ptex/tags,v
+$(PKG)_DEPS     := cc zlib libdeflate
+
+define $(PKG)_BUILD
+	# Patch Windows.h include to lowercase for MinGW (https://github.com/wdas/ptex/issues/85 is fixed but no tag yet)
+    sed -i 's/#include <Windows.h>/#include <windows.h>/' '$(SOURCE_DIR)/src/ptex/PtexPlatform.h'
+
+	cd '$(BUILD_DIR)' && $(TARGET)-cmake '$(SOURCE_DIR)' \
+		-DCMAKE_BUILD_TYPE=Release \
+		-DPTEX_BUILD_STATIC_LIBS=$(CMAKE_STATIC_BOOL) \
+		-DPTEX_BUILD_SHARED_LIBS=$(CMAKE_SHARED_BOOL) \
+		-DPTEX_BUILD_DOCS=OFF \
+		-DPRMAN_15_COMPATIBLE_PTEX=OFF \
+
+    $(MAKE) -C "$(BUILD_DIR)" -j "$(JOBS)"
+    $(MAKE) -C "$(BUILD_DIR)" -j 1 install
+
+	# Ptex library automatically builds a test utility:
+	# $(PREFIX)/$(TARGET)/bin/ptxinfo.exe
+endef


### PR DESCRIPTION
- Introduce a new MXE package for OpenSubdiv (libosdCPU), required as a dependency for Blender.
- Mark OpenSubdiv as depending on crew.mk for proper build ordering.
- Enables building and linking against OpenSubdiv in cross-compiled environments.
- Includes a minimal test for libosdCPU to verify successful compilation and linking.
