### PR TITLE
KF6 Introduction: Third step - Pre-requisite dependencies and native toolchain tweaks

### DIFF
--- a/src/canberra-1-mingw.patch
+++ b/src/canberra-1-mingw.patch
@@ -1,0 +1,25 @@
+This file is part of MXE. See LICENSE.md for licensing information.
+
+Contains ad hoc patches for cross building.
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Marco Borrini <borrinimarco74@gmail.com>
+Date: Tue, 4 Aug 2026 23:08:00 +0200
+Subject: [PATCH 1/1] Fix LC_MESSAGES on MinGW
+
+MinGW does not define LC_MESSAGES. Fallback to LC_ALL.
+
+diff -ur canberra-orig/src/sound-theme-spec.c canberra-new/src/sound-theme-spec.c
+--- canberra-orig/src/sound-theme-spec.c
++++ canberra-new/src/sound-theme-spec.c
+@@ -34,6 +34,10 @@
+ #include "llist.h"
+ #include "cache.h"
+ 
++#ifndef LC_MESSAGES
++#define LC_MESSAGES LC_ALL
++#endif
++
+ #define DEFAULT_THEME "freedesktop"
+ #define FALLBACK_THEME "freedesktop"
+ #define DEFAULT_OUTPUT_PROFILE "stereo"

--- a/src/canberra.mk
+++ b/src/canberra.mk
@@ -1,0 +1,39 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+PKG             := canberra
+$(PKG)_WEBSITE  := http://0pointer.de/lennart/projects/libcanberra/
+$(PKG)_DESCR    := libcanberra
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 0.30
+$(PKG)_CHECKSUM := c2b671e67e0c288a69fc33dc1b6f1b534d07882c2aceed37004bf48c601afa72
+$(PKG)_SUBDIR   := libcanberra-$($(PKG)_VERSION)
+$(PKG)_FILE     := libcanberra-$($(PKG)_VERSION).tar.xz
+$(PKG)_URL      := http://0pointer.de/lennart/projects/libcanberra/$($(PKG)_FILE)
+$(PKG)_DEPS     := cc libltdl vorbis
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- 'http://0pointer.de/lennart/projects/libcanberra/' | \
+    $(SED) -n 's,.*libcanberra-\([0-9][^>]*\)\.tar.*,\1,p' | \
+    head -1
+endef
+
+define $(PKG)_BUILD
+    cd '$(BUILD_DIR)' && '$(SOURCE_DIR)/configure' \
+        $(MXE_CONFIGURE_OPTS) \
+        LIBS="-ldl" \
+        --disable-lynx \
+        --disable-pulse \
+        --disable-alsa \
+        --disable-oss \
+        --disable-gstreamer \
+        --enable-null \
+        --disable-gtk \
+        --disable-gtk3 \
+        --disable-tdb \
+        --disable-udev \
+        --enable-builtin-null
+    $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)'
+    $(MAKE) -C '$(BUILD_DIR)' -j 1 install
+    
+    $(SED) -i 's/^Libs:.*/& -lltdl/g' '$(PREFIX)/$(TARGET)/lib/pkgconfig/libcanberra.pc'
+endef

