### PR TITLE
bfd: install libsframe

### DIFF
--- a/src/bfd.mk
+++ b/src/bfd.mk
@@ -21,8 +21,11 @@ define $(PKG)_BUILD
     # this package only configures/builds the bfd subdir, not all of binutils.
     cd '$(1)/libsframe' && ./configure \
         --host='$(TARGET)' \
+        --prefix='$(PREFIX)/$(TARGET)' \
+        --enable-install-libbfd \
         --disable-shared
     $(MAKE) -C '$(1)/libsframe' -j '$(JOBS)'
+    $(MAKE) -C '$(1)/libsframe' -j 1 install
 
     cd '$(1)/bfd' && ./configure \
         --host='$(TARGET)' \


### PR DESCRIPTION
libbfd.a references `sframe_encoder_free`/`sframe_decoder_free`, so anything linking `-lbfd` also needs `-lsframe`. Since #3321 libsframe is built, but it is never installed, leaving the sysroot with a libbfd that cannot be linked.

libsframe installs its library and headers only under `INSTALL_LIBBFD`, the same conditional bfd already uses, so enable it there too.