### PR TITLE
KF6 Introduction: Fourth step - Core KDE Frameworks 6 packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,9 @@ MXE_CCACHE_CACHE_DIR := $(MXE_CCACHE_DIR)/ccache
 # MXE_QT6_ID := qt6.2
 MXE_QT6_ID := qt6
 
+# set to major for KF
+MXE_KF6_ID := kf6
+
 # define some whitespace variables
 define newline
 
@@ -445,6 +448,7 @@ JOBS   ?= $(call LIST_NMIN, $(DEFAULT_MAX_JOBS) $(NPROCS))
 override MXE_PLUGIN_DIRS := \
     $(realpath $(TOP_DIR)/src) \
     $(realpath $(TOP_DIR)/src/qt/$(MXE_QT6_ID)) \
+    $(realpath $(TOP_DIR)/src/kf/$(MXE_KF6_ID)) \
     $(MXE_PLUGIN_DIRS)
 
 # Build native requirements for certain systems

--- a/src/kf/kf6/kf6-attica.mk
+++ b/src/kf/kf6/kf6-attica.mk
@@ -1,0 +1,18 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+include src/kf/kf6/kf6-conf.mk
+
+PKG              := kf6-attica
+$(eval $(call KF6_METADATA))
+
+$(PKG)_CHECKSUM  := 652e28562ed6798f834843b45f5cd3ea5833f0ee3c2607cfe3d021b57c6e7618
+$(PKG)_DEPS      := kf6-conf kf6-extra-cmake-modules qt6-qtbase
+$(PKG)_TARGETS   := $(MXE_TARGETS)
+$(PKG)_IGNORE    := 
+
+define $(PKG)_BUILD
+    $(KF6_CMAKE) -S '$(SOURCE_DIR)' -B '$(BUILD_DIR)'
+    
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --build . -j '$(JOBS)'
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --install .
+endef

--- a/src/kf/kf6/kf6-breeze-icons.mk
+++ b/src/kf/kf6/kf6-breeze-icons.mk
@@ -1,0 +1,31 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+include src/kf/kf6/kf6-conf.mk
+
+PKG              := kf6-breeze-icons
+$(eval $(call KF6_METADATA))
+
+$(PKG)_CHECKSUM  := 45de8138ead0f3ff24de886fbe61d588ecd7f66dde6f8cf6f2906279254d094d
+$(PKG)_DEPS      := kf6-conf kf6-extra-cmake-modules qt6-qtbase $(BUILD)~$(PKG)
+$(PKG)_DEPS_$(BUILD) := $(BUILD)~kf6-extra-cmake-modules $(BUILD)~qt6-qtbase
+$(PKG)_TARGETS   := $(BUILD) $(MXE_TARGETS)
+$(PKG)_IGNORE    := 
+
+define $(PKG)_BUILD_$(BUILD)
+    $(KF6_CMAKE) -S '$(SOURCE_DIR)' -B '$(BUILD_DIR)' \
+        -DINSTALL_HOST_TOOLS=ON \
+        -DBINARY_ICONS_RESOURCE=OFF \
+        -DSKIP_INSTALL_ICONS=ON
+    
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --build . -j '$(JOBS)'
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --install .
+endef
+
+define $(PKG)_BUILD
+    $(KF6_CMAKE) -S '$(SOURCE_DIR)' -B '$(BUILD_DIR)' \
+        -DBINARY_ICONS_RESOURCE=ON \
+        -DSKIP_INSTALL_ICONS=OFF
+    
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --build . -j '$(JOBS)'
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --install .
+endef

--- a/src/kf/kf6/kf6-conf.mk
+++ b/src/kf/kf6/kf6-conf.mk
@@ -1,0 +1,34 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+include src/qt/qt6/qt6-qtbase.mk
+
+PKG             := kf6-conf
+$(PKG)_VERSION  := 6.28.0
+$(PKG)_DEPS     := qt6-qtbase
+$(PKG)_TARGETS  := $(BUILD) $(MXE_TARGETS)
+
+define KF6_METADATA
+    $(PKG)_WEBSITE  := https://kde.org/
+    $(PKG)_DESCR    := KDE Frameworks 6
+    $(PKG)_IGNORE    :=
+    $(PKG)_VERSION  := $(kf6-conf_VERSION)
+    $(PKG)_SUBDIR   := $(subst kf6-,,$(PKG))-$(kf6-conf_VERSION)
+    $(PKG)_FILE     := $(subst kf6-,,$(PKG))-$(kf6-conf_VERSION).tar.xz
+    $(PKG)_URL      := https://download.kde.org/stable/frameworks/$(call SHORT_PKG_VERSION,kf6-conf)/$(subst kf6-,,$(PKG))-$(kf6-conf_VERSION).tar.xz
+    $(PKG)_UPDATE   := echo $(kf6-conf_VERSION)
+endef
+
+KF6_CMAKE = $(QT6_QT_CMAKE) \
+    -DBUILD_TESTING=OFF \
+    -DBUILD_PYTHON_BINDINGS=OFF \
+    -DKDE_INSTALL_USE_QT_SYS_PATHS=ON \
+    -DKDE_INSTALL_LIBDIR=lib \
+    -DKDE_INSTALL_LIBEXECDIR=libexec \
+    -DKDE_INSTALL_QMLDIR=qml \
+    -DKDE_INSTALL_PLUGINDIR=plugins \
+    -DKDE_INSTALL_QTMETATYPESDIR=metatypes \
+    -DKF6_HOST_TOOLING='$(PREFIX)/$(BUILD)/$(MXE_QT6_ID);$(PREFIX)/$(BUILD)/$(MXE_QT6_ID)/bin;$(PREFIX)/$(BUILD)/$(MXE_QT6_ID)/lib/cmake'
+
+define $(PKG)_BUILD
+    # kf6-conf is a configuration package, no build needed
+endef

--- a/src/kf/kf6/kf6-extra-cmake-modules.mk
+++ b/src/kf/kf6/kf6-extra-cmake-modules.mk
@@ -1,0 +1,31 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+include src/kf/kf6/kf6-conf.mk
+
+PKG              := kf6-extra-cmake-modules
+$(eval $(call KF6_METADATA))
+
+$(PKG)_CHECKSUM  := a32e24b267e8528d0253bc8df18bdc00e676560a43b796533e1b1406f4eef4db
+$(PKG)_DEPS     := kf6-conf
+$(PKG)_TARGETS  := $(BUILD) $(MXE_TARGETS)
+$(PKG)_IGNORE   := 
+
+define $(PKG)_BUILD_$(BUILD)
+    '$(TARGET)-cmake' -S '$(SOURCE_DIR)' -B '$(BUILD_DIR)' \
+        -G Ninja \
+        -DCMAKE_INSTALL_PREFIX='$(PREFIX)/$(TARGET)/$(MXE_QT6_ID)' \
+        -DBUILD_TESTING=OFF \
+        -DKDE_INSTALL_USE_QT_SYS_PATHS=ON
+    
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --build . -j '$(JOBS)'
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --install .
+endef
+
+define $(PKG)_BUILD
+    # ECM needs to be installed, but it's just CMake scripts.
+    # We use the standard KF6_CMAKE wrapper.
+    $(KF6_CMAKE) -S '$(SOURCE_DIR)' -B '$(BUILD_DIR)'
+    
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --build . -j '$(JOBS)'
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --install .
+endef

--- a/src/kf/kf6/kf6-karchive.mk
+++ b/src/kf/kf6/kf6-karchive.mk
@@ -1,0 +1,19 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+include src/kf/kf6/kf6-conf.mk
+
+PKG              := kf6-karchive
+$(eval $(call KF6_METADATA))
+
+$(PKG)_CHECKSUM  := ff36137e6b171906b4bde4006558739c5d7771dc30b9a037b65e62b2674a1b13
+$(PKG)_DEPS      := kf6-conf kf6-extra-cmake-modules qt6-qtbase qt6-qttools zlib bzip2 xz zstd
+$(PKG)_DEPS_$(BUILD) := $(BUILD)~kf6-extra-cmake-modules $(BUILD)~qt6-qtbase $(BUILD)~qt6-qttools $(BUILD)~zlib $(BUILD)~zstd
+$(PKG)_TARGETS   := $(BUILD) $(MXE_TARGETS)
+$(PKG)_IGNORE    := 
+
+define $(PKG)_BUILD
+    $(KF6_CMAKE) -DWITH_OPENSSL=OFF -S '$(SOURCE_DIR)' -B '$(BUILD_DIR)'
+    
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --build . -j '$(JOBS)'
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --install .
+endef

--- a/src/kf/kf6/kf6-karchive.mk
+++ b/src/kf/kf6/kf6-karchive.mk
@@ -12,7 +12,7 @@ $(PKG)_TARGETS   := $(BUILD) $(MXE_TARGETS)
 $(PKG)_IGNORE    := 
 
 define $(PKG)_BUILD
-    $(KF6_CMAKE) -S '$(SOURCE_DIR)' -B '$(BUILD_DIR)'
+    $(KF6_CMAKE) -DWITH_OPENSSL=OFF -S '$(SOURCE_DIR)' -B '$(BUILD_DIR)'
     
     cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --build . -j '$(JOBS)'
     cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --install .

--- a/src/kf/kf6/kf6-karchive.mk
+++ b/src/kf/kf6/kf6-karchive.mk
@@ -1,0 +1,19 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+include src/kf/kf6/kf6-conf.mk
+
+PKG              := kf6-karchive
+$(eval $(call KF6_METADATA))
+
+$(PKG)_CHECKSUM  := ff36137e6b171906b4bde4006558739c5d7771dc30b9a037b65e62b2674a1b13
+$(PKG)_DEPS      := kf6-conf kf6-extra-cmake-modules qt6-qtbase qt6-qttools zlib bzip2 xz zstd
+$(PKG)_DEPS_$(BUILD) := $(BUILD)~kf6-extra-cmake-modules $(BUILD)~qt6-qtbase $(BUILD)~qt6-qttools $(BUILD)~zlib $(BUILD)~zstd
+$(PKG)_TARGETS   := $(BUILD) $(MXE_TARGETS)
+$(PKG)_IGNORE    := 
+
+define $(PKG)_BUILD
+    $(KF6_CMAKE) -S '$(SOURCE_DIR)' -B '$(BUILD_DIR)'
+    
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --build . -j '$(JOBS)'
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --install .
+endef

--- a/src/kf/kf6/kf6-kbookmarks.mk
+++ b/src/kf/kf6/kf6-kbookmarks.mk
@@ -6,7 +6,7 @@ PKG              := kf6-kbookmarks
 $(eval $(call KF6_METADATA))
 
 $(PKG)_CHECKSUM  := d7f4048860ef00bc5d135e284dc6b1307d03199c2c13020994b17e38e3741f5c
