### PR TITLE
KF6 Introduction: Fifth step - KDE Applications Proof of Concept

### DIFF
--- a/plugins/apps/kmahjongg/kmahjongg-1-fixes.patch
+++ b/plugins/apps/kmahjongg/kmahjongg-1-fixes.patch
@@ -1,0 +1,31 @@
+This file is part of MXE. See LICENSE.md for licensing information.
+
+Contains ad hoc patches for cross building.
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Marco Borrini <borrinimarco74@gmail.com>
+Date: Tue, 4 Aug 2026 17:28:00 +0200
+Subject: [PATCH 1/1] Explicitly link Qt6::Quick and Qt6::Qml to fix link order
+
+In static builds, kmahjongg transitively depends on Qt6::Quick through
+KDEGames6. Due to CMake's dependency resolution, Qt6::Qml ends up being
+placed before Qt6::Quick on the linker line, leading to undefined
+references to QQmlParserStatus. Explicitly adding Qt6::Quick and Qt6::Qml
+to the kmahjongg target fixes the link order. Only for static builds so
+we don't break dynamic builds that don't need this direct linkage.
+
+diff -ur kmahjongg-orig/src/CMakeLists.txt kmahjongg-new/src/CMakeLists.txt
+--- kmahjongg-orig/src/CMakeLists.txt	2026-06-27 09:47:52.000000000 +0200
++++ kmahjongg-new/src/CMakeLists.txt	2026-08-04 17:28:54.100630258 +0200
+@@ -57,6 +57,11 @@
+     Qt6::Gui
+ )
+ 
++if (NOT BUILD_SHARED_LIBS)
++    find_package(Qt6 COMPONENTS Quick Qml REQUIRED)
++    target_link_libraries(kmahjongg Qt6::Quick Qt6::Qml)
++endif()
++
+ install(TARGETS kmahjongg  ${KDE_INSTALL_TARGETS_DEFAULT_ARGS})
+ 
+ install(FILES kmahjongg.kcfg  DESTINATION  ${KDE_INSTALL_KCFGDIR})