--- a/src/docbook-xml.mk
+++ b/src/docbook-xml.mk
@@ -1,0 +1,20 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+PKG             := docbook-xml
+$(PKG)_VERSION  := 4.5
+$(PKG)_CHECKSUM := 4e4e037a2b83c98c6c94818390d4bdd3f6e10f6ec62dd79188594e26190dc7b4
+$(PKG)_SUBDIR   := .
+$(PKG)_FILE     := docbook-xml-$($(PKG)_VERSION).zip
+$(PKG)_URL      := https://archive.docbook.org/xml/$($(PKG)_VERSION)/$($(PKG)_FILE)
+$(PKG)_DEPS     :=
+$(PKG)_TARGETS  := $(BUILD) $(MXE_TARGETS)
+$(PKG)_DEPS_$(BUILD) :=
+
+define $(PKG)_BUILD_$(BUILD)
+    mkdir -p '$(PREFIX)/$(TARGET)/share/xml/docbook/schema/dtd/$($(PKG)_VERSION)'
+    cp -r '$(SOURCE_DIR)'/* '$(PREFIX)/$(TARGET)/share/xml/docbook/schema/dtd/$($(PKG)_VERSION)/'
+endef
+
+define $(PKG)_BUILD
+    $($(PKG)_BUILD_$(BUILD))
+endef

--- a/src/docbook-xsl.mk
+++ b/src/docbook-xsl.mk
@@ -1,0 +1,20 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+PKG             := docbook-xsl
+$(PKG)_VERSION  := 1.79.2
+$(PKG)_CHECKSUM := 316524ea444e53208a2fb90eeb676af755da96e1417835ba5f5eb719c81fa371
+$(PKG)_SUBDIR   := docbook-xsl-$($(PKG)_VERSION)
+$(PKG)_FILE     := docbook-xsl-$($(PKG)_VERSION).tar.bz2
+$(PKG)_URL      := https://github.com/docbook/xslt10-stylesheets/releases/download/release%2F$($(PKG)_VERSION)/$($(PKG)_FILE)
+$(PKG)_DEPS     :=
+$(PKG)_TARGETS  := $(BUILD) $(MXE_TARGETS)
+$(PKG)_DEPS_$(BUILD) :=
+
+define $(PKG)_BUILD_$(BUILD)
+    mkdir -p '$(PREFIX)/$(TARGET)/share/xml/docbook/xsl-stylesheets'
+    cp -r '$(SOURCE_DIR)'/* '$(PREFIX)/$(TARGET)/share/xml/docbook/xsl-stylesheets/'
+endef
+
+define $(PKG)_BUILD
+    $($(PKG)_BUILD_$(BUILD))
+endef

--- a/src/libltdl.mk
+++ b/src/libltdl.mk
@@ -21,4 +21,5 @@ define $(PKG)_BUILD
         --enable-ltdl-install
     $(MAKE) -C '$(1)/libltdl' -j '$(JOBS)'
     $(MAKE) -C '$(1)/libltdl' -j 1 install
+    $(SED) -i 's, [^ ]*tmp-[^ ]*\.a,,g' '$(PREFIX)/$(TARGET)/lib/libltdl.la'
 endef

--- a/src/libxml2.mk
+++ b/src/libxml2.mk
@@ -10,7 +10,20 @@ $(PKG)_FILE     := libxml2-$($(PKG)_VERSION).tar.xz
 $(PKG)_URL      := https://download.gnome.org/sources/libxml2/2.14/$($(PKG)_FILE)
 $(PKG)_URL_2    := https://ftp.osuosl.org/pub/blfs/conglomeration/libxml2/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc libiconv xz zlib
+$(PKG)_TARGETS  := $(BUILD) $(MXE_TARGETS)
+$(PKG)_DEPS_$(BUILD) := zlib libiconv
 
+define $(PKG)_BUILD_$(BUILD)
+    cd '$(1)' && ./configure \
+        $(MXE_CONFIGURE_OPTS) \
+        --without-debug \
+        --without-python \
+        --without-threads \
+        --without-zlib \
+        --without-lzma
+    $(MAKE) -C '$(1)' -j '$(JOBS)' bin_PROGRAMS= sbin_PROGRAMS= noinst_PROGRAMS= CFLAGS='-O2 -fPIC' CXXFLAGS='-O2 -fPIC'
+    $(MAKE) -C '$(1)' -j 1 install bin_PROGRAMS= sbin_PROGRAMS= noinst_PROGRAMS= CFLAGS='-O2 -fPIC' CXXFLAGS='-O2 -fPIC'
+endef
 define $(PKG)_UPDATE
     $(WGET) -q -O- 'https://gitlab.gnome.org/GNOME/libxml2/tags' | \
     $(SED) -n "s,.*<a [^>]\+>v\([0-9,\.]\+\)<.*,\\1,p" | \

--- a/src/libxslt-1-fixes.patch
+++ b/src/libxslt-1-fixes.patch
@@ -3,21 +3,27 @@ This file is part of MXE. See LICENSE.md for licensing information.
 Contains ad hoc patches for cross building.
 
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: "fix@me" <fix@me>
+From: Marco Borrini <borrinimarco74@gmail.com>
 Date: Tue, 5 Jul 2016 21:12:38 +0300
 Subject: [PATCH 1/1] fix for deprecated mkdir
 
+The POSIX mkdir(directory, mode) is deprecated or not available with the
+same signature on Windows/MinGW. This patch replaces it with the Windows
+specific _mkdir(directory) when compiling for Windows.
 
-diff --git a/libxslt/security.c b/libxslt/security.c
-index 1111111..2222222 100644
---- a/libxslt/security.c
-+++ b/libxslt/security.c
-@@ -327,7 +327,7 @@ xsltCheckWritePath(xsltSecurityPrefsPtr sec,
+diff -ur libxslt-orig/libxslt/security.c libxslt-new/libxslt/security.c
+--- libxslt-orig/libxslt/security.c
++++ libxslt-new/libxslt/security.c
+@@ -327,7 +327,11 @@ xsltCheckWritePath(xsltSecurityPrefsPtr sec,
  	    }
  	    ret = xsltCheckWritePath(sec, ctxt, directory);
  	    if (ret == 1)
 -		ret = mkdir(directory, 0755);
++#if defined(_WIN32) || defined(__MINGW32__)
 +		ret = _mkdir(directory);
++#else
++		ret = mkdir(directory, 0755);
++#endif
  	}
  	xmlFree(directory);
  	if (ret < 0)

--- a/src/libxslt.mk
+++ b/src/libxslt.mk
@@ -9,7 +9,20 @@ $(PKG)_SUBDIR   := libxslt-$($(PKG)_VERSION)
 $(PKG)_FILE     := libxslt-$($(PKG)_VERSION).tar.xz
 $(PKG)_URL      := https://download.gnome.org/sources/libxslt/1.1/$($(PKG)_FILE)
 $(PKG)_DEPS     := cc libgcrypt libxml2
+$(PKG)_TARGETS  := $(BUILD) $(MXE_TARGETS)
+$(PKG)_DEPS_$(BUILD) := libxml2
 
+define $(PKG)_BUILD_$(BUILD)
+    cd '$(BUILD_DIR)' && $(SOURCE_DIR)/configure \
+        $(MXE_CONFIGURE_OPTS) \
+        --without-debug \
+        --with-libxml-prefix='$(PREFIX)/$(TARGET)' \
+        --without-python \
+        --without-crypto \
+        --without-plugins
+    $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)' bin_PROGRAMS= sbin_PROGRAMS= noinst_PROGRAMS= CFLAGS='-O2 -fPIC' CXXFLAGS='-O2 -fPIC'
+    $(MAKE) -C '$(BUILD_DIR)' -j 1 install bin_PROGRAMS= sbin_PROGRAMS= noinst_PROGRAMS= CFLAGS='-O2 -fPIC' CXXFLAGS='-O2 -fPIC'
+endef
 define $(PKG)_UPDATE
     $(WGET) -q -O- 'https://gitlab.gnome.org/GNOME/libxslt/tags' | \
     $(SED) -n "s,.*<a [^>]\+>v\([0-9,\.]\+\)<.*,\\1,p" | \

--- a/src/qt/qt6/qt6-qtbase-1-fixes.patch
+++ b/src/qt/qt6/qt6-qtbase-1-fixes.patch
@@ -477,3 +477,32 @@ index 1111111..2222222 100644
  
  struct LoadedOpenSsl {
      std::unique_ptr<QSystemLibrary> ssl, crypto;
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Marco Borrini <borrinimarco74@gmail.com>
+Date: Tue, 4 Aug 2026 06:54:00 +0200
+Subject: [PATCH 4/4] Fix Freetype transitive dependencies for static builds
+
+CMake's FindFreetype does not query pkg-config for transitive static
+dependencies (like brotli, bz2, harfbuzz) causing undefined references
+when other targets link against Qt6::Gui statically. We patch the Qt
+wrapper to inject them using pkg_check_modules.
+
+diff -ur qtbase-orig/cmake/FindWrapSystemFreetype.cmake qtbase-new/cmake/FindWrapSystemFreetype.cmake
+--- qtbase-orig/cmake/FindWrapSystemFreetype.cmake
++++ qtbase-new/cmake/FindWrapSystemFreetype.cmake
+@@ -47,6 +47,14 @@
+     add_library(WrapSystemFreetype::WrapSystemFreetype INTERFACE IMPORTED)
+     target_link_libraries(WrapSystemFreetype::WrapSystemFreetype
+                           INTERFACE "${__freetype_target_name}")
++    find_package(PkgConfig QUIET)
++    if(PKG_CONFIG_FOUND)
++        pkg_check_modules(PC_FREETYPE QUIET freetype2)
++        if(PC_FREETYPE_FOUND)
++            list(REMOVE_ITEM PC_FREETYPE_LIBRARIES freetype)
++            target_link_libraries(WrapSystemFreetype::WrapSystemFreetype INTERFACE ${PC_FREETYPE_LIBRARIES})
++        endif()
++    endif()
+ endif()
+ unset(__freetype_target_name)
+ unset(__freetype_found)


### PR DESCRIPTION
This is the third step in introducing KDE Frameworks 6 into MXE. 
It focuses on adding new missing dependencies and tweaking the native toolchain (libxml2/libxslt) to fulfill the requirements of upcoming KF6 components (like knotifications and kdoctools).

This PR has been tested locally against all 4 targets with GCC 11 and GCC 16 by checking all the packages interested.

Next step: Introducing the actual KDE Frameworks 6 packages into the tree.

==> aadaa116 qt6-qtbase: fix kf6-kguiaddons static build <==
* Build Fix: Fixed a static linkage issue affecting targets linking against Qt6::Gui. CMake's FindWrapSystemFreetype dropped transitive static dependencies (like brotli, bz2, harfbuzz) resulting in undefined references. Updated the existing qt6-qtbase-1-fixes.patch to explicitly inject them using pkg_check_modules.

==> 74438b72 Add new package canberra <==
* New Package: Added `libcanberra`, a crucial audio engine dependency required by `kf6-knotifications` to handle system notification sounds.

==> b6a8e398 libltdl: fix canberra static build <==
* Build Fix: Added a `sed` command to the libtool configuration of `libltdl` to strip temporary absolute paths (`tmp-*.a`) baked into the `.la` file. This prevents `canberra` from failing with "file not found" errors during static linkage.

==> db4beaf3 Add new package docbook-xml <==
* New Package: Added DocBook XML DTDs, an essential dependency required by `kf6-kdoctools` to process KDE documentation syntax.

==> 21cc12cb Add new package docbook-xsl <==
* New Package: Added DocBook XSL stylesheets, required by `kf6-kdoctools` to translate XML manuals into HTML or Man pages.

==> 9c8e9a2d libxml2: enable native build <==
* Toolchain Tweak: Enabled native build (`x86_64-pc-linux-gnu`) for `libxml2` to generate a host-executable `xmllint`. This is mandatory because `kf6-kdoctools` executes it natively during cross-compilation.

==> 3e97e7b5 libxslt: enable native build <==
* Toolchain Tweak: Enabled native build (`x86_64-pc-linux-gnu`) for `libxslt` to generate a host-executable `xsltproc`, completing the native XML processing toolchain required by `kf6-kdoctools`.