-$(PKG)_DEPS      := kf6-conf kf6-extra-cmake-modules qt6-qtbase kf6-kconfig kf6-kcoreaddons kf6-kwidgetsaddons
+$(PKG)_DEPS      := kf6-conf kf6-extra-cmake-modules qt6-qtbase qt6-qttools kf6-kconfig kf6-kcoreaddons kf6-kwidgetsaddons
 $(PKG)_TARGETS   := $(MXE_TARGETS)
 $(PKG)_IGNORE    := 
 

--- a/src/kf/kf6/kf6-kbookmarks.mk
+++ b/src/kf/kf6/kf6-kbookmarks.mk
@@ -1,0 +1,18 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+include src/kf/kf6/kf6-conf.mk
+
+PKG              := kf6-kbookmarks
+$(eval $(call KF6_METADATA))
+
+$(PKG)_CHECKSUM  := d7f4048860ef00bc5d135e284dc6b1307d03199c2c13020994b17e38e3741f5c
+$(PKG)_DEPS      := kf6-conf kf6-extra-cmake-modules qt6-qtbase qt6-qttools kf6-kconfig kf6-kcoreaddons kf6-kwidgetsaddons
+$(PKG)_TARGETS   := $(MXE_TARGETS)
+$(PKG)_IGNORE    := 
+
+define $(PKG)_BUILD
+    $(KF6_CMAKE) -S '$(SOURCE_DIR)' -B '$(BUILD_DIR)'
+    
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --build . -j '$(JOBS)'
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --install .
+endef

--- a/src/kf/kf6/kf6-kbookmarks.mk
+++ b/src/kf/kf6/kf6-kbookmarks.mk
@@ -1,0 +1,18 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+include src/kf/kf6/kf6-conf.mk
+
+PKG              := kf6-kbookmarks
+$(eval $(call KF6_METADATA))
+
+$(PKG)_CHECKSUM  := d7f4048860ef00bc5d135e284dc6b1307d03199c2c13020994b17e38e3741f5c
+$(PKG)_DEPS      := kf6-conf kf6-extra-cmake-modules qt6-qtbase kf6-kconfig kf6-kcoreaddons kf6-kwidgetsaddons
+$(PKG)_TARGETS   := $(MXE_TARGETS)
+$(PKG)_IGNORE    := 
+
+define $(PKG)_BUILD
+    $(KF6_CMAKE) -S '$(SOURCE_DIR)' -B '$(BUILD_DIR)'
+    
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --build . -j '$(JOBS)'
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --install .
+endef

--- a/src/kf/kf6/kf6-kcodecs.mk
+++ b/src/kf/kf6/kf6-kcodecs.mk
@@ -1,0 +1,18 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+include src/kf/kf6/kf6-conf.mk
+
+PKG              := kf6-kcodecs
+$(eval $(call KF6_METADATA))
+
+$(PKG)_CHECKSUM  := b0a9ae34b389c6460adad5323d21bb9e43638acb58da9685f8dc8d821c38a4d8
+$(PKG)_DEPS      := kf6-conf kf6-extra-cmake-modules qt6-qtbase
+$(PKG)_TARGETS   := $(MXE_TARGETS)
+$(PKG)_IGNORE    := 
+
+define $(PKG)_BUILD
+    $(KF6_CMAKE) -S '$(SOURCE_DIR)' -B '$(BUILD_DIR)'
+    
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --build . -j '$(JOBS)'
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --install .
+endef

--- a/src/kf/kf6/kf6-kcodecs.mk
+++ b/src/kf/kf6/kf6-kcodecs.mk
@@ -1,0 +1,18 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+include src/kf/kf6/kf6-conf.mk
+
+PKG              := kf6-kcodecs
+$(eval $(call KF6_METADATA))
+
+$(PKG)_CHECKSUM  := b0a9ae34b389c6460adad5323d21bb9e43638acb58da9685f8dc8d821c38a4d8
+$(PKG)_DEPS      := kf6-conf kf6-extra-cmake-modules qt6-qtbase qt6-qttools
+$(PKG)_TARGETS   := $(MXE_TARGETS)
+$(PKG)_IGNORE    := 
+
+define $(PKG)_BUILD
+    $(KF6_CMAKE) -S '$(SOURCE_DIR)' -B '$(BUILD_DIR)'
+    
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --build . -j '$(JOBS)'
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --install .
+endef

--- a/src/kf/kf6/kf6-kcodecs.mk
+++ b/src/kf/kf6/kf6-kcodecs.mk
@@ -6,7 +6,7 @@ PKG              := kf6-kcodecs
 $(eval $(call KF6_METADATA))
 
 $(PKG)_CHECKSUM  := b0a9ae34b389c6460adad5323d21bb9e43638acb58da9685f8dc8d821c38a4d8
-$(PKG)_DEPS      := kf6-conf kf6-extra-cmake-modules qt6-qtbase
+$(PKG)_DEPS      := kf6-conf kf6-extra-cmake-modules qt6-qtbase qt6-qttools
 $(PKG)_TARGETS   := $(MXE_TARGETS)
 $(PKG)_IGNORE    := 
 

--- a/src/kf/kf6/kf6-kcolorscheme.mk
+++ b/src/kf/kf6/kf6-kcolorscheme.mk
@@ -1,0 +1,18 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+include src/kf/kf6/kf6-conf.mk
+
+PKG              := kf6-kcolorscheme
+$(eval $(call KF6_METADATA))
+
+$(PKG)_CHECKSUM  := 129c98fd9ba3428cafbd7263557a9ea47c0d4f157b8a5f56b209a95dc9815e6a
+$(PKG)_DEPS      := kf6-conf kf6-extra-cmake-modules qt6-qtbase kf6-kconfig kf6-kguiaddons kf6-ki18n
+$(PKG)_TARGETS   := $(MXE_TARGETS)
+$(PKG)_IGNORE    := 
+
+define $(PKG)_BUILD
+    $(KF6_CMAKE) -S '$(SOURCE_DIR)' -B '$(BUILD_DIR)'
+    
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --build . -j '$(JOBS)'
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --install .
+endef

--- a/src/kf/kf6/kf6-kcompletion.mk
+++ b/src/kf/kf6/kf6-kcompletion.mk
@@ -1,0 +1,18 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+include src/kf/kf6/kf6-conf.mk
+
+PKG              := kf6-kcompletion
+$(eval $(call KF6_METADATA))
+
+$(PKG)_CHECKSUM  := 8aa9cbc36139adfa8e3b2c744cc94714afe154d21cef8a3a2d5f4d311be7cc3c
+$(PKG)_DEPS      := kf6-conf kf6-extra-cmake-modules qt6-qtbase qt6-qttools kf6-kconfig kf6-kwidgetsaddons kf6-kcodecs
+$(PKG)_TARGETS   := $(MXE_TARGETS)
+$(PKG)_IGNORE    := 
+
+define $(PKG)_BUILD
+    $(KF6_CMAKE) -S '$(SOURCE_DIR)' -B '$(BUILD_DIR)'
+    
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --build . -j '$(JOBS)'
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --install .
+endef

--- a/src/kf/kf6/kf6-kcompletion.mk
+++ b/src/kf/kf6/kf6-kcompletion.mk
@@ -6,7 +6,7 @@ PKG              := kf6-kcompletion
 $(eval $(call KF6_METADATA))
 
 $(PKG)_CHECKSUM  := 8aa9cbc36139adfa8e3b2c744cc94714afe154d21cef8a3a2d5f4d311be7cc3c
-$(PKG)_DEPS      := kf6-conf kf6-extra-cmake-modules qt6-qtbase kf6-kconfig kf6-kwidgetsaddons kf6-kcodecs
+$(PKG)_DEPS      := kf6-conf kf6-extra-cmake-modules qt6-qtbase qt6-qttools kf6-kconfig kf6-kwidgetsaddons kf6-kcodecs
 $(PKG)_TARGETS   := $(MXE_TARGETS)
 $(PKG)_IGNORE    := 
 

--- a/src/kf/kf6/kf6-kcompletion.mk
+++ b/src/kf/kf6/kf6-kcompletion.mk
@@ -1,0 +1,18 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+include src/kf/kf6/kf6-conf.mk
+
+PKG              := kf6-kcompletion
+$(eval $(call KF6_METADATA))
+
+$(PKG)_CHECKSUM  := 8aa9cbc36139adfa8e3b2c744cc94714afe154d21cef8a3a2d5f4d311be7cc3c
+$(PKG)_DEPS      := kf6-conf kf6-extra-cmake-modules qt6-qtbase kf6-kconfig kf6-kwidgetsaddons kf6-kcodecs
+$(PKG)_TARGETS   := $(MXE_TARGETS)
+$(PKG)_IGNORE    := 
+
+define $(PKG)_BUILD
+    $(KF6_CMAKE) -S '$(SOURCE_DIR)' -B '$(BUILD_DIR)'
+    
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --build . -j '$(JOBS)'
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --install .
+endef

--- a/src/kf/kf6/kf6-kconfig.mk
+++ b/src/kf/kf6/kf6-kconfig.mk
@@ -1,0 +1,19 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+include src/kf/kf6/kf6-conf.mk
+
+PKG              := kf6-kconfig
+$(eval $(call KF6_METADATA))
+
+$(PKG)_CHECKSUM  := 24e26e516b7904a26661eab7d2064bee1ac57165571e85b4da6020fd36f14322
+$(PKG)_DEPS      := kf6-conf kf6-extra-cmake-modules qt6-qtbase qt6-qtdeclarative qt6-qttools $(BUILD)~$(PKG)
+$(PKG)_DEPS_$(BUILD) := $(BUILD)~kf6-extra-cmake-modules $(BUILD)~qt6-qtbase $(BUILD)~qt6-qtdeclarative $(BUILD)~qt6-qttools
+$(PKG)_TARGETS   := $(BUILD) $(MXE_TARGETS)
+$(PKG)_IGNORE    := 
+
+define $(PKG)_BUILD
+    $(KF6_CMAKE) -S '$(SOURCE_DIR)' -B '$(BUILD_DIR)'
+    
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --build . -j '$(JOBS)'
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --install .
+endef

--- a/src/kf/kf6/kf6-kconfigwidgets.mk
+++ b/src/kf/kf6/kf6-kconfigwidgets.mk
@@ -1,0 +1,18 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+include src/kf/kf6/kf6-conf.mk
+
+PKG              := kf6-kconfigwidgets
+$(eval $(call KF6_METADATA))
+
+$(PKG)_CHECKSUM  := f795386fb06b8922325075a8fa9f817c3d25e04bbfdcf60b13ad714c7c54e987
+$(PKG)_DEPS      := kf6-conf kf6-extra-cmake-modules qt6-qtbase kf6-kcoreaddons kf6-kcodecs kf6-kconfig kf6-kguiaddons kf6-ki18n kf6-kwidgetsaddons kf6-kcolorscheme
+$(PKG)_TARGETS   := $(MXE_TARGETS)
+$(PKG)_IGNORE    := 
+
+define $(PKG)_BUILD
+    $(KF6_CMAKE) -S '$(SOURCE_DIR)' -B '$(BUILD_DIR)'
+    
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --build . -j '$(JOBS)'
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --install .
+endef