--- a/plugins/apps/kmahjongg/kmahjongg.mk
+++ b/plugins/apps/kmahjongg/kmahjongg.mk
@@ -1,0 +1,77 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+PKG             := kmahjongg
+$(PKG)_WEBSITE  := https://apps.kde.org/it/kmahjongg/
+$(PKG)_DESCR    := KMahjongg
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 26.04.3
+$(PKG)_CHECKSUM := 8e4575a50d37a6259b7c4381c4243d0a05d64847c620c5af58c34a83ae6ce38b
+$(PKG)_SUBDIR   := kmahjongg-$($(PKG)_VERSION)
+$(PKG)_FILE     := kmahjongg-$($(PKG)_VERSION).tar.xz
+$(PKG)_URL      := https://download.kde.org/stable/release-service/$($(PKG)_VERSION)/src/$($(PKG)_FILE)
+$(PKG)_DEPS     := cc qt6-qtbase qt6-qtsvg qt6-qtdeclarative \
+                   kf6-kconfig kf6-kcoreaddons kf6-kcrash kf6-kdbusaddons \
+                   kf6-ki18n kf6-knewstuff kf6-kxmlgui \
+                   kde-libkdegames kde-libkmahjongg
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- 'https://download.kde.org/stable/release-service/' | \
+    grep -o 'href="[0-9]*\.[0-9]*\.[0-9]*' | \
+    $(SED) 's/href="//' | \
+    $(SORT) -V | \
+    tail -1
+endef
+
+define $(PKG)_BUILD
+    # Workaround to prevent KMahjongg from crashing/exiting(1) on Windows due to missing DBus process
+    $(SED) -i 's/KDBusService service;/KDBusService service(KDBusService::Multiple | KDBusService::NoExitOnFailure);/' '$(SOURCE_DIR)/src/main.cpp'
+    
+    # Workaround for GCC 11 parsing bug with [[deprecated]] and __declspec
+    $(SED) -i 's/KF 6.0/KF 7.0/' '$(SOURCE_DIR)/CMakeLists.txt'
+    
+    cd '$(BUILD_DIR)' && $(KF6_CMAKE) -S '$(SOURCE_DIR)' -B '$(BUILD_DIR)' \
+        -DBUILD_TESTING=OFF \
+        -DBUILD_DOC=OFF
+    
+    cd '$(BUILD_DIR)' && $(TARGET)-cmake --build . -j '$(JOBS)'
+    cd '$(BUILD_DIR)' && $(TARGET)-cmake --install .
+    
+    # --- DEPLOYMENT PHASE ---
+    # Create the dist folder for the standalone app
+    mkdir -p '$(TOP_DIR)/plugins/apps/$(PKG)/bundle/$(TARGET)'
+    
+    # Copy the main executable
+    cp '$(PREFIX)/$(TARGET)/qt6/bin/kmahjongg.exe' '$(TOP_DIR)/plugins/apps/$(PKG)/bundle/$(TARGET)/'
+    
+    # Resolve and copy ONLY the strictly necessary DLLs using the native MXE tool
+    '$(TOP_DIR)/tools/copydlldeps.sh' -c \
+        -d '$(TOP_DIR)/plugins/apps/$(PKG)/bundle/$(TARGET)/' \
+        -S "$(PREFIX)/$(TARGET)/qt6/bin $(PREFIX)/$(TARGET)/bin" \
+        -f '$(TOP_DIR)/plugins/apps/$(PKG)/bundle/$(TARGET)/kmahjongg.exe'
+    
+    # Copy Qt6/KF6 plugins
+    cp -r '$(PREFIX)/$(TARGET)/qt6/plugins' '$(TOP_DIR)/plugins/apps/$(PKG)/bundle/$(TARGET)/' || true
+    
+    # Copy QML modules
+    cp -r '$(PREFIX)/$(TARGET)/qt6/qml' '$(TOP_DIR)/plugins/apps/$(PKG)/bundle/$(TARGET)/' || true
+    
+    # Resolve dependencies for all newly copied DLLs (plugins and qml)
+    '$(TOP_DIR)/tools/copydlldeps.sh' -c \
+        -d '$(TOP_DIR)/plugins/apps/$(PKG)/bundle/$(TARGET)/' \
+        -S "$(PREFIX)/$(TARGET)/qt6/bin $(PREFIX)/$(TARGET)/bin" \
+        -F '$(TOP_DIR)/plugins/apps/$(PKG)/bundle/$(TARGET)/'
+    
+    # Copy specific data files required by kmahjongg directly into the app folder
+    mkdir -p '$(TOP_DIR)/plugins/apps/$(PKG)/bundle/$(TARGET)/data'
+    cp -r '$(PREFIX)/$(TARGET)/qt6/bin/data/kmahjongg' '$(TOP_DIR)/plugins/apps/$(PKG)/bundle/$(TARGET)/data/' || true
+    cp -r '$(PREFIX)/$(TARGET)/qt6/bin/data/kmahjongglib' '$(TOP_DIR)/plugins/apps/$(PKG)/bundle/$(TARGET)/data/' || true
+    cp -r '$(PREFIX)/$(TARGET)/qt6/bin/data/icons' '$(TOP_DIR)/plugins/apps/$(PKG)/bundle/$(TARGET)/data/' || true
+    cp -r '$(PREFIX)/$(TARGET)/qt6/bin/data/locale' '$(TOP_DIR)/plugins/apps/$(PKG)/bundle/$(TARGET)/data/' || true
+    
+    # Create the qt.conf file to resolve hardcoded paths in a standalone environment
+    echo "[Paths]" > '$(TOP_DIR)/plugins/apps/$(PKG)/bundle/$(TARGET)/qt.conf'
+    echo "Prefix = ." >> '$(TOP_DIR)/plugins/apps/$(PKG)/bundle/$(TARGET)/qt.conf'
+    echo "Plugins = plugins" >> '$(TOP_DIR)/plugins/apps/$(PKG)/bundle/$(TARGET)/qt.conf'
+    echo "Data = data" >> '$(TOP_DIR)/plugins/apps/$(PKG)/bundle/$(TARGET)/qt.conf'
+    echo "Qml2Imports = qml" >> '$(TOP_DIR)/plugins/apps/$(PKG)/bundle/$(TARGET)/qt.conf'
+endef

