### PR TITLE
KF6 Introduction: Second step - Qt6 D-Bus enablement & i686 build fixes

### DIFF
--- a/src/dbus-2-fix-cmake-definitions.patch
+++ b/src/dbus-2-fix-cmake-definitions.patch
@@ -1,0 +1,33 @@
+This file is part of MXE. See LICENSE.md for licensing information.
+
+Contains ad hoc patches for cross building.
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Marco Borrini <borrinimarco74@gmail.com>
+Date: Tue, 4 Aug 2026 08:22:00 +0200
+Subject: [PATCH 2/2] Fix CMake definitions and missing transitive dependencies
+
+This patch fixes two bugs in DBus1Config.pkgconfig.in that break static builds:
+1) CFLAGS_OTHER (containing -DDBUS_STATIC_BUILD and -pthread) is incorrectly
+   assigned to INTERFACE_COMPILE_DEFINITIONS, which prefixes items with -D.
+   We change it to INTERFACE_COMPILE_OPTIONS.
+2) dbus-1 is incorrectly declared as SHARED IMPORTED and its transitive
+   dependencies (like iphlpapi, ws2_32) from pkg-config are discarded. We
+   declare it as UNKNOWN IMPORTED and properly inject INTERFACE_LINK_LIBRARIES.
+
+diff -ur dbus-orig/cmake/DBus1Config.pkgconfig.in dbus-new/cmake/DBus1Config.pkgconfig.in
+--- dbus-orig/cmake/DBus1Config.pkgconfig.in	2026-08-04 06:21:46.666073220 +0200
++++ dbus-new/cmake/DBus1Config.pkgconfig.in	2026-08-04 08:22:23.675360231 +0200
+@@ -73,8 +73,10 @@
+ set(DBus1_INCLUDE_DIRS "${DBus1_INCLUDE_DIR}" "${DBus1_ARCH_INCLUDE_DIR}")
+ 
+ # setup imported target
+-add_library(dbus-1 SHARED IMPORTED)
++add_library(dbus-1 UNKNOWN IMPORTED)
+ set_property(TARGET dbus-1 APPEND PROPERTY IMPORTED_LOCATION ${DBus1_LIBRARY})
+ set_property(TARGET dbus-1 APPEND PROPERTY IMPORTED_IMPLIB ${DBus1_LIBRARY})
+ set_property(TARGET dbus-1 APPEND PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${DBus1_INCLUDE_DIRS})
+-set_property(TARGET dbus-1 APPEND PROPERTY INTERFACE_COMPILE_DEFINITIONS ${DBus1_DEFINITIONS})
++set_property(TARGET dbus-1 APPEND PROPERTY INTERFACE_COMPILE_OPTIONS ${DBus1_DEFINITIONS})
++list(REMOVE_ITEM PC_DBUS1_LIBRARIES dbus-1)
++set_property(TARGET dbus-1 APPEND PROPERTY INTERFACE_LINK_LIBRARIES ${PC_DBUS1_LIBRARIES})

--- a/src/mariadb-connector-c.mk
+++ b/src/mariadb-connector-c.mk
@@ -28,8 +28,7 @@ define $(PKG)_BUILD
         mv '$(PREFIX)/$(TARGET)/lib/mariadb/libmariadbclient.a' '$(PREFIX)/$(TARGET)/lib/mariadb/libmariadb.a',
         mv '$(PREFIX)/$(TARGET)/lib/mariadb/liblibmariadb.dll.a' '$(PREFIX)/$(TARGET)/lib/mariadb/libmariadb.a'
         mv '$(PREFIX)/$(TARGET)/lib/mariadb/libmariadb.dll' '$(PREFIX)/$(TARGET)/bin/')
-    # workaround for linking to 32-bit shared libmariadb.a
-    $(if $(BUILD_SHARED), '$(SED)' -i -e 's/^#define STDCALL __stdcall/#define STDCALL/;' '$(PREFIX)/$(TARGET)/include/mariadb/mysql.h')
+
 
     # build test
     '$(TARGET)-g++' \

--- a/src/qt/qt6/qt6-qtbase.mk
+++ b/src/qt/qt6/qt6-qtbase.mk
@@ -11,7 +11,7 @@ $(PKG)_SUBDIR   := $(PKG_BASENAME)-everywhere-src-$($(PKG)_VERSION)
 $(PKG)_FILE     := $(PKG_BASENAME)-everywhere-src-$($(PKG)_VERSION).tar.xz
 $(PKG)_URL      := https://download.qt.io/archive/qt/6.11/$($(PKG)_VERSION)/submodules/$($(PKG)_FILE)
 $(PKG)_TARGETS  := $(BUILD) $(MXE_TARGETS)
-$(PKG)_DEPS     := cc freetype harfbuzz jpeg libpng mesa mariadb-connector-c openssl pcre2 sqlite zlib zstd $(BUILD)~$(PKG) \
+$(PKG)_DEPS     := cc dbus freetype harfbuzz jpeg libpng mesa mariadb-connector-c openssl pcre2 sqlite zlib zstd $(BUILD)~$(PKG) \
                    $(if $(findstring shared,$(MXE_TARGETS)), icu4c)
 $(PKG)_DEPS_$(BUILD) :=
 $(PKG)_OO_DEPS_$(BUILD) := ninja