--- a/src/kf/kf6/kf6-kcoreaddons.mk
+++ b/src/kf/kf6/kf6-kcoreaddons.mk
@@ -1,0 +1,19 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+include src/kf/kf6/kf6-conf.mk
+
+PKG              := kf6-kcoreaddons
+$(eval $(call KF6_METADATA))
+
+$(PKG)_CHECKSUM  := a713febee2f43bc31986d6c27d846ccab556fc7bc7c1919c3a662495720b431a
+$(PKG)_DEPS      := kf6-conf kf6-extra-cmake-modules qt6-qtbase qt6-qtdeclarative qt6-qttools $(BUILD)~$(PKG)
+$(PKG)_DEPS_$(BUILD) := $(BUILD)~kf6-extra-cmake-modules $(BUILD)~qt6-qtbase $(BUILD)~qt6-qtdeclarative $(BUILD)~qt6-qttools
+$(PKG)_TARGETS   := $(BUILD) $(MXE_TARGETS)
+$(PKG)_IGNORE    := 
+
+define $(PKG)_BUILD
+    $(KF6_CMAKE) -S '$(SOURCE_DIR)' -B '$(BUILD_DIR)'
+    
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --build . -j '$(JOBS)'
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --install .
+endef

--- a/src/kf/kf6/kf6-kcrash.mk
+++ b/src/kf/kf6/kf6-kcrash.mk
@@ -1,0 +1,18 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+include src/kf/kf6/kf6-conf.mk
+
+PKG              := kf6-kcrash
+$(eval $(call KF6_METADATA))
+
+$(PKG)_CHECKSUM  := ddcc14c0c40e24f4c0dc04246b87d11b650e6fd8be2cb00e4f2cc2ee9e605702
+$(PKG)_DEPS      := kf6-conf kf6-extra-cmake-modules qt6-qtbase kf6-kcoreaddons
+$(PKG)_TARGETS   := $(MXE_TARGETS)
+$(PKG)_IGNORE    := 
+
+define $(PKG)_BUILD
+    $(KF6_CMAKE) -S '$(SOURCE_DIR)' -B '$(BUILD_DIR)'
+    
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --build . -j '$(JOBS)'
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --install .
+endef

--- a/src/kf/kf6/kf6-kcrash.mk
+++ b/src/kf/kf6/kf6-kcrash.mk
@@ -6,7 +6,7 @@ PKG              := kf6-kcrash
 $(eval $(call KF6_METADATA))
 
 $(PKG)_CHECKSUM  := ddcc14c0c40e24f4c0dc04246b87d11b650e6fd8be2cb00e4f2cc2ee9e605702
-$(PKG)_DEPS      := kf6-conf kf6-extra-cmake-modules qt6-qtbase kf6-kcoreaddons kf6-kwindowsystem
+$(PKG)_DEPS      := kf6-conf kf6-extra-cmake-modules qt6-qtbase kf6-kcoreaddons
 $(PKG)_TARGETS   := $(MXE_TARGETS)
 $(PKG)_IGNORE    := 
 

--- a/src/kf/kf6/kf6-kcrash.mk
+++ b/src/kf/kf6/kf6-kcrash.mk
@@ -1,0 +1,18 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+include src/kf/kf6/kf6-conf.mk
+
+PKG              := kf6-kcrash
+$(eval $(call KF6_METADATA))
+
+$(PKG)_CHECKSUM  := ddcc14c0c40e24f4c0dc04246b87d11b650e6fd8be2cb00e4f2cc2ee9e605702
+$(PKG)_DEPS      := kf6-conf kf6-extra-cmake-modules qt6-qtbase kf6-kcoreaddons kf6-kwindowsystem
+$(PKG)_TARGETS   := $(MXE_TARGETS)
+$(PKG)_IGNORE    := 
+
+define $(PKG)_BUILD
+    $(KF6_CMAKE) -S '$(SOURCE_DIR)' -B '$(BUILD_DIR)'
+    
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --build . -j '$(JOBS)'
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --install .
+endef

--- a/src/kf/kf6/kf6-kdbusaddons.mk
+++ b/src/kf/kf6/kf6-kdbusaddons.mk
@@ -1,0 +1,18 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+include src/kf/kf6/kf6-conf.mk
+
+PKG              := kf6-kdbusaddons
+$(eval $(call KF6_METADATA))
+
+$(PKG)_CHECKSUM  := 94ff8745ce65507986a05bffbab905bfd894936e8f53b4b6e2d9b3a96cb2d6f4
+$(PKG)_DEPS      := kf6-conf kf6-extra-cmake-modules qt6-qtbase qt6-qttools
+$(PKG)_TARGETS   := $(MXE_TARGETS)
+$(PKG)_IGNORE    := 
+
+define $(PKG)_BUILD
+    $(KF6_CMAKE) -S '$(SOURCE_DIR)' -B '$(BUILD_DIR)'
+    
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --build . -j '$(JOBS)'
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --install .
+endef

--- a/src/kf/kf6/kf6-kdbusaddons.mk
+++ b/src/kf/kf6/kf6-kdbusaddons.mk
@@ -6,7 +6,7 @@ PKG              := kf6-kdbusaddons
 $(eval $(call KF6_METADATA))
 
 $(PKG)_CHECKSUM  := 94ff8745ce65507986a05bffbab905bfd894936e8f53b4b6e2d9b3a96cb2d6f4
-$(PKG)_DEPS      := kf6-conf kf6-extra-cmake-modules qt6-qtbase
+$(PKG)_DEPS      := kf6-conf kf6-extra-cmake-modules qt6-qtbase qt6-qttools
 $(PKG)_TARGETS   := $(MXE_TARGETS)
 $(PKG)_IGNORE    := 
 

--- a/src/kf/kf6/kf6-kdbusaddons.mk
+++ b/src/kf/kf6/kf6-kdbusaddons.mk
@@ -1,0 +1,18 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+include src/kf/kf6/kf6-conf.mk
+
+PKG              := kf6-kdbusaddons
+$(eval $(call KF6_METADATA))
+
+$(PKG)_CHECKSUM  := 94ff8745ce65507986a05bffbab905bfd894936e8f53b4b6e2d9b3a96cb2d6f4
+$(PKG)_DEPS      := kf6-conf kf6-extra-cmake-modules qt6-qtbase
+$(PKG)_TARGETS   := $(MXE_TARGETS)
+$(PKG)_IGNORE    := 
+
+define $(PKG)_BUILD
+    $(KF6_CMAKE) -S '$(SOURCE_DIR)' -B '$(BUILD_DIR)'
+    
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --build . -j '$(JOBS)'
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --install .
+endef

--- a/src/kf/kf6/kf6-kdnssd.mk
+++ b/src/kf/kf6/kf6-kdnssd.mk
@@ -1,0 +1,18 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+include src/kf/kf6/kf6-conf.mk
+
+PKG              := kf6-kdnssd
+$(eval $(call KF6_METADATA))
+
+$(PKG)_CHECKSUM  := f4fe731aad56ae010c2b42f2bd56d4499339bb0839ae2251035132f1a3708df2
+$(PKG)_DEPS      := kf6-conf kf6-extra-cmake-modules qt6-qtbase qt6-qttools
+$(PKG)_TARGETS   := $(MXE_TARGETS)
+$(PKG)_IGNORE    := 
+
+define $(PKG)_BUILD
+    $(KF6_CMAKE) -S '$(SOURCE_DIR)' -B '$(BUILD_DIR)'
+    
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --build . -j '$(JOBS)'
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --install .
+endef

--- a/src/kf/kf6/kf6-kdnssd.mk
+++ b/src/kf/kf6/kf6-kdnssd.mk
@@ -1,0 +1,18 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+include src/kf/kf6/kf6-conf.mk
+
+PKG              := kf6-kdnssd
+$(eval $(call KF6_METADATA))
+
+$(PKG)_CHECKSUM  := f4fe731aad56ae010c2b42f2bd56d4499339bb0839ae2251035132f1a3708df2
+$(PKG)_DEPS      := kf6-conf kf6-extra-cmake-modules qt6-qtbase
+$(PKG)_TARGETS   := $(MXE_TARGETS)
+$(PKG)_IGNORE    := 
+
+define $(PKG)_BUILD
+    $(KF6_CMAKE) -S '$(SOURCE_DIR)' -B '$(BUILD_DIR)'
+    
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --build . -j '$(JOBS)'
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --install .
+endef

--- a/src/kf/kf6/kf6-kdnssd.mk
+++ b/src/kf/kf6/kf6-kdnssd.mk
@@ -6,7 +6,7 @@ PKG              := kf6-kdnssd
 $(eval $(call KF6_METADATA))
 
 $(PKG)_CHECKSUM  := f4fe731aad56ae010c2b42f2bd56d4499339bb0839ae2251035132f1a3708df2
-$(PKG)_DEPS      := kf6-conf kf6-extra-cmake-modules qt6-qtbase
+$(PKG)_DEPS      := kf6-conf kf6-extra-cmake-modules qt6-qtbase qt6-qttools
 $(PKG)_TARGETS   := $(MXE_TARGETS)
 $(PKG)_IGNORE    := 
 