--- a/plugins/apps/kpat/black-hole-solver.mk
+++ b/plugins/apps/kpat/black-hole-solver.mk
@@ -1,0 +1,28 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+PKG             := black-hole-solver
+$(PKG)_WEBSITE  := https://www.shlomifish.org/open-source/projects/black-hole-solitaire-solver/
+$(PKG)_DESCR    := Black Hole Solver
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 1.12.0
+$(PKG)_CHECKSUM := d32f32536f7573292588f41bb0d85ae42d561376c218dc4ab6badfe4904a37a7
+$(PKG)_SUBDIR   := black-hole-solver-$($(PKG)_VERSION)
+$(PKG)_FILE     := black-hole-solver-$($(PKG)_VERSION).tar.xz
+$(PKG)_URL      := https://fc-solve.shlomifish.org/downloads/fc-solve/$($(PKG)_FILE)
+$(PKG)_DEPS     := cc rinutils
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- 'https://fc-solve.shlomifish.org/downloads/fc-solve/' | \
+    grep -o 'black-hole-solver-[0-9.]*\.tar\.xz' | \
+    $(SED) 's/black-hole-solver-//; s/\.tar\.xz//' | \
+    $(SORT) -V | \
+    tail -1
+endef
+
+define $(PKG)_BUILD
+    cd '$(BUILD_DIR)' && $(TARGET)-cmake '$(SOURCE_DIR)' \
+        -DBUILD_TESTING=OFF \
+        -DBHS_WITH_TEST_SUITE=OFF
+    $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)'
+    $(MAKE) -C '$(BUILD_DIR)' -j 1 install
+endef

--- a/plugins/apps/kpat/freecell-solver.mk
+++ b/plugins/apps/kpat/freecell-solver.mk
@@ -1,0 +1,30 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+PKG             := freecell-solver
+$(PKG)_WEBSITE  := https://fc-solve.shlomifish.org/
+$(PKG)_DESCR    := Freecell Solver
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 6.16.0
+$(PKG)_CHECKSUM := 71b8882e68f1be62529069018d0c732b75078669077c96348279575849f34313
+$(PKG)_SUBDIR   := freecell-solver-$($(PKG)_VERSION)
+$(PKG)_FILE     := freecell-solver-$($(PKG)_VERSION).tar.xz
+$(PKG)_URL      := https://downloads.sourceforge.net/project/fc-solve/fc-solve/$($(PKG)_FILE)
+$(PKG)_DEPS     := cc rinutils
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- 'https://sourceforge.net/projects/fc-solve/rss?path=/fc-solve' | \
+    grep -o 'freecell-solver-[0-9.]*\.tar\.xz' | \
+    $(SED) 's/freecell-solver-//; s/\.tar\.xz//' | \
+    $(SORT) -V | \
+    tail -1
+endef
+
+define $(PKG)_BUILD
+    cd '$(BUILD_DIR)' && $(TARGET)-cmake '$(SOURCE_DIR)' \
+        -DFCS_WITH_TEST_SUITE=OFF \
+        -DBUILD_TESTING=OFF \
+        -DFCS_ENABLE_DBM_SOLVER=OFF \
+        -D_PYTHON3=_PYTHON3-NOTFOUND
+    $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)'
+    $(MAKE) -C '$(BUILD_DIR)' -j 1 install
+endef