@@ -41,7 +41,7 @@ define $(PKG)_BUILD
         -DQT_BUILD_TESTS=OFF \
         -DBUILD_WITH_PCH=OFF \
         -DFEATURE_accessibility=ON \
-        -DFEATURE_dbus=OFF \
+        -DFEATURE_dbus=ON \
         -DFEATURE_fontconfig=OFF \
         -DFEATURE_system_freetype=ON \
         -DFEATURE_glib=OFF \

--- a/src/qt/qt6/qt6-qtmultimedia-2-fixes.patch
+++ b/src/qt/qt6/qt6-qtmultimedia-2-fixes.patch
@@ -1,0 +1,29 @@
+This file is part of MXE. See LICENSE.md for licensing information.
+
+Contains ad hoc patches for cross building.
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Marco Borrini <borrinimarco74@gmail.com>
+Date: Tue, 11 Aug 2026 08:40:00 +0200
+Subject: [PATCH 1/1] Fix i686-w64-mingw32 build for qtmultimedia qwindows_propertystore
+
+Add __stdcall specialization for first_arg_is_ptr to match the Windows API
+calling convention on 32-bit architectures.
+
+diff --git a/src/multimedia/windows/qwindows_propertystore.cpp b/src/multimedia/windows/qwindows_propertystore.cpp
+--- a/src/multimedia/windows/qwindows_propertystore.cpp
++++ b/src/multimedia/windows/qwindows_propertystore.cpp
+@@ -86,6 +86,13 @@
+ {
+ };
+ 
++#if defined(__i386__)
++template <typename Result, typename Arg, typename... Args>
++struct first_arg_is_ptr<Result (__stdcall *)(Arg, Args...)> : std::bool_constant<std::is_pointer_v<Arg>>
++{
++};
++#endif
++
+ auto wrapPropVariantArg(const PROPVARIANT &arg)
+ {
+     if constexpr (first_arg_is_ptr<decltype(&PropVariantToGUID)>::value) {

--- a/src/qt/qt6/qt6-qtwebview-1-fixes.patch
+++ b/src/qt/qt6/qt6-qtwebview-1-fixes.patch
@@ -1,0 +1,29 @@
+This file is part of MXE. See LICENSE.md for licensing information.
+
+Contains ad hoc patches for cross building.
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Marco Borrini <borrinimarco74@gmail.com>
+Date: Tue, 11 Aug 2026 10:45:00 +0200
+Subject: [PATCH 1/1] Fix i686 build: add x86 architecture to FindWebView2
+
+Recognize i686/x86/i386 as valid architectures for WebView2 SDK and map
+them to the x86 directory.
+
+diff --git a/cmake/FindWebView2.cmake b/cmake/FindWebView2.cmake
+--- a/cmake/FindWebView2.cmake
++++ b/cmake/FindWebView2.cmake
+@@ -9,10 +9,13 @@
+ function(get_cpu_arch result arch)
+     set(arm64List arm64 ARM64 aarch64)
+     set(x64List x86_64 AMD64 x86_64h)
++    set(x86List x86 i386 i686)
+     if(arch IN_LIST x64List)
+         set(${result} "x64" PARENT_SCOPE)
+     elseif(arch IN_LIST arm64List)
+         set(${result} "arm64" PARENT_SCOPE)
++    elseif(arch IN_LIST x86List)
++        set(${result} "x86" PARENT_SCOPE)
+     else()
+         message(FATAL_ERROR "Unknown architecture: ${arch}")
+     endif()


### PR DESCRIPTION
This is the second step in introducing KDE Framework 6 into MXE. 
It focuses on enabling D-Bus in Qt6 and resolving several build failures specifically affecting the 32-bit (i686) targets.

This PR has been tested locally against all 4 targets with GCC 11 and GCC 16.

Next step: adding new dependencies and updating current packages to support the KDE Frameworks 6 build.

==> 5c9bfd88 qt6-qtbase: enable dbus <==
* Feature Enablement: Explicitly enabled D-Bus support in the qt6-qtbase build configuration, which is a crucial requirement for many KF6 components.

==> cabfaec1 dbus: patch to fix qt6-qtbase i686 static build <==
* Build Fix: Added a patch to resolve static linkage issues encountered when building qt6-qtbase against D-Bus on the i686 architecture.

==> 510151cc qt6-qtmultimedia: patch to fix i686 static build <==
* Build Fix: Fixed a compilation error in qwindows_propertystore.cpp on 32-bit targets. The patch adds the missing __stdcall template specialization for first_arg_is_ptr, which caused the build to fail on i686-w64-mingw32.

==> e566b631 qt6-qtwebview: patch to fix i686 static build <==
* CMake Fix: Resolved a fatal configuration error where FindWebView2.cmake failed to recognize the i686 architecture. The patch maps i686/i386/x86 to the correct x86 SDK directory, allowing the build to succeed.

==> 7bc4a8f1 mariadb-connector-c: fix i686 shared build <==
* Build Fix: Applied a minor correction to ensure mariadb-connector-c compiles successfully as a shared library on the i686 architecture.