--- a/src/kf/kf6/kf6-kdoctools-1-fixes.patch
+++ b/src/kf/kf6/kf6-kdoctools-1-fixes.patch
@@ -1,0 +1,64 @@
+This file is part of MXE. See LICENSE.md for licensing information.
+
+Contains ad hoc patches for cross building.
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Marco Borrini <borrinimarco74@gmail.com>
+Date: Tue, 4 Aug 2026 09:40:00 +0200
+Subject: [PATCH 1/1] Fix static build for libxml2/libxslt and KF6DocTools
+
+1. In static builds, libxml2 and libxslt headers require macros like
+   LIBXML_STATIC to avoid __imp_ decorations.
+2. KF6DocTools was hardcoded to build as a SHARED library. We remove
+   the SHARED keyword so it respects the BUILD_SHARED_LIBS property.
+3. CMake's FindLibXml2 and FindLibXslt drop static transitive deps
+   (like iconv and bcrypt). We inject them via pkg_check_modules.
+   NOTE: these additions must be guarded by WIN32 AND NOT BUILD_SHARED_LIBS
+   otherwise they break the native linux tool builds in MXE.
+
+diff -ur kdoctools-6.28.0/CMakeLists.txt kdoctools-6.28.0-new/CMakeLists.txt
+--- kdoctools-6.28.0/CMakeLists.txt	2026-07-03 12:54:45.000000000 +0200
++++ kdoctools-6.28.0-new/CMakeLists.txt	2026-08-04 11:57:29.216216828 +0200
+@@ -44,6 +44,10 @@
+ set(REQUIRED_QT_VERSION 6.9.0)
+ find_package(Qt6Core ${REQUIRED_QT_VERSION} REQUIRED NO_MODULE)
+ 
++if(WIN32 AND NOT BUILD_SHARED_LIBS)
++    add_definitions(-DLIBXML_STATIC -DLIBXSLT_STATIC -DLIBEXSLT_STATIC)
++endif()
++
+ # KF6 frameworks
+ if (NOT MEINPROC_NO_KARCHIVE)
+    find_package(KF6Archive ${KF_DEP_VERSION} REQUIRED)
+@@ -69,6 +73,19 @@
+                        PURPOSE "Required by the KDE help system to process DocBook XML"
+                       )
+ 
++if(WIN32 AND NOT BUILD_SHARED_LIBS)
++    find_package(PkgConfig QUIET)
++    if(PKG_CONFIG_FOUND)
++        pkg_check_modules(PC_LIBXML2 QUIET libxml-2.0)
++        pkg_check_modules(PC_LIBXSLT QUIET libxslt)
++        pkg_check_modules(PC_LIBEXSLT QUIET libexslt)
++        list(APPEND LIBXML2_LIBRARIES ${PC_LIBXML2_LIBRARIES})
++        list(APPEND LIBXSLT_LIBRARIES ${PC_LIBXSLT_LIBRARIES})
++        list(APPEND LIBXSLT_EXSLT_LIBRARIES ${PC_LIBEXSLT_LIBRARIES})
++    endif()
++endif()
++
++
+ if (NOT LIBXML2_XMLLINT_EXECUTABLE)
+    message(FATAL_ERROR "xmllint is required to process DocBook XML")
+ endif()
+diff -ur kdoctools-6.28.0/src/CMakeLists.txt kdoctools-6.28.0-new/src/CMakeLists.txt
+--- kdoctools-6.28.0/src/CMakeLists.txt	2026-07-03 12:54:45.000000000 +0200
++++ kdoctools-6.28.0-new/src/CMakeLists.txt	2026-08-04 11:57:29.216365545 +0200
+@@ -32,7 +32,7 @@
+ )
+ 
+ # needed by KIO, need to export it
+-add_library(KF6DocTools SHARED xslt.cpp xslt_kde.cpp ${kdoctoolslog_core_SRCS})
++add_library(KF6DocTools xslt.cpp xslt_kde.cpp ${kdoctoolslog_core_SRCS})
+ add_library(KF6::DocTools ALIAS KF6DocTools)
+ 
+ set_target_properties(KF6DocTools PROPERTIES

--- a/src/kf/kf6/kf6-kdoctools.mk
+++ b/src/kf/kf6/kf6-kdoctools.mk
@@ -1,0 +1,35 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+include src/kf/kf6/kf6-conf.mk
+
+PKG              := kf6-kdoctools
+$(eval $(call KF6_METADATA))
+
+$(PKG)_CHECKSUM  := 024914031fba7a9b79982d02736b21399d9a0d09ad81323d58e17d6b2216c7b0
+$(PKG)_DEPS      := kf6-conf kf6-extra-cmake-modules qt6-qtbase kf6-karchive kf6-ki18n gettext libxml2 libxslt docbook-xml docbook-xsl $(BUILD)~$(PKG)
+$(PKG)_DEPS_$(BUILD) := $(BUILD)~kf6-extra-cmake-modules $(BUILD)~qt6-qtbase $(BUILD)~kf6-karchive $(BUILD)~kf6-ki18n $(BUILD)~gettext $(BUILD)~libxml2 $(BUILD)~libxslt $(BUILD)~docbook-xml $(BUILD)~docbook-xsl
+$(PKG)_TARGETS   := $(BUILD) $(MXE_TARGETS)
+$(PKG)_IGNORE    := 
+
+define $(PKG)_BUILD_$(BUILD)
+    sed -i 's/NO_DEFAULT_PATH/NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH/g' '$(SOURCE_DIR)/KF6DocToolsConfig.cmake.in'
+    $(KF6_CMAKE) -S '$(SOURCE_DIR)' -B '$(BUILD_DIR)' \
+        -DDocBookXML4_DTD_DIR='$(PREFIX)/$(TARGET)/share/xml/docbook/schema/dtd/4.5' \
+        -DDocBookXSL_DIR='$(PREFIX)/$(TARGET)/share/xml/docbook/xsl-stylesheets' \
+        -DINSTALL_INTERNAL_TOOLS=ON
+    
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --build . -j '$(JOBS)'
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --install .
+endef
+
+define $(PKG)_BUILD
+    sed -i 's/NO_DEFAULT_PATH/NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH/g' '$(SOURCE_DIR)/KF6DocToolsConfig.cmake.in'
+    $(KF6_CMAKE) -S '$(SOURCE_DIR)' -B '$(BUILD_DIR)' \
+        -DDocBookXML4_DTD_DIR='$(PREFIX)/$(TARGET)/share/xml/docbook/schema/dtd/4.5' \
+        -DDocBookXSL_DIR='$(PREFIX)/$(TARGET)/share/xml/docbook/xsl-stylesheets' \
+        -DMEINPROC6_EXECUTABLE='$(PREFIX)/$(BUILD)/qt6/bin/meinproc6' \
+        -DDOCBOOKL10NHELPER_EXECUTABLE='$(PREFIX)/$(BUILD)/qt6/bin/docbookl10nhelper'
+    
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --build . -j '$(JOBS)'
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --install .
+endef

--- a/src/kf/kf6/kf6-kguiaddons.mk
+++ b/src/kf/kf6/kf6-kguiaddons.mk
@@ -1,0 +1,18 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+include src/kf/kf6/kf6-conf.mk
+
+PKG              := kf6-kguiaddons
+$(eval $(call KF6_METADATA))
+
+$(PKG)_CHECKSUM  := f46aeca80707e774fcffe8aa82e464a81056ce84f613347a5c9cc24c1c9a8432
+$(PKG)_DEPS      := kf6-conf kf6-extra-cmake-modules qt6-qtbase
+$(PKG)_TARGETS   := $(MXE_TARGETS)
+$(PKG)_IGNORE    := 
+
+define $(PKG)_BUILD
+    $(KF6_CMAKE) -S '$(SOURCE_DIR)' -B '$(BUILD_DIR)'
+    
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --build . -j '$(JOBS)'
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --install .
+endef

--- a/src/kf/kf6/kf6-ki18n.mk
+++ b/src/kf/kf6/kf6-ki18n.mk
@@ -1,0 +1,19 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+include src/kf/kf6/kf6-conf.mk
+
+PKG              := kf6-ki18n
+$(eval $(call KF6_METADATA))
+
+$(PKG)_CHECKSUM  := 820ce5858c6db732d68da53572a0e7db8353e4372d2122debcfb0f9ff10b85db
+$(PKG)_DEPS      := kf6-conf kf6-extra-cmake-modules qt6-qtbase qt6-qtdeclarative gettext $(BUILD)~$(PKG)
+$(PKG)_DEPS_$(BUILD) := $(BUILD)~kf6-extra-cmake-modules $(BUILD)~qt6-qtbase $(BUILD)~qt6-qtdeclarative $(BUILD)~gettext
+$(PKG)_TARGETS   := $(BUILD) $(MXE_TARGETS)
+$(PKG)_IGNORE    := 
+
+define $(PKG)_BUILD
+    $(KF6_CMAKE) -S '$(SOURCE_DIR)' -B '$(BUILD_DIR)'
+    
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --build . -j '$(JOBS)'
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --install .
+endef

--- a/src/kf/kf6/kf6-kiconthemes-1-fixes.patch
+++ b/src/kf/kf6/kf6-kiconthemes-1-fixes.patch
@@ -1,0 +1,27 @@
+This file is part of MXE. See LICENSE.md for licensing information.
+
+Contains ad hoc patches for cross building.
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Marco Borrini <borrinimarco74@gmail.com>
+Date: Tue, 4 Aug 2026 12:56:00 +0200
+Subject: [PATCH 1/1] Fix static build for KIconEnginePlugin
+
+Remove the hardcoded MODULE library type for KIconEnginePlugin, which
+causes the plugin to be built as a shared library even in static builds.
+This leads to "export ordinal too large" errors when linking statically
+against the entirety of Qt6 on Windows. Removing it allows CMake to follow
+the BUILD_SHARED_LIBS property.
+
+diff -ur kiconthemes-6.28.0/src/CMakeLists.txt kiconthemes-6.28.0-new/src/CMakeLists.txt
+--- kiconthemes-6.28.0/src/CMakeLists.txt	2026-07-03 12:55:38.000000000 +0200
++++ kiconthemes-6.28.0-new/src/CMakeLists.txt	2026-08-04 12:55:43.134419329 +0200
+@@ -102,7 +102,7 @@
+ )
+ 
+ if(NOT IOS)
+-    add_library(KIconEnginePlugin MODULE kiconengineplugin.cpp)
++    add_library(KIconEnginePlugin kiconengineplugin.cpp)
+     target_link_libraries(KIconEnginePlugin
+         PRIVATE
+             Qt6::Gui

--- a/src/kf/kf6/kf6-kiconthemes.mk
+++ b/src/kf/kf6/kf6-kiconthemes.mk
@@ -1,0 +1,18 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+include src/kf/kf6/kf6-conf.mk
+
+PKG              := kf6-kiconthemes
+$(eval $(call KF6_METADATA))
+
+$(PKG)_CHECKSUM  := edf83069f25f8edf759d07502a6f8302c8c064cd562651deedefe6393fefcace
+$(PKG)_DEPS      := kf6-conf kf6-extra-cmake-modules qt6-qtbase qt6-qtsvg kf6-karchive kf6-ki18n kf6-kcolorscheme kf6-kwidgetsaddons kf6-breeze-icons
+$(PKG)_TARGETS   := $(MXE_TARGETS)
+$(PKG)_IGNORE    := 
+
+define $(PKG)_BUILD
+    $(KF6_CMAKE) -S '$(SOURCE_DIR)' -B '$(BUILD_DIR)'
+    
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --build . -j '$(JOBS)'
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --install .
+endef

--- a/src/kf/kf6/kf6-kio.mk
+++ b/src/kf/kf6/kf6-kio.mk
@@ -1,0 +1,18 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+include src/kf/kf6/kf6-conf.mk
+
+PKG              := kf6-kio
+$(eval $(call KF6_METADATA))
+
+$(PKG)_CHECKSUM  := 158f47746806c3dd87a09091eaa46ffee286cd658f9e26b4422656b66176627a
+$(PKG)_DEPS      := kf6-conf kf6-extra-cmake-modules qt6-qtbase qt6-qtdeclarative kf6-karchive kf6-kconfig kf6-kcoreaddons kf6-kcrash kf6-kdbusaddons kf6-ki18n kf6-kservice kf6-solid kf6-kbookmarks kf6-kcolorscheme kf6-kcompletion kf6-kguiaddons kf6-kiconthemes kf6-kitemviews kf6-kjobwidgets kf6-kwidgetsaddons kf6-kwindowsystem
+$(PKG)_TARGETS   := $(MXE_TARGETS)
+$(PKG)_IGNORE    := 
+
+define $(PKG)_BUILD
+    $(KF6_CMAKE) -S '$(SOURCE_DIR)' -B '$(BUILD_DIR)'
+    
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --build . -j '$(JOBS)'
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --install .
+endef

--- a/src/kf/kf6/kf6-kio.mk
+++ b/src/kf/kf6/kf6-kio.mk
@@ -1,0 +1,18 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+include src/kf/kf6/kf6-conf.mk
+
+PKG              := kf6-kio
+$(eval $(call KF6_METADATA))
+
+$(PKG)_CHECKSUM  := 158f47746806c3dd87a09091eaa46ffee286cd658f9e26b4422656b66176627a
+$(PKG)_DEPS      := kf6-conf kf6-extra-cmake-modules qt6-qtbase qt6-qtdeclarative kf6-kconfig kf6-kcoreaddons kf6-kcrash kf6-ki18n kf6-kservice kf6-solid kf6-kbookmarks kf6-kcolorscheme kf6-kcompletion kf6-kguiaddons kf6-kiconthemes kf6-kitemviews kf6-kjobwidgets kf6-kwidgetsaddons kf6-kwindowsystem
+$(PKG)_TARGETS   := $(MXE_TARGETS)
+$(PKG)_IGNORE    := 
+
+define $(PKG)_BUILD
+    $(KF6_CMAKE) -DUSE_DBUS=OFF -S '$(SOURCE_DIR)' -B '$(BUILD_DIR)'
+    
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --build . -j '$(JOBS)'
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --install .
+endef

--- a/src/kf/kf6/kf6-kio.mk
+++ b/src/kf/kf6/kf6-kio.mk
@@ -6,12 +6,12 @@ PKG              := kf6-kio
 $(eval $(call KF6_METADATA))
 
 $(PKG)_CHECKSUM  := 158f47746806c3dd87a09091eaa46ffee286cd658f9e26b4422656b66176627a
-$(PKG)_DEPS      := kf6-conf kf6-extra-cmake-modules qt6-qtbase qt6-qtdeclarative kf6-karchive kf6-kconfig kf6-kcoreaddons kf6-kcrash kf6-kdbusaddons kf6-ki18n kf6-kservice kf6-solid kf6-kbookmarks kf6-kcolorscheme kf6-kcompletion kf6-kguiaddons kf6-kiconthemes kf6-kitemviews kf6-kjobwidgets kf6-kwidgetsaddons kf6-kwindowsystem
+$(PKG)_DEPS      := kf6-conf kf6-extra-cmake-modules qt6-qtbase qt6-qtdeclarative kf6-kconfig kf6-kcoreaddons kf6-kcrash kf6-ki18n kf6-kservice kf6-solid kf6-kbookmarks kf6-kcolorscheme kf6-kcompletion kf6-kguiaddons kf6-kiconthemes kf6-kitemviews kf6-kjobwidgets kf6-kwidgetsaddons kf6-kwindowsystem
 $(PKG)_TARGETS   := $(MXE_TARGETS)
 $(PKG)_IGNORE    := 
 
 define $(PKG)_BUILD
-    $(KF6_CMAKE) -S '$(SOURCE_DIR)' -B '$(BUILD_DIR)'
+    $(KF6_CMAKE) -DUSE_DBUS=OFF -S '$(SOURCE_DIR)' -B '$(BUILD_DIR)'
     
     cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --build . -j '$(JOBS)'
     cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --install .

--- a/src/kf/kf6/kf6-kirigami.mk
+++ b/src/kf/kf6/kf6-kirigami.mk
@@ -1,0 +1,18 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+include src/kf/kf6/kf6-conf.mk
+
+PKG              := kf6-kirigami
+$(eval $(call KF6_METADATA))
+
+$(PKG)_CHECKSUM  := 30fc6bd928a7124ace334944c8b45748603d37e45464db874903d7eb91f41d36
+$(PKG)_DEPS      := kf6-conf kf6-extra-cmake-modules qt6-qtbase qt6-qttools qt6-qtdeclarative qt6-qtsvg qt6-qtshadertools
+$(PKG)_TARGETS   := $(MXE_TARGETS)
+$(PKG)_IGNORE    := 
+
+define $(PKG)_BUILD
+    $(KF6_CMAKE) -S '$(SOURCE_DIR)' -B '$(BUILD_DIR)'
+    
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --build . -j '$(JOBS)'
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --install .
+endef

--- a/src/kf/kf6/kf6-kirigami.mk
+++ b/src/kf/kf6/kf6-kirigami.mk
@@ -6,7 +6,7 @@ PKG              := kf6-kirigami
 $(eval $(call KF6_METADATA))
 
 $(PKG)_CHECKSUM  := 30fc6bd928a7124ace334944c8b45748603d37e45464db874903d7eb91f41d36
-$(PKG)_DEPS      := kf6-conf kf6-extra-cmake-modules qt6-qtbase qt6-qtdeclarative qt6-qtsvg qt6-qtshadertools
+$(PKG)_DEPS      := kf6-conf kf6-extra-cmake-modules qt6-qtbase qt6-qttools qt6-qtdeclarative qt6-qtsvg qt6-qtshadertools
 $(PKG)_TARGETS   := $(MXE_TARGETS)
 $(PKG)_IGNORE    := 
 

--- a/src/kf/kf6/kf6-kirigami.mk
+++ b/src/kf/kf6/kf6-kirigami.mk
@@ -1,0 +1,18 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+include src/kf/kf6/kf6-conf.mk
+
+PKG              := kf6-kirigami
+$(eval $(call KF6_METADATA))
+
+$(PKG)_CHECKSUM  := 30fc6bd928a7124ace334944c8b45748603d37e45464db874903d7eb91f41d36
+$(PKG)_DEPS      := kf6-conf kf6-extra-cmake-modules qt6-qtbase qt6-qtdeclarative qt6-qtsvg qt6-qtshadertools
+$(PKG)_TARGETS   := $(MXE_TARGETS)
+$(PKG)_IGNORE    := 
+
+define $(PKG)_BUILD
+    $(KF6_CMAKE) -S '$(SOURCE_DIR)' -B '$(BUILD_DIR)'
+    
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --build . -j '$(JOBS)'
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --install .
+endef

--- a/src/kf/kf6/kf6-kitemviews.mk
+++ b/src/kf/kf6/kf6-kitemviews.mk
@@ -1,0 +1,18 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+include src/kf/kf6/kf6-conf.mk
+
+PKG              := kf6-kitemviews
+$(eval $(call KF6_METADATA))
+
+$(PKG)_CHECKSUM  := 2b474a0a0ca1d59111ab864d4f05100e0056b5204d52dfbab6776ca0fbfdd402
+$(PKG)_DEPS      := kf6-conf kf6-extra-cmake-modules qt6-qtbase qt6-qttools
+$(PKG)_TARGETS   := $(MXE_TARGETS)
+$(PKG)_IGNORE    := 
+
+define $(PKG)_BUILD
+    $(KF6_CMAKE) -S '$(SOURCE_DIR)' -B '$(BUILD_DIR)'
+    
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --build . -j '$(JOBS)'
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --install .
+endef

--- a/src/kf/kf6/kf6-kitemviews.mk
+++ b/src/kf/kf6/kf6-kitemviews.mk
@@ -1,0 +1,18 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+include src/kf/kf6/kf6-conf.mk
+
+PKG              := kf6-kitemviews
+$(eval $(call KF6_METADATA))
+
+$(PKG)_CHECKSUM  := 2b474a0a0ca1d59111ab864d4f05100e0056b5204d52dfbab6776ca0fbfdd402
+$(PKG)_DEPS      := kf6-conf kf6-extra-cmake-modules qt6-qtbase
+$(PKG)_TARGETS   := $(MXE_TARGETS)
+$(PKG)_IGNORE    := 
+
+define $(PKG)_BUILD
+    $(KF6_CMAKE) -S '$(SOURCE_DIR)' -B '$(BUILD_DIR)'
+    
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --build . -j '$(JOBS)'
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --install .
+endef

--- a/src/kf/kf6/kf6-kitemviews.mk
+++ b/src/kf/kf6/kf6-kitemviews.mk
@@ -6,7 +6,7 @@ PKG              := kf6-kitemviews
 $(eval $(call KF6_METADATA))
 
 $(PKG)_CHECKSUM  := 2b474a0a0ca1d59111ab864d4f05100e0056b5204d52dfbab6776ca0fbfdd402
-$(PKG)_DEPS      := kf6-conf kf6-extra-cmake-modules qt6-qtbase
+$(PKG)_DEPS      := kf6-conf kf6-extra-cmake-modules qt6-qtbase qt6-qttools
 $(PKG)_TARGETS   := $(MXE_TARGETS)
 $(PKG)_IGNORE    := 
 

--- a/src/kf/kf6/kf6-kjobwidgets-1-fixes.patch
+++ b/src/kf/kf6/kf6-kjobwidgets-1-fixes.patch
@@ -1,0 +1,25 @@
+This file is part of MXE. See LICENSE.md for licensing information.
+
+Contains ad hoc patches for cross building.
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Marco Borrini <borrinimarco74@gmail.com>
+Date: Tue, 4 Aug 2026 15:42:00 +0200
+Subject: [PATCH 1/1] Add missing find_dependency in KF6JobWidgetsConfig
+
+When building statically, the CMake targets explicitly declare link
+dependencies on KF6Notifications and KF6WidgetsAddons. However, these
+packages are not searched for in the Config file. This breaks static
+builds of consumers like KIO which cannot find the targets.
+
+diff -ur kjobwidgets-6.28.0/KF6JobWidgetsConfig.cmake.in kjobwidgets-6.28.0-new/KF6JobWidgetsConfig.cmake.in
+--- kjobwidgets-6.28.0/KF6JobWidgetsConfig.cmake.in	2026-07-03 12:57:25.000000000 +0200
++++ kjobwidgets-6.28.0-new/KF6JobWidgetsConfig.cmake.in	2026-08-04 15:42:42.260054744 +0200
+@@ -5,5 +5,7 @@
+ include(CMakeFindDependencyMacro)
+ find_dependency(Qt6Widgets @REQUIRED_QT_VERSION@)
+ find_dependency(KF6CoreAddons "@KF_DEP_VERSION@")
++find_dependency(KF6Notifications "@KF_DEP_VERSION@")
++find_dependency(KF6WidgetsAddons "@KF_DEP_VERSION@")
+ 
+ include("${CMAKE_CURRENT_LIST_DIR}/KF6JobWidgetsTargets.cmake")

--- a/src/kf/kf6/kf6-kjobwidgets.mk
+++ b/src/kf/kf6/kf6-kjobwidgets.mk
@@ -6,7 +6,7 @@ PKG              := kf6-kjobwidgets
 $(eval $(call KF6_METADATA))
 
 $(PKG)_CHECKSUM  := a13fcc9c861a90a540e5f93028fa7fae48f4c8643dadd287f3d54f5f24fab3da
-$(PKG)_DEPS      := kf6-conf kf6-extra-cmake-modules qt6-qtbase kf6-kcoreaddons kf6-knotifications kf6-kwidgetsaddons
+$(PKG)_DEPS      := kf6-conf kf6-extra-cmake-modules qt6-qtbase qt6-qttools kf6-kcoreaddons kf6-knotifications kf6-kwidgetsaddons
 $(PKG)_TARGETS   := $(MXE_TARGETS)
 $(PKG)_IGNORE    := 
 

--- a/src/kf/kf6/kf6-kjobwidgets.mk
+++ b/src/kf/kf6/kf6-kjobwidgets.mk
@@ -1,0 +1,18 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+include src/kf/kf6/kf6-conf.mk
+
+PKG              := kf6-kjobwidgets
+$(eval $(call KF6_METADATA))
+
+$(PKG)_CHECKSUM  := a13fcc9c861a90a540e5f93028fa7fae48f4c8643dadd287f3d54f5f24fab3da
+$(PKG)_DEPS      := kf6-conf kf6-extra-cmake-modules qt6-qtbase kf6-kcoreaddons kf6-knotifications kf6-kwidgetsaddons
+$(PKG)_TARGETS   := $(MXE_TARGETS)
+$(PKG)_IGNORE    := 
+
+define $(PKG)_BUILD
+    $(KF6_CMAKE) -S '$(SOURCE_DIR)' -B '$(BUILD_DIR)'
+    
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --build . -j '$(JOBS)'
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --install .
+endef

--- a/src/kf/kf6/kf6-kjobwidgets.mk
+++ b/src/kf/kf6/kf6-kjobwidgets.mk
@@ -1,0 +1,18 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+include src/kf/kf6/kf6-conf.mk
+
+PKG              := kf6-kjobwidgets
+$(eval $(call KF6_METADATA))
+
+$(PKG)_CHECKSUM  := a13fcc9c861a90a540e5f93028fa7fae48f4c8643dadd287f3d54f5f24fab3da
+$(PKG)_DEPS      := kf6-conf kf6-extra-cmake-modules qt6-qtbase qt6-qttools kf6-kcoreaddons kf6-knotifications kf6-kwidgetsaddons
+$(PKG)_TARGETS   := $(MXE_TARGETS)
+$(PKG)_IGNORE    := 
+
+define $(PKG)_BUILD
+    $(KF6_CMAKE) -S '$(SOURCE_DIR)' -B '$(BUILD_DIR)'
+    
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --build . -j '$(JOBS)'
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --install .
+endef

--- a/src/kf/kf6/kf6-knewstuff-1-fixes.patch
+++ b/src/kf/kf6/kf6-knewstuff-1-fixes.patch
@@ -1,0 +1,79 @@
+This file is part of MXE. See LICENSE.md for licensing information.
+
+Contains ad hoc patches for cross building.
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Marco Borrini <borrinimarco74@gmail.com>
+Date: Tue, 4 Aug 2026 16:07:00 +0200
+Subject: [PATCH 1/1] Fix static build missing dependencies and linker order
+
+KF6NewStuffCore links privately to the internal convenience library
+knscore_jobs_static. In a static build, this requires knscore_jobs_static
+to be exported alongside KF6NewStuffCore in its EXPORT set so that CMake
+can resolve the target during linking of consumers.
+
+Also, knewstuff_qml_STATIC explicitly links Qt6::Qml but uses classes
+from Qt6Quick. Because it didn't explicitly link Qt6::Quick, the static
+linker command line evaluated Qt6::Qml *before* Qt6::Quick, leading to
+undefined references inside Qt6Quick for Qml symbols. Explicitly adding
+Qt6::Quick to its dependencies fixes the linker ordering in static builds.
+
+Additionally, KF6NewStuffWidgets links to Qt6QuickWidgets, so this
+must be advertised in KF6NewStuffConfig.cmake.in for static builds.
+
+diff -ur knewstuff-6.28.0/KF6NewStuffConfig.cmake.in knewstuff-6.28.0-new/KF6NewStuffConfig.cmake.in
+--- knewstuff-6.28.0/KF6NewStuffConfig.cmake.in	2026-07-03 12:57:46.000000000 +0200
++++ knewstuff-6.28.0-new/KF6NewStuffConfig.cmake.in	2026-08-04 16:48:01.143794463 +0200
+@@ -11,6 +11,7 @@
+ if (NOT @BUILD_SHARED_LIBS@)
+     find_dependency(Qt6Qml @REQUIRED_QT_VERSION@)
+     find_dependency(Qt6Quick @REQUIRED_QT_VERSION@)
++    find_dependency(Qt6QuickWidgets @REQUIRED_QT_VERSION@)
+ 
+     find_dependency(KF6I18n "@KF_DEP_VERSION@")
+ endif()
+diff -ur knewstuff-6.28.0/src/core/CMakeLists.txt knewstuff-6.28.0-new/src/core/CMakeLists.txt
+--- knewstuff-6.28.0/src/core/CMakeLists.txt	2026-07-03 12:57:46.000000000 +0200
++++ knewstuff-6.28.0-new/src/core/CMakeLists.txt	2026-08-04 16:07:53.041334111 +0200
+@@ -149,7 +149,7 @@
+   REQUIRED_HEADERS KNewStuffCore_HEADERS
+ )
+ 
+-install(TARGETS KF6NewStuffCore EXPORT KF6NewStuffCoreTargets ${KF_INSTALL_TARGETS_DEFAULT_ARGS})
++install(TARGETS KF6NewStuffCore knscore_jobs_static EXPORT KF6NewStuffCoreTargets ${KF_INSTALL_TARGETS_DEFAULT_ARGS})
+ 
+ install(
+     FILES
+diff -ur knewstuff-6.28.0/src/qtquick/CMakeLists.txt knewstuff-6.28.0-new/src/qtquick/CMakeLists.txt
+--- knewstuff-6.28.0/src/qtquick/CMakeLists.txt	2026-07-03 12:57:46.000000000 +0200
++++ knewstuff-6.28.0-new/src/qtquick/CMakeLists.txt	2026-08-04 16:18:43.636126053 +0200
+@@ -26,6 +26,7 @@
+ target_link_libraries(knewstuff_qml_STATIC PUBLIC
+     Qt6::Core
+     Qt6::Gui # QImage
++    Qt6::Quick
+     Qt6::Qml
+     KF6::ConfigCore
+     KF6::I18n
+@@ -76,7 +77,7 @@
+     qml/private/entrygriddelegates/TileDelegate.qml
+ )
+ 
+-target_link_libraries (newstuffqmlplugin PRIVATE knewstuff_qml_STATIC)
++target_link_libraries (newstuffqmlplugin PRIVATE knewstuff_qml_STATIC Qt6::Qml Qt6::QmlModels)
+ 
+ ecm_finalize_qml_module(newstuffqmlplugin DESTINATION ${KDE_INSTALL_QMLDIR})
+ 
+diff -ur knewstuff-6.28.0/src/tools/knewstuff-dialog/CMakeLists.txt knewstuff-6.28.0-new/src/tools/knewstuff-dialog/CMakeLists.txt
+--- knewstuff-6.28.0/src/tools/knewstuff-dialog/CMakeLists.txt	2026-07-03 12:57:46.000000000 +0200
++++ knewstuff-6.28.0-new/src/tools/knewstuff-dialog/CMakeLists.txt	2026-08-04 16:21:07.556710776 +0200
+@@ -14,8 +14,8 @@
+     Qt6::Core
+     Qt6::Gui
+     Qt6::Widgets
+-    Qt6::Qml
+     Qt6::Quick
++    Qt6::Qml
+     KF6::ConfigCore
+     KF6::I18n
+     KF6::NewStuffCore

--- a/src/kf/kf6/kf6-knewstuff.mk
+++ b/src/kf/kf6/kf6-knewstuff.mk
@@ -1,0 +1,18 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+include src/kf/kf6/kf6-conf.mk
+
+PKG              := kf6-knewstuff
+$(eval $(call KF6_METADATA))
+
+$(PKG)_CHECKSUM  := dc479d74def4e2d3e96f320f19285dcf88ec3ec6d39229f14ecb362983e305bd
+$(PKG)_DEPS      := kf6-conf kf6-extra-cmake-modules qt6-qtbase qt6-qtdeclarative kf6-karchive kf6-kconfig kf6-kcoreaddons kf6-ki18n kf6-kpackage kf6-kwidgetsaddons kf6-attica kf6-kirigami kf6-syndication
+$(PKG)_TARGETS   := $(MXE_TARGETS)
+$(PKG)_IGNORE    := 
+
+define $(PKG)_BUILD
+    $(KF6_CMAKE) -S '$(SOURCE_DIR)' -B '$(BUILD_DIR)'
+    
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --build . -j '$(JOBS)'
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --install .
+endef

--- a/src/kf/kf6/kf6-knotifications.mk
+++ b/src/kf/kf6/kf6-knotifications.mk
@@ -1,0 +1,19 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+include src/kf/kf6/kf6-conf.mk
+
+PKG              := kf6-knotifications
+$(eval $(call KF6_METADATA))
+
+$(PKG)_CHECKSUM  := e5d3b284ccc907f190d3ab10995a0ae7fa0f505088acc69edc7adfcc6a8140d6
+$(PKG)_DEPS      := kf6-conf kf6-extra-cmake-modules qt6-qtbase qt6-qtdeclarative kf6-kconfig canberra
+$(PKG)_TARGETS   := $(MXE_TARGETS)
+$(PKG)_IGNORE    := 
+
+define $(PKG)_BUILD
+    $(KF6_CMAKE) -S '$(SOURCE_DIR)' -B '$(BUILD_DIR)' \
+        -DWITH_SNORETOAST=OFF
+    
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --build . -j '$(JOBS)'
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --install .
+endef

--- a/src/kf/kf6/kf6-knotifications.mk
+++ b/src/kf/kf6/kf6-knotifications.mk
@@ -1,0 +1,19 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+include src/kf/kf6/kf6-conf.mk
+
+PKG              := kf6-knotifications
+$(eval $(call KF6_METADATA))
+
+$(PKG)_CHECKSUM  := e5d3b284ccc907f190d3ab10995a0ae7fa0f505088acc69edc7adfcc6a8140d6
+$(PKG)_DEPS      := kf6-conf kf6-extra-cmake-modules qt6-qtbase qt6-qttools qt6-qtdeclarative kf6-kconfig canberra
+$(PKG)_TARGETS   := $(MXE_TARGETS)
+$(PKG)_IGNORE    := 
+
+define $(PKG)_BUILD
+    $(KF6_CMAKE) -S '$(SOURCE_DIR)' -B '$(BUILD_DIR)' \
+        -DWITH_SNORETOAST=OFF
+    
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --build . -j '$(JOBS)'
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --install .
+endef

--- a/src/kf/kf6/kf6-knotifications.mk
+++ b/src/kf/kf6/kf6-knotifications.mk
@@ -6,7 +6,7 @@ PKG              := kf6-knotifications
 $(eval $(call KF6_METADATA))
 
 $(PKG)_CHECKSUM  := e5d3b284ccc907f190d3ab10995a0ae7fa0f505088acc69edc7adfcc6a8140d6
-$(PKG)_DEPS      := kf6-conf kf6-extra-cmake-modules qt6-qtbase qt6-qtdeclarative kf6-kconfig canberra
+$(PKG)_DEPS      := kf6-conf kf6-extra-cmake-modules qt6-qtbase qt6-qttools qt6-qtdeclarative kf6-kconfig canberra
 $(PKG)_TARGETS   := $(MXE_TARGETS)
 $(PKG)_IGNORE    := 
 

--- a/src/kf/kf6/kf6-kpackage-1-fixes.patch
+++ b/src/kf/kf6/kf6-kpackage-1-fixes.patch
@@ -1,0 +1,25 @@
+This file is part of MXE. See LICENSE.md for licensing information.
+
+Contains ad hoc patches for cross building.
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Marco Borrini <borrinimarco74@gmail.com>
+Date: Tue, 4 Aug 2026 15:51:00 +0200
+Subject: [PATCH 1/1] Remove legacy kpackage_common_STATIC install target
+
+KF6Package refactored its targets and no longer builds a separate
+kpackage_common_STATIC target. However, the static build install rules
+erroneously still attempted to install it, causing CMake configuration
+to fail during static builds.
+
+diff -ur kpackage-6.28.0/src/kpackage/CMakeLists.txt kpackage-6.28.0-new/src/kpackage/CMakeLists.txt
+--- kpackage-6.28.0/src/kpackage/CMakeLists.txt	2026-07-03 12:58:54.000000000 +0200
++++ kpackage-6.28.0-new/src/kpackage/CMakeLists.txt	2026-08-04 15:51:16.887234409 +0200
+@@ -87,6 +87,4 @@
+         DESTINATION ${KDE_INSTALL_INCLUDEDIR_KF}/KPackage/KPackage COMPONENT Devel)
+ 
+ install(TARGETS KF6Package EXPORT KF6PackageTargets ${KF_INSTALL_TARGETS_DEFAULT_ARGS})
+-if (NOT BUILD_SHARED_LIBS)
+-    install(TARGETS kpackage_common_STATIC EXPORT KF6PackageTargets ${KF_INSTALL_TARGETS_DEFAULT_ARGS})
+-endif()
++

