### PR TITLE
bfd: build libsframe before bfd

### DIFF
--- a/src/bfd.mk
+++ b/src/bfd.mk
@@ -17,6 +17,13 @@ define $(PKG)_UPDATE
 endef
 
 define $(PKG)_BUILD
+    # libbfd links against libsframe since binutils 2.41; build it here since
+    # this package only configures/builds the bfd subdir, not all of binutils.
+    cd '$(1)/libsframe' && ./configure \
+        --host='$(TARGET)' \
+        --disable-shared
+    $(MAKE) -C '$(1)/libsframe' -j '$(JOBS)'
+
     cd '$(1)/bfd' && ./configure \
         --host='$(TARGET)' \
         --target='$(TARGET)' \


### PR DESCRIPTION
Since binutils 2.41, libbfd links against ../libsframe/libsframe.la unconditionally. This package only configures/builds the bfd subdir rather than all of binutils, so libsframe was never built, and the bfd build failed with `No rule to make target '../libsframe/libsframe.la'`.