--- a/plugins/apps/kpat/kpat.mk
+++ b/plugins/apps/kpat/kpat.mk
@@ -1,0 +1,77 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+PKG             := kpat
+$(PKG)_WEBSITE  := https://apps.kde.org/kpat/
+$(PKG)_DESCR    := KPat (KDE Patience)
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 26.04.3
+$(PKG)_CHECKSUM := 562ab74043bfb77ec57970f757f107ded9d8e3fe13748324009720077ad719cb
+$(PKG)_SUBDIR   := kpat-$($(PKG)_VERSION)
+$(PKG)_FILE     := kpat-$($(PKG)_VERSION).tar.xz
+$(PKG)_URL      := https://download.kde.org/stable/release-service/$($(PKG)_VERSION)/src/$($(PKG)_FILE)
+$(PKG)_DEPS     := cc qt6-qtbase qt6-qtsvg qt6-qtdeclarative \
+                   kf6-kcompletion kf6-kconfig kf6-kconfigwidgets kf6-kcoreaddons \
+                   kf6-kcrash kf6-kdbusaddons kf6-kguiaddons kf6-ki18n kf6-kio \
+                   kf6-knewstuff kf6-kwidgetsaddons kf6-kxmlgui \
+                   freecell-solver black-hole-solver kde-libkdegames
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- 'https://download.kde.org/stable/release-service/' | \
+    grep -o 'href="[0-9]*\.[0-9]*\.[0-9]*' | \
+    $(SED) 's/href="//' | \
+    $(SORT) -V | \
+    tail -1
+endef
+
+define $(PKG)_BUILD
+    # Workaround to prevent KPat from crashing/exiting(1) on Windows due to missing DBus process
+    $(SED) -i 's/KDBusService::Multiple/KDBusService::Multiple | KDBusService::NoExitOnFailure/' '$(SOURCE_DIR)/src/main.cpp'
+    
+    # Workaround for GCC 11 parsing bug with [[deprecated]] and __declspec
+    $(SED) -i 's/KF 6.0/KF 7.0/' '$(SOURCE_DIR)/CMakeLists.txt'
+    
+    cd '$(BUILD_DIR)' && $(KF6_CMAKE) -S '$(SOURCE_DIR)' -B '$(BUILD_DIR)' \
+        -DBUILD_TESTING=OFF \
+        -DBUILD_DOC=OFF
+    
+    cd '$(BUILD_DIR)' && $(TARGET)-cmake --build . -j '$(JOBS)'
+    cd '$(BUILD_DIR)' && $(TARGET)-cmake --install .
+    
+    # --- DEPLOYMENT PHASE ---
+    # Create the dist folder for the standalone app
+    mkdir -p '$(TOP_DIR)/plugins/apps/$(PKG)/bundle/$(TARGET)'
+    
+    # Copy the main executable
+    cp '$(PREFIX)/$(TARGET)/qt6/bin/kpat.exe' '$(TOP_DIR)/plugins/apps/$(PKG)/bundle/$(TARGET)/'
+    # Resolve and copy ONLY the strictly necessary DLLs using the native MXE tool
+    '$(TOP_DIR)/tools/copydlldeps.sh' -c \
+        -d '$(TOP_DIR)/plugins/apps/$(PKG)/bundle/$(TARGET)/' \
+        -S "$(PREFIX)/$(TARGET)/qt6/bin $(PREFIX)/$(TARGET)/bin" \
+        -f '$(TOP_DIR)/plugins/apps/$(PKG)/bundle/$(TARGET)/kpat.exe'
+    
+    # Copy Qt6/KF6 plugins
+    cp -r '$(PREFIX)/$(TARGET)/qt6/plugins' '$(TOP_DIR)/plugins/apps/$(PKG)/bundle/$(TARGET)/' || true
+    
+    # Copy QML modules
+    cp -r '$(PREFIX)/$(TARGET)/qt6/qml' '$(TOP_DIR)/plugins/apps/$(PKG)/bundle/$(TARGET)/' || true
+    
+    # Resolve dependencies for all newly copied DLLs (plugins and qml)
+    '$(TOP_DIR)/tools/copydlldeps.sh' -c \
+        -d '$(TOP_DIR)/plugins/apps/$(PKG)/bundle/$(TARGET)/' \
+        -S "$(PREFIX)/$(TARGET)/qt6/bin $(PREFIX)/$(TARGET)/bin" \
+        -F '$(TOP_DIR)/plugins/apps/$(PKG)/bundle/$(TARGET)/'
+    
+    # Copy specific data files required by kpat directly into the app folder
+    mkdir -p '$(TOP_DIR)/plugins/apps/$(PKG)/bundle/$(TARGET)/data'
+    cp -r '$(PREFIX)/$(TARGET)/qt6/bin/data/kpat' '$(TOP_DIR)/plugins/apps/$(PKG)/bundle/$(TARGET)/data/' || true
+    cp -r '$(PREFIX)/$(TARGET)/qt6/bin/data/carddecks' '$(TOP_DIR)/plugins/apps/$(PKG)/bundle/$(TARGET)/data/' || true
+    cp -r '$(PREFIX)/$(TARGET)/qt6/bin/data/icons' '$(TOP_DIR)/plugins/apps/$(PKG)/bundle/$(TARGET)/data/' || true
+    cp -r '$(PREFIX)/$(TARGET)/qt6/bin/data/locale' '$(TOP_DIR)/plugins/apps/$(PKG)/bundle/$(TARGET)/data/' || true
+    
+    # Create the qt.conf file to resolve hardcoded paths in a standalone environment
+    echo "[Paths]" > '$(TOP_DIR)/plugins/apps/$(PKG)/bundle/$(TARGET)/qt.conf'
+    echo "Prefix = ." >> '$(TOP_DIR)/plugins/apps/$(PKG)/bundle/$(TARGET)/qt.conf'
+    echo "Plugins = plugins" >> '$(TOP_DIR)/plugins/apps/$(PKG)/bundle/$(TARGET)/qt.conf'
+    echo "Data = data" >> '$(TOP_DIR)/plugins/apps/$(PKG)/bundle/$(TARGET)/qt.conf'
+    echo "Qml2Imports = qml" >> '$(TOP_DIR)/plugins/apps/$(PKG)/bundle/$(TARGET)/qt.conf'
+endef