--- a/src/kf/kf6/kf6-kpackage.mk
+++ b/src/kf/kf6/kf6-kpackage.mk
@@ -1,0 +1,19 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+include src/kf/kf6/kf6-conf.mk
+
+PKG              := kf6-kpackage
+$(eval $(call KF6_METADATA))
+
+$(PKG)_CHECKSUM  := 2d04bcbc3492229cfc240884b04e7b220fa2022019c8f9d87f9f7814ea94c382
+$(PKG)_DEPS      := kf6-conf kf6-extra-cmake-modules qt6-qtbase kf6-karchive kf6-ki18n kf6-kcoreaddons kf6-kdoctools $(BUILD)~$(PKG)
+$(PKG)_DEPS_$(BUILD) := $(BUILD)~kf6-extra-cmake-modules $(BUILD)~qt6-qtbase $(BUILD)~kf6-karchive $(BUILD)~kf6-ki18n $(BUILD)~kf6-kcoreaddons $(BUILD)~kf6-kdoctools
+$(PKG)_TARGETS   := $(BUILD) $(MXE_TARGETS)
+$(PKG)_IGNORE    := _$(BUILD)
+
+define $(PKG)_BUILD
+    $(KF6_CMAKE) -S '$(SOURCE_DIR)' -B '$(BUILD_DIR)'
+    
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --build . -j '$(JOBS)'
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --install .
+endef

