### PR TITLE
libopusenc: new package

### DIFF
--- a/src/libopusenc.mk
+++ b/src/libopusenc.mk
@@ -1,0 +1,29 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+PKG             := libopusenc
+$(PKG)_WEBSITE  := https://opus-codec.org/
+$(PKG)_DESCR    := High-level API for encoding .opus files
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 0.3
+$(PKG)_CHECKSUM := f616d3aff9b2034547894ccb8ab56c36cf1a4acb0d922c5d7119f97bbe58642c
+$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.gz
+$(PKG)_URL      := https://downloads.xiph.org/releases/opus/$($(PKG)_FILE)
+$(PKG)_DEPS     := cc opus
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- 'https://downloads.xiph.org/releases/opus/' | \
+    $(SED) -n 's,.*libopusenc-\([0-9][^>]*\)\.tar\.gz.*,\1,p' | \
+    grep -v 'alpha' | \
+    grep -v 'beta' | \
+    $(SORT) -Vr | \
+    head -1
+endef
+
+define $(PKG)_BUILD
+    cd '$(1)' && ./configure \
+        $(MXE_CONFIGURE_OPTS) \
+        --disable-doc
+    $(MAKE) -C '$(1)' -j '$(JOBS)'
+    $(MAKE) -C '$(1)' -j 1 install
+endef


### PR DESCRIPTION
Adds `libopusenc`, Xiph's high-level Opus encoding library.

`opus` and `opusfile` are already packaged, so a project built against MXE can decode `.opus` but not write one. libopusenc is what closes that gap — it is the library `opusenc(1)` itself is built on, and the one SoX uses for Opus output.

### Source

Fetched from `downloads.xiph.org` rather than the `archive.mozilla.org` mirror that `opus.mk` and `opusfile.mk` use. The Mozilla archive has nothing newer than libopusenc 0.2.1, while the current release is 0.3. The Xiph URL redirects to `ftp.osuosl.org`, which serves a directory index, so the `_UPDATE` macro has something to read.

Happy to switch to the Mozilla mirror and 0.2.1 if you would rather keep the three opus packages on the same host.

### Testing

Built for `x86_64-w64-mingw32.static` and linked into SoX 14.8.0.1, then the resulting `.exe` was run on Windows 11:

- encodes `.opus` at 96 kbit/s CBR, 400 kbit/s CBR and 1 kbit/s VBR
- the output decodes back to full-length PCM
- `soxi` reports the streams as valid Opus

**The other three targets are untested** — I have no way to exercise the shared builds. If CI is unhappy on those, say so and I will follow up.