--- a/plugins/apps/kpat/rinutils.mk
+++ b/plugins/apps/kpat/rinutils.mk
@@ -1,0 +1,16 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+PKG             := rinutils
+$(PKG)_WEBSITE  := https://github.com/shlomif/rinutils
+$(PKG)_DESCR    := Rinutils
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 0.10.3
+$(PKG)_CHECKSUM := f9e527d37a6cc8c7b8870ada63caa24f32ab0d29fd1116df3ebb686583030955
+$(PKG)_GH_CONF  := shlomif/rinutils/releases,,,,,.tar.xz
+$(PKG)_DEPS     := cc
+
+define $(PKG)_BUILD
+    cd '$(BUILD_DIR)' && $(TARGET)-cmake '$(SOURCE_DIR)'
+    $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)'
+    $(MAKE) -C '$(BUILD_DIR)' -j 1 install
+endef

--- a/src/kde-libkdegames-1-fixes.patch
+++ b/src/kde-libkdegames-1-fixes.patch
@@ -1,0 +1,144 @@
+This file is part of MXE. See LICENSE.md for licensing information.
+
+Contains ad hoc patches for cross building.
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Marco Borrini <borrinimarco74@gmail.com>
+Date: Tue, 4 Aug 2026 17:04:00 +0200
+Subject: [PATCH 1/1] Add AL_LIBTYPE_STATIC and PkgConfig for libsndfile and OpenAL
+
+When building KDEGames statically, it links to OpenAL statically.
+The OpenAL headers on Windows use __declspec(dllimport) for functions
+like alcGetError unless AL_LIBTYPE_STATIC is defined.
+This patch defines AL_LIBTYPE_STATIC when building statically.
+
+Additionally, FindSndFile did not use PkgConfig to find libsndfile,
+which is a problem in a static build because libsndfile has private
+dependencies like libopus, libvorbis, and libogg which need to be linked.
+
+Similarly, CMake's FindOpenAL does not pull in pkg-config dependencies,
+which causes linking to fail due to missing Windows libraries like avrt.
+This patch leverages pkg-config for OpenAL in CMakeLists.txt to pull in
+the correct linker flags for static builds.
+
+Finally, KDEGames and KDEGamesPrivate were explicitly defining themselves
+as SHARED libraries, which caused issues during static builds (export ordinal too large)
+when it tried to link a DLL with all static Qt dependencies. Removing SHARED allows
+them to respect BUILD_SHARED_LIBS.
+
+diff -ur libkdegames-orig/cmake/modules/FindSndFile.cmake libkdegames-new/cmake/modules/FindSndFile.cmake
+--- libkdegames-orig/cmake/modules/FindSndFile.cmake	2026-08-04 16:51:22.156207696 +0200
++++ libkdegames-new/cmake/modules/FindSndFile.cmake	2026-08-04 16:55:56.771474126 +0200
+@@ -11,37 +11,32 @@
+ # SPDX-License-Identifier: BSD-3-Clause
+ #
+ 
++find_package(PkgConfig QUIET)
++if (PKG_CONFIG_FOUND)
++    pkg_check_modules(PC_SNDFILE QUIET sndfile)
++endif()
++
+ find_path(SNDFILE_INCLUDE_DIR
+     NAMES
+       sndfile.h
+     PATHS
+-      /usr/include
+-      /usr/local/include
+-      /opt/local/include
+-      /sw/include
++      HINTS ${PC_SNDFILE_INCLUDEDIR} ${PC_SNDFILE_INCLUDE_DIRS}
+ )
+ 
+ find_library(SNDFILE_LIBRARY
+-    NAMES
+-      sndfile sndfile-1
+-    PATHS
+-      /usr/lib
+-      /usr/local/lib
+-      /opt/local/lib
+-      /sw/lib
++      NAMES sndfile sndfile-1
++      HINTS ${PC_SNDFILE_LIBDIR} ${PC_SNDFILE_LIBRARY_DIRS}
+ )
+ 
+-set(SNDFILE_INCLUDE_DIRS
+-    ${SNDFILE_INCLUDE_DIR}
+-)
+-set(SNDFILE_LIBRARIES
+-    ${SNDFILE_LIBRARY}
+-)
++set(SNDFILE_INCLUDE_DIRS ${SNDFILE_INCLUDE_DIR})
++
++if (PC_SNDFILE_FOUND)
++    set(SNDFILE_LIBRARIES ${PC_SNDFILE_STATIC_LDFLAGS} ${PC_SNDFILE_LDFLAGS})
++else()
++    set(SNDFILE_LIBRARIES ${SNDFILE_LIBRARY})
++endif()
+ 
+-INCLUDE(FindPackageHandleStandardArgs)
+-# handle the QUIETLY and REQUIRED arguments and set SNDFILE_FOUND to TRUE if
+-# all listed variables are TRUE
+-FIND_PACKAGE_HANDLE_STANDARD_ARGS(SndFile DEFAULT_MSG SNDFILE_LIBRARY SNDFILE_INCLUDE_DIR)
++include(FindPackageHandleStandardArgs)
++FIND_PACKAGE_HANDLE_STANDARD_ARGS(SndFile DEFAULT_MSG SNDFILE_LIBRARIES SNDFILE_INCLUDE_DIR)
+ 
+-# show the SNDFILE_INCLUDE_DIRS and SNDFILE_LIBRARIES variables only in the advanced view
+ mark_as_advanced(SNDFILE_INCLUDE_DIRS SNDFILE_LIBRARIES)
+diff -ur libkdegames-orig/CMakeLists.txt libkdegames-new/CMakeLists.txt
+--- libkdegames-orig/CMakeLists.txt	2026-08-04 16:51:22.166380377 +0200
++++ libkdegames-new/CMakeLists.txt	2026-08-04 17:01:34.240695904 +0200
+@@ -94,9 +94,19 @@
+ find_package(OpenAL)
+ set_package_properties(OpenAL PROPERTIES
+     URL "https://www.openal.org/"
++    DESCRIPTION "OpenAL API"
+     TYPE REQUIRED
++    PURPOSE "Support for the KGameAudio system"
+ )
+ 
++find_package(PkgConfig QUIET)
++if (PKG_CONFIG_FOUND)
++    pkg_check_modules(PC_OPENAL QUIET openal)
++    if (PC_OPENAL_FOUND)
++        set(OPENAL_LIBRARY ${PC_OPENAL_STATIC_LDFLAGS} ${PC_OPENAL_LDFLAGS})
++    endif()
++endif()
++
+ find_package(SndFile)
+ set_package_properties(SndFile PROPERTIES
+     URL "http://www.mega-nerd.com/libsndfile/"
+diff -ur libkdegames-orig/src/CMakeLists.txt libkdegames-new/src/CMakeLists.txt
+--- libkdegames-orig/src/CMakeLists.txt	2026-08-04 16:51:22.171442448 +0200
++++ libkdegames-new/src/CMakeLists.txt	2026-08-04 17:04:01.268195283 +0200
+@@ -18,7 +18,7 @@
+ configure_file(libkdegames_capabilities.h.in ${CMAKE_CURRENT_BINARY_DIR}/libkdegames_capabilities.h)
+ configure_file(highscore/config-highscore.h.in ${CMAKE_CURRENT_BINARY_DIR}/highscore/config-highscore.h )
+ 
+-add_library(KDEGames SHARED)
++add_library(KDEGames)
+ 
+ set_target_properties(KDEGames PROPERTIES
+     OUTPUT_NAME ${KDEGAMES_OUTPUT_NAME}
+@@ -144,6 +144,10 @@
+         ${CMAKE_CURRENT_BINARY_DIR}/highscore
+ )
+ 
++if (NOT BUILD_SHARED_LIBS)
++    target_compile_definitions(KDEGames PRIVATE AL_LIBTYPE_STATIC)
++endif()
++
+ install(TARGETS KDEGames EXPORT KDEGamesTargets ${KDE_INSTALL_TARGETS_DEFAULT_ARGS})
+ 
+ 
+diff -ur libkdegames-orig/src/private/CMakeLists.txt libkdegames-new/src/private/CMakeLists.txt
+--- libkdegames-orig/src/private/CMakeLists.txt	2026-08-04 16:51:22.171239700 +0200
++++ libkdegames-new/src/private/CMakeLists.txt	2026-08-04 17:04:01.578190019 +0200
+@@ -6,7 +6,7 @@
+     add_subdirectory(tests)
+ endif()
+ 
+-add_library(KDEGamesPrivate SHARED)
++add_library(KDEGamesPrivate)
+ 
+ set_target_properties(KDEGamesPrivate PROPERTIES
+     OUTPUT_NAME ${KDEGAMESPRIVATE_OUTPUT_NAME}

--- a/src/kde-libkdegames.mk
+++ b/src/kde-libkdegames.mk
@@ -1,0 +1,31 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+PKG             := kde-libkdegames
+$(PKG)_WEBSITE  := https://invent.kde.org/games/libkdegames
+$(PKG)_DESCR    := KDE Games Library
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 26.04.3
+$(PKG)_CHECKSUM := fb9a2199c1d7d5ad827584edb063dd96e41aa8a937980d641e1ffa122d1eccc3
+$(PKG)_SUBDIR   := libkdegames-$($(PKG)_VERSION)
+$(PKG)_FILE     := libkdegames-$($(PKG)_VERSION).tar.xz
+$(PKG)_URL      := https://download.kde.org/stable/release-service/$($(PKG)_VERSION)/src/$($(PKG)_FILE)
+$(PKG)_DEPS     := cc qt6-qtbase qt6-qtdeclarative qt6-qtsvg \
+                   kf6-karchive kf6-kcolorscheme kf6-kcompletion kf6-kconfig \
+                   kf6-kconfigwidgets kf6-kdnssd kf6-kguiaddons kf6-kiconthemes \
+                   kf6-ki18n kf6-knewstuff kf6-kxmlgui \
+                   openal libsndfile
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- 'https://download.kde.org/stable/release-service/' | \
+    grep -o 'href="[0-9]*\.[0-9]*\.[0-9]*' | \
+    $(SED) 's/href="//' | \
+    $(SORT) -V | \
+    tail -1
+endef
+
+define $(PKG)_BUILD
+    cd '$(BUILD_DIR)' && $(KF6_CMAKE) -S '$(SOURCE_DIR)' -B '$(BUILD_DIR)' \
+        -DBUILD_TESTING=OFF
+    cd '$(BUILD_DIR)' && $(TARGET)-cmake --build . -j '$(JOBS)'
+    cd '$(BUILD_DIR)' && $(TARGET)-cmake --install .
+endef

--- a/src/kde-libkmahjongg-1-fixes.patch
+++ b/src/kde-libkmahjongg-1-fixes.patch
@@ -1,0 +1,26 @@
+This file is part of MXE. See LICENSE.md for licensing information.
+
+Contains ad hoc patches for cross building.
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Marco Borrini <borrinimarco74@gmail.com>
+Date: Tue, 4 Aug 2026 17:14:00 +0200
+Subject: [PATCH 1/1] Remove SHARED hardcoded keyword from KMahjongglib
+
+KMahjongglib explicitly defined itself as a SHARED library, which caused
+issues during static builds (export ordinal too large) when it tried to
+link a DLL with all static Qt dependencies. Removing SHARED allows it to
+respect BUILD_SHARED_LIBS.
+
+diff -ur libkmahjongg-orig/src/CMakeLists.txt libkmahjongg-new/src/CMakeLists.txt
+--- libkmahjongg-orig/src/CMakeLists.txt	2026-06-26 12:10:40.000000000 +0200
++++ libkmahjongg-new/src/CMakeLists.txt	2026-08-04 17:13:40.916387651 +0200
+@@ -21,7 +21,7 @@
+     SOVERSION 6
+ )
+ 
+-add_library(KMahjongglib SHARED)
++add_library(KMahjongglib)
+ set_target_properties(KMahjongglib PROPERTIES
+     VERSION     ${KMAHJONGGLIB_VERSION}
+     SOVERSION   ${KMAHJONGGLIB_SOVERSION}

--- a/src/kde-libkmahjongg.mk
+++ b/src/kde-libkmahjongg.mk
@@ -1,0 +1,30 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+PKG             := kde-libkmahjongg
+$(PKG)_WEBSITE  := https://apps.kde.org/it/kmahjongg/
+$(PKG)_DESCR    := KMahjongg library
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 26.04.3
+$(PKG)_CHECKSUM := 1914c780160d8913dd649fdd1b0760b445523c09b572f45ce99c08196e29c7e8
+$(PKG)_SUBDIR   := libkmahjongg-$($(PKG)_VERSION)
+$(PKG)_FILE     := libkmahjongg-$($(PKG)_VERSION).tar.xz
+$(PKG)_URL      := https://download.kde.org/stable/release-service/$($(PKG)_VERSION)/src/$($(PKG)_FILE)
+$(PKG)_DEPS     := cc qt6-qtbase qt6-qtsvg kf6-kconfig kf6-kconfigwidgets \
+                   kf6-kcoreaddons kf6-kwidgetsaddons kf6-ki18n
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- 'https://download.kde.org/stable/release-service/' | \
+    grep -o 'href="[0-9]*\.[0-9]*\.[0-9]*' | \
+    $(SED) 's/href="//' | \
+    $(SORT) -V | \
+    tail -1
+endef
+
+define $(PKG)_BUILD
+    cd '$(BUILD_DIR)' && $(KF6_CMAKE) -S '$(SOURCE_DIR)' -B '$(BUILD_DIR)' \
+        -DBUILD_TESTING=OFF \
+        -DBUILD_DOC=OFF
+    
+    cd '$(BUILD_DIR)' && $(TARGET)-cmake --build . -j '$(JOBS)'
+    cd '$(BUILD_DIR)' && $(TARGET)-cmake --install .
+endef


### PR DESCRIPTION
This is the fifth and final step in introducing KDE Frameworks 6 into MXE. 

It focuses on introducing the first set of KDE end-user applications (kpat and kmahjongg) as MXE plugins, along with their core game libraries and backend logic dependencies, enabling fully standalone Windows deployment.

This PR has been tested with:
```bash
git clone https://github.com/mxe/mxe.git mxe-test-3332
cd mxe-test-3332
git fetch origin pull/3332/head:test-pr3332
git checkout test-pr3332

make kpat kmahjongg \
    MXE_TARGETS="i686-w64-mingw32.static i686-w64-mingw32.shared x86_64-w64-mingw32.static x86_64-w64-mingw32.shared" \
    MXE_PLUGIN_DIRS="plugins/gcc16 plugins/apps/kpat plugins/apps/kmahjongg"
```

==> b7207479ba48ee6c2ce3e72c237c168bae62414a Add new package rinutils <==

- New Package: Added rinutils, a core dependency required by KPat's solvers.

==> f79e1ff87850e029fb8f3869bcf844bd73760d0f Add new package freecell-solver <==

- New Package: Added freecell-solver, a logic backend required by KPat. Includes an architecture-specific fix to ensure it compiles correctly under i686 static targets.

==> 2be8903cb96098a1cb7288eaecb5a30ba386df88 Add new package black-hole-solver <==

- New Package: Added black-hole-solver, a logic backend required by KPat.

==> 06df6b1941d5349ac9b8524a2f1e0edcaba4d75a Add new package kde-libkdegames <==

- New Package: Added kde-libkdegames, the foundational library for all KDE games.

==> 939e580172a78fdc35553bea54b278b1b0f7e7cf Add new package kpat <==

- New Package: Added kpat (KDE Patience) as an apps plugin.

==> 80d1562dc861ac625dd461ec219bcb60e3381ae6 Add new package kde-libkmahjongg <==

- New Package: Added kde-libkmahjongg, the core library for KDE Mahjongg games.

==> 7dd3bee2798e8b826754adbfcc7ec99fbc580da3 Add new package kmahjongg <==

- New Package: Added kmahjongg (KDE Mahjongg) as an apps plugin.