--- a/src/kf/kf6/kf6-kservice.mk
+++ b/src/kf/kf6/kf6-kservice.mk
@@ -1,0 +1,18 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+include src/kf/kf6/kf6-conf.mk
+
+PKG              := kf6-kservice
+$(eval $(call KF6_METADATA))
+
+$(PKG)_CHECKSUM  := d9151195b748361a12d7aeafd8df531d2f45b55d202d7fa5f47c3a11d59877d6
+$(PKG)_DEPS      := kf6-conf kf6-extra-cmake-modules qt6-qtbase kf6-kconfig kf6-kcoreaddons kf6-ki18n kf6-kdoctools
+$(PKG)_TARGETS   := $(MXE_TARGETS)
+$(PKG)_IGNORE    := 
+
+define $(PKG)_BUILD
+    $(KF6_CMAKE) -S '$(SOURCE_DIR)' -B '$(BUILD_DIR)'
+    
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --build . -j '$(JOBS)'
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --install .
+endef

--- a/src/kf/kf6/kf6-kwidgetsaddons.mk
+++ b/src/kf/kf6/kf6-kwidgetsaddons.mk
@@ -6,7 +6,7 @@ PKG              := kf6-kwidgetsaddons
 $(eval $(call KF6_METADATA))
 
 $(PKG)_CHECKSUM  := 6bb6a22e40bc8cfaeda08276b771488294ad417e7802b27bdc455202afdabd7d
-$(PKG)_DEPS      := kf6-conf kf6-extra-cmake-modules qt6-qtbase
+$(PKG)_DEPS      := kf6-conf kf6-extra-cmake-modules qt6-qtbase qt6-qttools
 $(PKG)_TARGETS   := $(MXE_TARGETS)
 $(PKG)_IGNORE    := 
 

--- a/src/kf/kf6/kf6-kwidgetsaddons.mk
+++ b/src/kf/kf6/kf6-kwidgetsaddons.mk
@@ -1,0 +1,18 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+include src/kf/kf6/kf6-conf.mk
+
+PKG              := kf6-kwidgetsaddons
+$(eval $(call KF6_METADATA))
+
+$(PKG)_CHECKSUM  := 6bb6a22e40bc8cfaeda08276b771488294ad417e7802b27bdc455202afdabd7d
+$(PKG)_DEPS      := kf6-conf kf6-extra-cmake-modules qt6-qtbase qt6-qttools
+$(PKG)_TARGETS   := $(MXE_TARGETS)
+$(PKG)_IGNORE    := 
+
+define $(PKG)_BUILD
+    $(KF6_CMAKE) -S '$(SOURCE_DIR)' -B '$(BUILD_DIR)'
+    
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --build . -j '$(JOBS)'
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --install .
+endef

--- a/src/kf/kf6/kf6-kwidgetsaddons.mk
+++ b/src/kf/kf6/kf6-kwidgetsaddons.mk
@@ -1,0 +1,18 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+include src/kf/kf6/kf6-conf.mk
+
+PKG              := kf6-kwidgetsaddons
+$(eval $(call KF6_METADATA))
+
+$(PKG)_CHECKSUM  := 6bb6a22e40bc8cfaeda08276b771488294ad417e7802b27bdc455202afdabd7d
+$(PKG)_DEPS      := kf6-conf kf6-extra-cmake-modules qt6-qtbase
+$(PKG)_TARGETS   := $(MXE_TARGETS)
+$(PKG)_IGNORE    := 
+
+define $(PKG)_BUILD
+    $(KF6_CMAKE) -S '$(SOURCE_DIR)' -B '$(BUILD_DIR)'
+    
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --build . -j '$(JOBS)'
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --install .
+endef

--- a/src/kf/kf6/kf6-kwindowsystem.mk
+++ b/src/kf/kf6/kf6-kwindowsystem.mk
@@ -6,7 +6,7 @@ PKG              := kf6-kwindowsystem
 $(eval $(call KF6_METADATA))
 
 $(PKG)_CHECKSUM  := 5adbdf9c82b1ecbb92bda6498ea1b8f88c08f9ec57dbff70d582e2453bf16b12
-$(PKG)_DEPS      := kf6-conf kf6-extra-cmake-modules qt6-qtbase qt6-qtdeclarative
+$(PKG)_DEPS      := kf6-conf kf6-extra-cmake-modules qt6-qtbase qt6-qttools qt6-qtdeclarative
 $(PKG)_TARGETS   := $(MXE_TARGETS)
 $(PKG)_IGNORE    := 
 

--- a/src/kf/kf6/kf6-kwindowsystem.mk
+++ b/src/kf/kf6/kf6-kwindowsystem.mk
@@ -1,0 +1,18 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+include src/kf/kf6/kf6-conf.mk
+
+PKG              := kf6-kwindowsystem
+$(eval $(call KF6_METADATA))
+
+$(PKG)_CHECKSUM  := 5adbdf9c82b1ecbb92bda6498ea1b8f88c08f9ec57dbff70d582e2453bf16b12
+$(PKG)_DEPS      := kf6-conf kf6-extra-cmake-modules qt6-qtbase qt6-qtdeclarative
+$(PKG)_TARGETS   := $(MXE_TARGETS)
+$(PKG)_IGNORE    := 
+
+define $(PKG)_BUILD
+    $(KF6_CMAKE) -S '$(SOURCE_DIR)' -B '$(BUILD_DIR)'
+    
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --build . -j '$(JOBS)'
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --install .
+endef

--- a/src/kf/kf6/kf6-kwindowsystem.mk
+++ b/src/kf/kf6/kf6-kwindowsystem.mk
@@ -1,0 +1,18 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+include src/kf/kf6/kf6-conf.mk
+
+PKG              := kf6-kwindowsystem
+$(eval $(call KF6_METADATA))
+
+$(PKG)_CHECKSUM  := 5adbdf9c82b1ecbb92bda6498ea1b8f88c08f9ec57dbff70d582e2453bf16b12
+$(PKG)_DEPS      := kf6-conf kf6-extra-cmake-modules qt6-qtbase qt6-qttools qt6-qtdeclarative
+$(PKG)_TARGETS   := $(MXE_TARGETS)
+$(PKG)_IGNORE    := 
+
+define $(PKG)_BUILD
+    $(KF6_CMAKE) -S '$(SOURCE_DIR)' -B '$(BUILD_DIR)'
+    
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --build . -j '$(JOBS)'
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --install .
+endef

--- a/src/kf/kf6/kf6-kxmlgui.mk
+++ b/src/kf/kf6/kf6-kxmlgui.mk
@@ -6,7 +6,7 @@ PKG              := kf6-kxmlgui
 $(eval $(call KF6_METADATA))
 
 $(PKG)_CHECKSUM  := e40b86ebb9f1be00255cd4835ab0b0ac8650c47d0eb17a47d9df7d4b5658df58
-$(PKG)_DEPS      := kf6-conf kf6-extra-cmake-modules qt6-qtbase kf6-kcoreaddons kf6-kitemviews kf6-kconfig kf6-kconfigwidgets kf6-kguiaddons kf6-ki18n kf6-kiconthemes
+$(PKG)_DEPS      := kf6-conf kf6-extra-cmake-modules qt6-qtbase kf6-kcoreaddons kf6-kitemviews kf6-kconfig kf6-kconfigwidgets kf6-kguiaddons kf6-ki18n kf6-kiconthemes kf6-kwidgetsaddons
 $(PKG)_TARGETS   := $(MXE_TARGETS)
 $(PKG)_IGNORE    := 
 

--- a/src/kf/kf6/kf6-kxmlgui.mk
+++ b/src/kf/kf6/kf6-kxmlgui.mk
@@ -1,0 +1,18 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+include src/kf/kf6/kf6-conf.mk
+
+PKG              := kf6-kxmlgui
+$(eval $(call KF6_METADATA))
+
+$(PKG)_CHECKSUM  := e40b86ebb9f1be00255cd4835ab0b0ac8650c47d0eb17a47d9df7d4b5658df58
+$(PKG)_DEPS      := kf6-conf kf6-extra-cmake-modules qt6-qtbase kf6-kcoreaddons kf6-kitemviews kf6-kconfig kf6-kconfigwidgets kf6-kguiaddons kf6-ki18n kf6-kiconthemes
+$(PKG)_TARGETS   := $(MXE_TARGETS)
+$(PKG)_IGNORE    := 
+
+define $(PKG)_BUILD
+    $(KF6_CMAKE) -S '$(SOURCE_DIR)' -B '$(BUILD_DIR)'
+    
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --build . -j '$(JOBS)'
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --install .
+endef

--- a/src/kf/kf6/kf6-kxmlgui.mk
+++ b/src/kf/kf6/kf6-kxmlgui.mk
@@ -1,0 +1,18 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+include src/kf/kf6/kf6-conf.mk
+
+PKG              := kf6-kxmlgui
+$(eval $(call KF6_METADATA))
+
+$(PKG)_CHECKSUM  := e40b86ebb9f1be00255cd4835ab0b0ac8650c47d0eb17a47d9df7d4b5658df58
+$(PKG)_DEPS      := kf6-conf kf6-extra-cmake-modules qt6-qtbase kf6-kcoreaddons kf6-kitemviews kf6-kconfig kf6-kconfigwidgets kf6-kguiaddons kf6-ki18n kf6-kiconthemes kf6-kwidgetsaddons
+$(PKG)_TARGETS   := $(MXE_TARGETS)
+$(PKG)_IGNORE    := 
+
+define $(PKG)_BUILD
+    $(KF6_CMAKE) -S '$(SOURCE_DIR)' -B '$(BUILD_DIR)'
+    
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --build . -j '$(JOBS)'
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --install .
+endef

--- a/src/kf/kf6/kf6-solid.mk
+++ b/src/kf/kf6/kf6-solid.mk
@@ -1,0 +1,18 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+include src/kf/kf6/kf6-conf.mk
+
+PKG              := kf6-solid
+$(eval $(call KF6_METADATA))
+
+$(PKG)_CHECKSUM  := 47fa84db565372584c6ecb03f71a6085f706a1c031ea4f2ffc35808f09a19b3d
+$(PKG)_DEPS      := kf6-conf kf6-extra-cmake-modules qt6-qtbase qt6-qttools
+$(PKG)_TARGETS   := $(MXE_TARGETS)
+$(PKG)_IGNORE    := 
+
+define $(PKG)_BUILD
+    $(KF6_CMAKE) -S '$(SOURCE_DIR)' -B '$(BUILD_DIR)'
+    
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --build . -j '$(JOBS)'
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --install .
+endef

--- a/src/kf/kf6/kf6-solid.mk
+++ b/src/kf/kf6/kf6-solid.mk
@@ -6,7 +6,7 @@ PKG              := kf6-solid
 $(eval $(call KF6_METADATA))
 
 $(PKG)_CHECKSUM  := 47fa84db565372584c6ecb03f71a6085f706a1c031ea4f2ffc35808f09a19b3d
-$(PKG)_DEPS      := kf6-conf kf6-extra-cmake-modules qt6-qtbase qt6-qtdeclarative
+$(PKG)_DEPS      := kf6-conf kf6-extra-cmake-modules qt6-qtbase qt6-qttools
 $(PKG)_TARGETS   := $(MXE_TARGETS)
 $(PKG)_IGNORE    := 
 

--- a/src/kf/kf6/kf6-solid.mk
+++ b/src/kf/kf6/kf6-solid.mk
@@ -1,0 +1,18 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+include src/kf/kf6/kf6-conf.mk
+
+PKG              := kf6-solid
+$(eval $(call KF6_METADATA))
+
+$(PKG)_CHECKSUM  := 47fa84db565372584c6ecb03f71a6085f706a1c031ea4f2ffc35808f09a19b3d
+$(PKG)_DEPS      := kf6-conf kf6-extra-cmake-modules qt6-qtbase qt6-qtdeclarative
+$(PKG)_TARGETS   := $(MXE_TARGETS)
+$(PKG)_IGNORE    := 
+
+define $(PKG)_BUILD
+    $(KF6_CMAKE) -S '$(SOURCE_DIR)' -B '$(BUILD_DIR)'
+    
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --build . -j '$(JOBS)'
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --install .
+endef

--- a/src/kf/kf6/kf6-syndication.mk
+++ b/src/kf/kf6/kf6-syndication.mk
@@ -1,0 +1,18 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+include src/kf/kf6/kf6-conf.mk
+
+PKG              := kf6-syndication
+$(eval $(call KF6_METADATA))
+
+$(PKG)_CHECKSUM  := 24db750155b69e3f858997cad0655a2f230f85d587c1063166113bc7690fd7b8
+$(PKG)_DEPS      := kf6-conf kf6-extra-cmake-modules qt6-qtbase kf6-kcodecs
+$(PKG)_TARGETS   := $(MXE_TARGETS)
+$(PKG)_IGNORE    := 
+
+define $(PKG)_BUILD
+    $(KF6_CMAKE) -S '$(SOURCE_DIR)' -B '$(BUILD_DIR)'
+    
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --build . -j '$(JOBS)'
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' --install .
+endef

--- a/src/kf/kf6/kf6.mk
+++ b/src/kf/kf6/kf6.mk
@@ -1,0 +1,16 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+PKG             := kf6
+$(PKG)_WEBSITE  := https://kde.org/
+$(PKG)_DESCR    := KDE Frameworks 6
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := $(kf6-conf_VERSION)
+$(PKG)_TYPE     := meta
+$(PKG)_DEPS     := $(shell grep -l 'KF6_METADATA' $(dir $(lastword $(MAKEFILE_LIST)))/kf6-*.mk | \
+                     sed -n 's,.*kf6-\(.*\)\.mk,\1,p' | \
+                     grep -v '^conf$$' | \
+                     sed 's,^,kf6-,g')
+
+define $(PKG)_UPDATE
+    echo $(kf6-conf_VERSION)
+endef


### PR DESCRIPTION
This is the fourth and most substantial step in introducing KDE Frameworks 6 into MXE. 

Building upon the toolchain tweaks and missing dependencies merged in the previous three PRs, this step finally introduces the core KDE Frameworks 6 ecosystem (Tier 1, Tier 2, and Tier 3 packages) into the MXE tree.

This PR has been tested locally against all 4 targets (shared/static, i686/x86_64) using both GCC 11 and GCC 16, successfully building the qt6 & kf6 meta packages.

**Next step:** Introducing KDE Gear applications

### Summary of Additions

**1. Infrastructure & Build System**
Established the foundational CMake configuration for KF6 apps and the essential extra modules.
* `ad30b3ba2fde6c35dd458829b5ab5689eba96f38` Add KDE6 Framework skeleton structure
* `a1d9a4c5135b976e16a5350bb144a8467a8dd9e6` Add new package kf6-extra-cmake-modules

**2. Tier 1 Frameworks**
Foundational libraries with no dependencies other than Qt and system libraries.
* `73209b8e2c82bd6672ca01656472f534de3a464d` Add new package kf6-kconfig
* `33333de0030a95a5d650beb0553afaa02397a68b` Add new package kf6-kwidgetsaddons
* `8d0ed5515cf2fafdabfdb8f8c92b9b2547053cb0` Add new package kf6-kcodecs
* `6d69e8aa74cb6029b68be0dcfef61a7f6f3ca38b` Add new package kf6-kcoreaddons
* `b6e8e045e7c310a6cc5de356988e2732008adb4b` Add new package kf6-kguiaddons
* `2659e04f7eff091b21ff1ea2469c221361d7c84c` Add new package kf6-ki18n
* `0777e795681908cf379de7b3cf482585222af7e7` Add new package kf6-kcolorscheme
* `1ed7fde9b743ba604a9b2f9dd122c0efababac7a` Add new package kf6-kconfigwidgets
* `0b1f00317b9f627fbe558c58b002fe668527105e` Add new package kf6-kwindowsystem
* `1abd4e023d1f8ca2b119dc1f4730ffb8992b6758` Add new package kf6-karchive
* `daa12d63ed55ee746422bf1717a96f018ea53a92` Add new package kf6-solid
* `cd4abbb458f4c055c66d9ffa0d96179989d3f1c5` Add new package kf6-breeze-icons
* `00a07d5257d25558c13a3436f7c014ed4c2a271e` Add new package kf6-kitemviews
* `d48b0dfa52ce113317f3e777d1e485fdaf8c22c8` Add new package kf6-kirigami
* `955b4a2945669789b07f1c921749920465260fbb` Add new package kf6-attica
* `0fd5d208c7fb5e6e9267e4ae3aebc2ac816a5647` Add new package kf6-kdnssd

**3. Tier 2 Frameworks**
Integration libraries that depend on Tier 1 frameworks.
* `7da035a77a8d3713ff88376dbfe007a6a41ce5d7` Add new package kf6-kcompletion
* `ae79e2691e20ba5c06b6a5f53696ffebed95f522` Add new package kf6-kcrash
* `b494d1d45891741482a47c370c66693d0d2bc3cd` Add new package kf6-kdoctools
* `840c5f147f252ad81293da42229cd73a1347054a` Add new package kf6-kjobwidgets
* `b4b848e3dcdd225806abc29ead21e7e705fc4aed` Add new package kf6-syndication
* `15d7b597c41e1d2d8d3c9ef2971fa53fc89c8300` Add new package kf6-kdbusaddons

**4. Tier 3 Frameworks**
Complex frameworks that depend on Tier 2 frameworks.
* `30428b9bba56f25a44e6685267f3b6bbb4440759` Add new package kf6-kservice
* `78c6b35f13c25746cab66bf102ff5a24694d10a6` Add new package kf6-kbookmarks
* `6b60ccb4e3a26b47500a22fdbb0a956b2b5c3144` Add new package kf6-kiconthemes
* `43c58a6258579824f6b7910e8f091c9ba5c12ecd` Add new package kf6-knotifications
* `8d8ac9a14b96d4ae57d143f7594b0a9cd71abd95` Add new package kf6-kio
* `c080fe5ffe15b4cec2fae8529faa5699fe2711fe` Add new package kf6-kpackage
* `6a8705dd34e549b57cca830bc03a33142153da0f` Add new package kf6-knewstuff
* `bddd8078d2e9d08dacb9b626199a16d9b83a5058` Add new package kf6-kxmlgui